### PR TITLE
feat: APIクライアント・型定義・モック層を追加 (#18 フェーズ1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Rails API のベースURL（開発時は localhost:3001 / 本番は API ドメイン）
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Rails API が未完成の間、モックレスポンスを返すかどうか。
+# "true" でモック / それ以外で実 API。
+NEXT_PUBLIC_USE_MOCK=true
+
+# Google Maps（#22 現在地検索で使用）
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
+
+# NextAuth.js（#23 認証で使用）
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "swr": "^2.4.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2529,6 +2530,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -5736,6 +5746,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
@@ -6035,6 +6058,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "swr": "^2.4.1"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/lib/api/areas.ts
+++ b/src/lib/api/areas.ts
@@ -1,0 +1,6 @@
+import type { AreaListResponse } from "@/types";
+import { apiClient } from "./client";
+
+export function getAreas(): Promise<AreaListResponse> {
+  return apiClient<AreaListResponse>("/areas");
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,63 @@
+import { ApiError } from "./error";
+import { mockClient } from "./mock";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+
+export { ApiError } from "./error";
+
+export async function apiClient<T>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<T> {
+  if (USE_MOCK) {
+    return mockClient<T>(endpoint, options);
+  }
+
+  const res = await fetch(`${API_BASE_URL}/api/v1${endpoint}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    let data: unknown = null;
+    try {
+      data = await res.json();
+    } catch {
+      // レスポンスボディが空/非JSONのケースは status のみで判断する
+    }
+    throw new ApiError(res.status, data);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+// Ransack 形式（q[name_cont] 等）を含むクエリ文字列を組み立てる。
+// ネストしたオブジェクトは `key[nestedKey]` 形式に展開する。
+export function buildQuery(params?: Record<string, unknown>): string {
+  if (!params) return "";
+
+  const search = new URLSearchParams();
+
+  const append = (key: string, value: unknown) => {
+    if (value === undefined || value === null || value === "") return;
+    search.append(key, String(value));
+  };
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== null && typeof value === "object") {
+      for (const [nestedKey, nestedValue] of Object.entries(value)) {
+        append(`${key}[${nestedKey}]`, nestedValue);
+      }
+    } else {
+      append(key, value);
+    }
+  }
+
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}

--- a/src/lib/api/error.ts
+++ b/src/lib/api/error.ts
@@ -1,0 +1,11 @@
+export class ApiError extends Error {
+  readonly status: number;
+  readonly data: unknown;
+
+  constructor(status: number, data: unknown) {
+    super(`API request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}

--- a/src/lib/api/genres.ts
+++ b/src/lib/api/genres.ts
@@ -1,0 +1,6 @@
+import type { GenreListResponse } from "@/types";
+import { apiClient } from "./client";
+
+export function getGenres(): Promise<GenreListResponse> {
+  return apiClient<GenreListResponse>("/genres");
+}

--- a/src/lib/api/greenteas.ts
+++ b/src/lib/api/greenteas.ts
@@ -1,0 +1,22 @@
+import type { GreenteaDetailResponse, GreenteaListResponse } from "@/types";
+import { apiClient, buildQuery } from "./client";
+
+export type GreenteaSearchParams = {
+  page?: number;
+  q?: {
+    name_cont?: string;
+    genres_id_eq?: number;
+  };
+};
+
+export function getGreenteas(
+  params?: GreenteaSearchParams,
+): Promise<GreenteaListResponse> {
+  return apiClient<GreenteaListResponse>(`/greenteas${buildQuery(params)}`);
+}
+
+export function getGreentea(
+  id: number | string,
+): Promise<GreenteaDetailResponse> {
+  return apiClient<GreenteaDetailResponse>(`/greenteas/${id}`);
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,9 @@
+export { apiClient, buildQuery, ApiError } from "./client";
+export { getGreenteas, getGreentea } from "./greenteas";
+export type { GreenteaSearchParams } from "./greenteas";
+export { getTemples, getTemple } from "./temples";
+export type { TempleSearchParams } from "./temples";
+export { getAreas } from "./areas";
+export { getGenres } from "./genres";
+export { getNearby } from "./nearby";
+export type { NearbySearchParams } from "./nearby";

--- a/src/lib/api/mock/data.ts
+++ b/src/lib/api/mock/data.ts
@@ -1,0 +1,130 @@
+import type { Greentea, Temple, Genre, Area, Comment } from "@/types";
+
+export const mockGenres: Genre[] = [
+  { id: 1, name: "パフェ" },
+  { id: 2, name: "ドリンク" },
+  { id: 3, name: "団子" },
+];
+
+export const mockAreas: Area[] = [
+  { id: 1, name: "東山区" },
+  { id: 2, name: "中京区" },
+  { id: 3, name: "右京区" },
+];
+
+const mockComments: Comment[] = [
+  {
+    id: 1,
+    body: "抹茶パフェが最高でした！",
+    user: { id: 1, name: "抹茶好き" },
+    created_at: "2024-01-15T10:30:00Z",
+  },
+];
+
+export const mockGreenteas: Greentea[] = [
+  {
+    id: 1,
+    name: "茶寮都路里",
+    description: "宇治抹茶を使ったパフェが人気の老舗甘味処。",
+    address: "京都市東山区祇園町南側",
+    access: "祇園四条駅から徒歩5分",
+    phone_number: "075-000-0001",
+    business_hours: "10:00-21:00",
+    holiday: "不定休",
+    homepage: "https://example.com/tsujiri",
+    closed: false,
+    img: "https://placehold.jp/400x300.png?text=Greentea1",
+    latitude: 35.0036,
+    longitude: 135.7714,
+    genres: [mockGenres[0]],
+    likes_count: 12,
+  },
+  {
+    id: 2,
+    name: "中村藤吉本店",
+    description: "石臼挽き抹茶のスイーツとお茶を楽しめる名店。",
+    address: "京都市中京区河原町通",
+    access: "京都市役所前駅から徒歩3分",
+    phone_number: "075-000-0002",
+    business_hours: "10:00-18:00",
+    holiday: "水曜日",
+    homepage: "https://example.com/nakamura",
+    closed: false,
+    img: "https://placehold.jp/400x300.png?text=Greentea2",
+    latitude: 35.0094,
+    longitude: 135.7689,
+    genres: [mockGenres[0], mockGenres[1]],
+    likes_count: 8,
+  },
+  {
+    id: 3,
+    name: "ぎおん徳屋",
+    description: "出来たての本わらび餅と抹茶が味わえる。",
+    address: "京都市東山区祇園町南側",
+    access: "祇園四条駅から徒歩7分",
+    phone_number: "075-000-0003",
+    business_hours: "12:00-18:00",
+    holiday: "不定休",
+    homepage: "https://example.com/tokuya",
+    closed: false,
+    img: "https://placehold.jp/400x300.png?text=Greentea3",
+    latitude: 35.0028,
+    longitude: 135.7752,
+    genres: [mockGenres[2]],
+    likes_count: 20,
+  },
+];
+
+export const mockTemples: Temple[] = [
+  {
+    id: 1,
+    name: "建仁寺",
+    description: "京都最古の禅寺。風神雷神図屏風で知られる。",
+    address: "京都市東山区大和大路通四条下る",
+    access: "祇園四条駅から徒歩7分",
+    phone_number: "075-000-1001",
+    business_hours: "10:00-17:00",
+    holiday: "なし",
+    homepage: "https://example.com/kenninji",
+    img: "https://placehold.jp/400x300.png?text=Temple1",
+    latitude: 35.0,
+    longitude: 135.7741,
+    areas: [mockAreas[0]],
+    likes_count: 15,
+  },
+  {
+    id: 2,
+    name: "八坂神社",
+    description: "祇園さんの愛称で親しまれる京都の総鎮守。",
+    address: "京都市東山区祇園町北側",
+    access: "祇園四条駅から徒歩5分",
+    phone_number: "075-000-1002",
+    business_hours: "終日参拝可",
+    holiday: "なし",
+    homepage: "https://example.com/yasaka",
+    img: "https://placehold.jp/400x300.png?text=Temple2",
+    latitude: 35.0036,
+    longitude: 135.7785,
+    areas: [mockAreas[0]],
+    likes_count: 30,
+  },
+  {
+    id: 3,
+    name: "二条城",
+    description: "徳川家ゆかりの世界遺産。二の丸御殿が有名。",
+    address: "京都市中京区二条通堀川西入二条城町",
+    access: "二条城前駅すぐ",
+    phone_number: "075-000-1003",
+    business_hours: "08:45-16:00",
+    holiday: "12月29日〜31日",
+    homepage: "https://example.com/nijojo",
+    img: "https://placehold.jp/400x300.png?text=Temple3",
+    latitude: 35.0142,
+    longitude: 135.7481,
+    areas: [mockAreas[1]],
+    likes_count: 25,
+  },
+];
+
+export const mockGreenteaComments = mockComments;
+export const mockTempleComments = mockComments;

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -1,0 +1,192 @@
+import type {
+  AreaListResponse,
+  GenreListResponse,
+  GreenteaDetailResponse,
+  GreenteaListResponse,
+  NearbyResponse,
+  NearbySpot,
+  TempleDetailResponse,
+  TempleListResponse,
+} from "@/types";
+import { ApiError } from "../error";
+import {
+  mockAreas,
+  mockGenres,
+  mockGreenteaComments,
+  mockGreenteas,
+  mockTempleComments,
+  mockTemples,
+} from "./data";
+
+const PER_PAGE = 12;
+
+function paginate<T>(items: T[], page: number) {
+  const start = (page - 1) * PER_PAGE;
+  return {
+    items: items.slice(start, start + PER_PAGE),
+    meta: {
+      current_page: page,
+      total_pages: Math.max(1, Math.ceil(items.length / PER_PAGE)),
+      total_count: items.length,
+    },
+  };
+}
+
+// 緯度経度から概算の距離（メートル）を求める（Haversine）。
+function distanceMeters(
+  from: { latitude: number; longitude: number },
+  to: { latitude: number; longitude: number },
+): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(to.latitude - from.latitude);
+  const dLng = toRad(to.longitude - from.longitude);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(from.latitude)) *
+      Math.cos(toRad(to.latitude)) *
+      Math.sin(dLng / 2) ** 2;
+  return Math.round(R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
+}
+
+function notFound(endpoint: string): never {
+  throw new ApiError(404, { error: `Mock route not found: ${endpoint}` });
+}
+
+export async function mockClient<T>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<T> {
+  const method = (options?.method ?? "GET").toUpperCase();
+  const url = new URL(endpoint, "http://mock.local");
+  const path = url.pathname;
+  const params = url.searchParams;
+
+  if (method === "GET") {
+    if (path === "/greenteas") {
+      const page = Number(params.get("page")) || 1;
+      const nameCont = params.get("q[name_cont]")?.toLowerCase();
+      const genreId = params.get("q[genres_id_eq]");
+
+      let items = mockGreenteas;
+      if (nameCont) {
+        items = items.filter((g) => g.name.toLowerCase().includes(nameCont));
+      }
+      if (genreId) {
+        items = items.filter((g) =>
+          g.genres.some((genre) => String(genre.id) === genreId),
+        );
+      }
+
+      const { items: greenteas, meta } = paginate(items, page);
+      return { greenteas, meta } satisfies GreenteaListResponse as T;
+    }
+
+    const greenteaMatch = path.match(/^\/greenteas\/(\d+)$/);
+    if (greenteaMatch) {
+      const greentea = mockGreenteas.find(
+        (g) => g.id === Number(greenteaMatch[1]),
+      );
+      if (!greentea) notFound(endpoint);
+
+      const nearby_temples: NearbySpot[] = mockTemples
+        .map((t) => ({
+          id: t.id,
+          name: t.name,
+          distance_meters: distanceMeters(greentea, t),
+        }))
+        .filter((t) => t.distance_meters <= 1500)
+        .sort((a, b) => a.distance_meters - b.distance_meters);
+
+      return {
+        greentea: {
+          ...greentea,
+          liked_by_current_user: false,
+          nearby_temples,
+          comments: mockGreenteaComments,
+        },
+      } satisfies GreenteaDetailResponse as T;
+    }
+
+    if (path === "/temples") {
+      const page = Number(params.get("page")) || 1;
+      const nameCont = params.get("q[name_cont]")?.toLowerCase();
+      const areaId = params.get("q[areas_id_eq]");
+
+      let items = mockTemples;
+      if (nameCont) {
+        items = items.filter((t) => t.name.toLowerCase().includes(nameCont));
+      }
+      if (areaId) {
+        items = items.filter((t) =>
+          t.areas.some((area) => String(area.id) === areaId),
+        );
+      }
+
+      const { items: temples, meta } = paginate(items, page);
+      return { temples, meta } satisfies TempleListResponse as T;
+    }
+
+    const templeMatch = path.match(/^\/temples\/(\d+)$/);
+    if (templeMatch) {
+      const temple = mockTemples.find((t) => t.id === Number(templeMatch[1]));
+      if (!temple) notFound(endpoint);
+
+      const nearby_greenteas: NearbySpot[] = mockGreenteas
+        .map((g) => ({
+          id: g.id,
+          name: g.name,
+          distance_meters: distanceMeters(temple, g),
+        }))
+        .filter((g) => g.distance_meters <= 1500)
+        .sort((a, b) => a.distance_meters - b.distance_meters);
+
+      return {
+        temple: {
+          ...temple,
+          liked_by_current_user: false,
+          nearby_greenteas,
+          comments: mockTempleComments,
+        },
+      } satisfies TempleDetailResponse as T;
+    }
+
+    if (path === "/areas") {
+      return { areas: mockAreas } satisfies AreaListResponse as T;
+    }
+
+    if (path === "/genres") {
+      return { genres: mockGenres } satisfies GenreListResponse as T;
+    }
+
+    if (path === "/nearby") {
+      const lat = Number(params.get("lat"));
+      const lng = Number(params.get("lng"));
+      const radiusKm = Number(params.get("radius")) || 1.5;
+      const origin = { latitude: lat, longitude: lng };
+      const radiusM = radiusKm * 1000;
+
+      const toSpot = (item: {
+        id: number;
+        name: string;
+        latitude: number;
+        longitude: number;
+      }): NearbySpot => ({
+        id: item.id,
+        name: item.name,
+        distance_meters: distanceMeters(origin, item),
+      });
+
+      const within = (spot: NearbySpot) => spot.distance_meters <= radiusM;
+      const byDistance = (a: NearbySpot, b: NearbySpot) =>
+        a.distance_meters - b.distance_meters;
+
+      return {
+        greenteas: mockGreenteas.map(toSpot).filter(within).sort(byDistance),
+        temples: mockTemples.map(toSpot).filter(within).sort(byDistance),
+      } satisfies NearbyResponse as T;
+    }
+  }
+
+  notFound(endpoint);
+}

--- a/src/lib/api/nearby.ts
+++ b/src/lib/api/nearby.ts
@@ -1,0 +1,14 @@
+import type { NearbyResponse } from "@/types";
+import { apiClient, buildQuery } from "./client";
+
+export type NearbySearchParams = {
+  lat: number;
+  lng: number;
+  radius?: number;
+};
+
+export function getNearby(
+  params: NearbySearchParams,
+): Promise<NearbyResponse> {
+  return apiClient<NearbyResponse>(`/nearby${buildQuery(params)}`);
+}

--- a/src/lib/api/temples.ts
+++ b/src/lib/api/temples.ts
@@ -1,0 +1,20 @@
+import type { TempleDetailResponse, TempleListResponse } from "@/types";
+import { apiClient, buildQuery } from "./client";
+
+export type TempleSearchParams = {
+  page?: number;
+  q?: {
+    name_cont?: string;
+    areas_id_eq?: number;
+  };
+};
+
+export function getTemples(
+  params?: TempleSearchParams,
+): Promise<TempleListResponse> {
+  return apiClient<TempleListResponse>(`/temples${buildQuery(params)}`);
+}
+
+export function getTemple(id: number | string): Promise<TempleDetailResponse> {
+  return apiClient<TempleDetailResponse>(`/temples/${id}`);
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,58 @@
+import type { Greentea } from "./greentea";
+import type { Temple } from "./temple";
+import type { Genre } from "./genre";
+import type { Area } from "./area";
+import type { Comment } from "./comment";
+
+export interface Meta {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+}
+
+export interface NearbySpot {
+  id: number;
+  name: string;
+  distance_meters: number;
+}
+
+export interface GreenteaDetail extends Greentea {
+  nearby_temples: NearbySpot[];
+  comments: Comment[];
+}
+
+export interface TempleDetail extends Temple {
+  nearby_greenteas: NearbySpot[];
+  comments: Comment[];
+}
+
+export interface GreenteaListResponse {
+  greenteas: Greentea[];
+  meta: Meta;
+}
+
+export interface TempleListResponse {
+  temples: Temple[];
+  meta: Meta;
+}
+
+export interface GreenteaDetailResponse {
+  greentea: GreenteaDetail;
+}
+
+export interface TempleDetailResponse {
+  temple: TempleDetail;
+}
+
+export interface AreaListResponse {
+  areas: Area[];
+}
+
+export interface GenreListResponse {
+  genres: Genre[];
+}
+
+export interface NearbyResponse {
+  greenteas: NearbySpot[];
+  temples: NearbySpot[];
+}

--- a/src/types/area.ts
+++ b/src/types/area.ts
@@ -1,0 +1,4 @@
+export interface Area {
+  id: number;
+  name: string;
+}

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,8 @@
+import type { User } from "./user";
+
+export interface Comment {
+  id: number;
+  body: string;
+  user: User;
+  created_at: string;
+}

--- a/src/types/genre.ts
+++ b/src/types/genre.ts
@@ -1,0 +1,4 @@
+export interface Genre {
+  id: number;
+  name: string;
+}

--- a/src/types/greentea.ts
+++ b/src/types/greentea.ts
@@ -1,0 +1,20 @@
+import type { Genre } from "./genre";
+
+export interface Greentea {
+  id: number;
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  closed: boolean;
+  img: string;
+  latitude: number;
+  longitude: number;
+  genres: Genre[];
+  likes_count: number;
+  liked_by_current_user?: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,19 @@
+export type { Genre } from "./genre";
+export type { Area } from "./area";
+export type { User } from "./user";
+export type { Comment } from "./comment";
+export type { Greentea } from "./greentea";
+export type { Temple } from "./temple";
+export type {
+  Meta,
+  NearbySpot,
+  GreenteaDetail,
+  TempleDetail,
+  GreenteaListResponse,
+  TempleListResponse,
+  GreenteaDetailResponse,
+  TempleDetailResponse,
+  AreaListResponse,
+  GenreListResponse,
+  NearbyResponse,
+} from "./api";

--- a/src/types/temple.ts
+++ b/src/types/temple.ts
@@ -1,0 +1,19 @@
+import type { Area } from "./area";
+
+export interface Temple {
+  id: number;
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  img: string;
+  latitude: number;
+  longitude: number;
+  areas: Area[];
+  likes_count: number;
+  liked_by_current_user?: boolean;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
## 概要

Issue #18（Next.js プロジェクト基盤構築）のうち、**データ層（型定義・API クライアント・モック・リソース API 関数）** を実装します。共通レイアウト（daisyUI 導入含む）は別 PR に分割します。

Rails API（greentea_temple）がまだ存在しないため、**環境変数でモック / 実 API を切り替えられる**構成にし、モックだけで一覧・詳細・近隣検索の動作確認ができる状態を先に整えます。

## 変更内容

### 型定義（`src/types/`）
- `Greentea` / `Temple` / `Genre` / `Area` / `User` / `Comment` を `docs/migration-plan.md` 2-3 の契約に合わせて定義
- `api.ts` に一覧（`meta` 付き）・詳細（近隣スポット + コメント）・近隣検索のレスポンス型を集約
- `index.ts` で再エクスポート

### API クライアント（`src/lib/api/`）
- `client.ts`: fetch ベースの `apiClient<T>`、`credentials: include`、エラー時は `ApiError` を throw
- `buildQuery`: Ransack 形式（`q[name_cont]` 等）のクエリ文字列を組み立て
- `NEXT_PUBLIC_USE_MOCK=true` でモックへ切り替え

### モック層（`src/lib/api/mock/`）
- `data.ts`: 抹茶店 3 件・神社 3 件・ジャンル・エリアのサンプル（migration-plan の例準拠）
- `index.ts`: エンドポイントを解釈して一覧/詳細/エリア/ジャンル/近隣を返すルーター。検索・ページネーション・1.5km 圏内の近隣計算（Haversine）に対応

### リソース API 関数
- `getGreenteas` / `getGreentea` / `getTemples` / `getTemple` / `getAreas` / `getGenres` / `getNearby`

### その他
- データフェッチ用に `swr` を導入（一覧の検索/ページネーションで使用予定）
- `.env.example` を追加（`.gitignore` に例外を追加）し、`NEXT_PUBLIC_USE_MOCK` 等を明文化

## 確認

- [x] `npx tsc --noEmit` 通過
- [x] `npm run lint` 通過

## 補足

- 地図（`@vis.gl/react-google-maps`）・認証（next-auth）・フォーム（react-hook-form 等）は、実際に使う Issue（#22 / #23）で導入予定。
- 認証依存のいいね・コメント API 関数は #24 で追加予定。

Refs #18


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZKVaQQSVEigv5cCBPUUbB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated API infrastructure for retrieving and filtering locations, temples, areas, and genres
  * Added nearby search functionality to discover items based on geographic proximity
  * Implemented mock data mode for development and offline testing

* **Chores**
  * Updated dependencies and added environment configuration for API integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->