### PR TITLE
fix: APIクライアントのヘッダーマージとモック /nearby の座標検証

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -14,12 +14,15 @@ export async function apiClient<T>(
     return mockClient<T>(endpoint, options);
   }
 
+  // Headers インスタンスや [key, value][] で渡されても欠落しないようマージする。
+  const headers = new Headers(options?.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
   const res = await fetch(`${API_BASE_URL}/api/v1${endpoint}`, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
+    headers,
     credentials: "include",
   });
 

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -162,6 +162,16 @@ export async function mockClient<T>(
     if (path === "/nearby") {
       const lat = Number(params.get("lat"));
       const lng = Number(params.get("lng"));
+      if (
+        !params.has("lat") ||
+        !params.has("lng") ||
+        !Number.isFinite(lat) ||
+        !Number.isFinite(lng)
+      ) {
+        throw new ApiError(400, {
+          error: "lat and lng are required and must be valid numbers",
+        });
+      }
       const radiusKm = Number(params.get("radius")) || 1.5;
       const origin = { latitude: lat, longitude: lng };
       const radiusM = radiusKm * 1000;


### PR DESCRIPTION
## 概要

マージ済み PR #30 に付いた Codex（chatgpt-codex-connector）のレビュー指摘 2 件を反映する追従 PR です。いずれも P2（データ整合性・潜在バグ）で妥当と判断し修正しました。

## 修正内容

### 1. `src/lib/api/client.ts` — ヘッダーのマージを修正
`RequestInit.headers` は `Headers` インスタンスや `[key, value][]` の場合があり、オブジェクトスプレッド（`...options?.headers`）ではそれらの値が欠落していました。`new Headers()` でマージし、`Content-Type` は未指定時のみデフォルトを設定するようにしました。これにより認証（#23）で `Authorization` を付与した際の欠落を防ぎます。

### 2. `src/lib/api/mock/index.ts` — /nearby の座標検証を追加
`Number(params.get(...))` は欠損を `0`、不正値を `NaN` に変換し、200 で誤った結果を返していました。`lat` / `lng` を有限数として検証し、欠損・不正時は `ApiError(400)` を返すようにして、モックでフロントのパラメータバグを隠さないようにしました。

## 確認

- [x] `npx tsc --noEmit` 通過
- [x] `npm run lint` 通過

## 補足

- 指摘元: PR #30 のレビュースレッド（Codex）。
- CodeRabbit の本レビューは #30 で進行中のため、追加指摘が出た場合は別途対応します。

Refs #18


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZKVaQQSVEigv5cCBPUUbB)_