### PR TITLE
feat: トップページの実装 (#19)

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import ComingSoon from "@/components/common/ComingSoon";
+
+export const metadata: Metadata = {
+  title: "抹茶店の詳細",
+};
+
+export default function GreenteaDetailPage() {
+  return (
+    <ComingSoon
+      title="抹茶店の詳細"
+      description="抹茶店の詳細ページは現在準備中です。"
+    />
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,148 @@
 import Link from "next/link";
+import { HiArrowRight, HiMagnifyingGlass, HiMapPin } from "react-icons/hi2";
+import { getGreenteas, getTemples } from "@/lib/api";
+import GreenteaCard from "@/components/greentea/GreenteaCard";
+import TempleCard from "@/components/temple/TempleCard";
 
-export default function Home() {
+export const revalidate = 3600;
+
+const RECOMMEND_LIMIT = 3;
+
+export default async function Home() {
+  const [greenteasResult, templesResult] = await Promise.allSettled([
+    getGreenteas(),
+    getTemples(),
+  ]);
+
+  const greenteas =
+    greenteasResult.status === "fulfilled"
+      ? greenteasResult.value.greenteas.slice(0, RECOMMEND_LIMIT)
+      : [];
+  const temples =
+    templesResult.status === "fulfilled"
+      ? templesResult.value.temples.slice(0, RECOMMEND_LIMIT)
+      : [];
+
   return (
-    <section className="hero min-h-[60vh] bg-base-200">
-      <div className="hero-content text-center">
-        <div className="max-w-xl">
-          <h1 className="text-4xl font-bold sm:text-5xl">
-            <span className="text-primary">抹茶</span>と
-            <span className="text-secondary">神社</span>。
-          </h1>
-          <p className="py-6 text-base-content/80">
-            京都の抹茶スイーツと神社仏閣を、近さでつなぐ。
-            お店のそばの神社、神社のそばの甘味処を見つけよう。
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link href="/greenteas" className="btn btn-primary">
-              抹茶店をさがす
-            </Link>
-            <Link href="/temples" className="btn btn-secondary btn-outline">
-              神社をさがす
-            </Link>
+    <>
+      <section className="hero min-h-[60vh] bg-base-200">
+        <div className="hero-content text-center">
+          <div className="max-w-xl">
+            <h1 className="text-4xl font-bold sm:text-5xl">
+              <span className="text-primary">抹茶</span>と
+              <span className="text-secondary">神社</span>。
+            </h1>
+            <p className="py-6 text-base-content/80">
+              京都の抹茶スイーツと神社仏閣を、近さでつなぐ。
+              お店のそばの神社、神社のそばの甘味処を見つけよう。
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link href="/greenteas" className="btn btn-primary">
+                抹茶店をさがす
+              </Link>
+              <Link href="/temples" className="btn btn-secondary btn-outline">
+                神社をさがす
+              </Link>
+            </div>
           </div>
         </div>
+      </section>
+
+      <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:py-16">
+        {greenteas.length > 0 && (
+          <section aria-labelledby="recommend-greenteas">
+            <div className="flex items-end justify-between gap-4">
+              <h2
+                id="recommend-greenteas"
+                className="text-2xl font-bold sm:text-3xl"
+              >
+                おすすめの<span className="text-primary">抹茶店</span>
+              </h2>
+              <Link
+                href="/greenteas"
+                className="link link-hover inline-flex items-center gap-1 text-sm font-medium text-primary"
+              >
+                一覧を見る
+                <HiArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+            <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {greenteas.map((greentea) => (
+                <GreenteaCard key={greentea.id} greentea={greentea} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {temples.length > 0 && (
+          <section aria-labelledby="recommend-temples" className="mt-16">
+            <div className="flex items-end justify-between gap-4">
+              <h2
+                id="recommend-temples"
+                className="text-2xl font-bold sm:text-3xl"
+              >
+                おすすめの<span className="text-secondary">神社</span>
+              </h2>
+              <Link
+                href="/temples"
+                className="link link-hover inline-flex items-center gap-1 text-sm font-medium text-secondary"
+              >
+                一覧を見る
+                <HiArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+            <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {temples.map((temple) => (
+                <TempleCard key={temple.id} temple={temple} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section aria-labelledby="explore" className="mt-16">
+          <h2 id="explore" className="text-2xl font-bold sm:text-3xl">
+            さがし方
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-3">
+            <Link
+              href="/greenteas"
+              className="card bg-base-100 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+            >
+              <HiMagnifyingGlass
+                className="h-8 w-8 text-primary"
+                aria-hidden="true"
+              />
+              <h3 className="mt-3 text-lg font-bold">抹茶店から探す</h3>
+              <p className="mt-1 text-sm text-base-content/70">
+                ジャンルや名前で京都の抹茶スイーツ店をさがせます。
+              </p>
+            </Link>
+            <Link
+              href="/temples"
+              className="card bg-base-100 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+            >
+              <HiMagnifyingGlass
+                className="h-8 w-8 text-secondary"
+                aria-hidden="true"
+              />
+              <h3 className="mt-3 text-lg font-bold">神社から探す</h3>
+              <p className="mt-1 text-sm text-base-content/70">
+                エリアや名前で京都の神社仏閣をさがせます。
+              </p>
+            </Link>
+            <Link
+              href="/nearby"
+              className="card bg-base-100 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+            >
+              <HiMapPin className="h-8 w-8 text-accent" aria-hidden="true" />
+              <h3 className="mt-3 text-lg font-bold">現在地から探す</h3>
+              <p className="mt-1 text-sm text-base-content/70">
+                いまいる場所の近くの抹茶店と神社をまとめてさがせます。
+              </p>
+            </Link>
+          </div>
+        </section>
       </div>
-    </section>
+    </>
   );
 }

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import ComingSoon from "@/components/common/ComingSoon";
+
+export const metadata: Metadata = {
+  title: "神社の詳細",
+};
+
+export default function TempleDetailPage() {
+  return (
+    <ComingSoon
+      title="神社の詳細"
+      description="神社仏閣の詳細ページは現在準備中です。"
+    />
+  );
+}

--- a/src/components/greentea/GreenteaCard.tsx
+++ b/src/components/greentea/GreenteaCard.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { HiHeart } from "react-icons/hi2";
+import type { Greentea } from "@/types";
+
+type GreenteaCardProps = {
+  greentea: Greentea;
+};
+
+export default function GreenteaCard({ greentea }: GreenteaCardProps) {
+  return (
+    <Link
+      href={`/greenteas/${greentea.id}`}
+      className="card bg-base-100 shadow-sm transition hover:-translate-y-1 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+    >
+      <figure className="aspect-[4/3] overflow-hidden">
+        {/* 画像は Rails(CarrierWave)/外部 URL をそのまま表示するため next/image を使わない */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={greentea.img}
+          alt={greentea.name}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      </figure>
+      <div className="card-body gap-2 p-4">
+        <h3 className="card-title text-lg">{greentea.name}</h3>
+        <p className="line-clamp-2 text-sm text-base-content/70">
+          {greentea.description}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          {greentea.genres.map((genre) => (
+            <span key={genre.id} className="badge badge-primary badge-sm">
+              {genre.name}
+            </span>
+          ))}
+          <span className="ml-auto inline-flex items-center gap-1 text-sm text-base-content/60">
+            <HiHeart className="h-4 w-4 text-secondary" aria-hidden="true" />
+            {greentea.likes_count}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/temple/TempleCard.tsx
+++ b/src/components/temple/TempleCard.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { HiHeart } from "react-icons/hi2";
+import type { Temple } from "@/types";
+
+type TempleCardProps = {
+  temple: Temple;
+};
+
+export default function TempleCard({ temple }: TempleCardProps) {
+  return (
+    <Link
+      href={`/temples/${temple.id}`}
+      className="card bg-base-100 shadow-sm transition hover:-translate-y-1 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+    >
+      <figure className="aspect-[4/3] overflow-hidden">
+        {/* 画像は Rails(CarrierWave)/外部 URL をそのまま表示するため next/image を使わない */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={temple.img}
+          alt={temple.name}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      </figure>
+      <div className="card-body gap-2 p-4">
+        <h3 className="card-title text-lg">{temple.name}</h3>
+        <p className="line-clamp-2 text-sm text-base-content/70">
+          {temple.description}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          {temple.areas.map((area) => (
+            <span key={area.id} className="badge badge-secondary badge-sm">
+              {area.name}
+            </span>
+          ))}
+          <span className="ml-auto inline-flex items-center gap-1 text-sm text-base-content/60">
+            <HiHeart className="h-4 w-4 text-secondary" aria-hidden="true" />
+            {temple.likes_count}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## 概要

「抹茶と神社。」のトップページを Next.js で実装しました。ヒーロー・おすすめスポット・ナビゲーションを備えた構成です。

Closes #19

## 変更内容

- **ヒーローセクション**: 既存のヒーローを踏襲しつつ、抹茶店/神社へのCTAを配置。
- **おすすめ抹茶店 / 神社の表示**: `lib/api`（`getGreenteas` / `getTemples`）経由でデータを取得し、各3件をカード表示。各セクションに「一覧を見る」リンクを設置。
- **ナビゲーションリンク**: 「さがし方」セクションとして、抹茶店 / 神社 / 現在地から探す への導線カードを追加。
- **コンポーネント追加**: `GreenteaCard` / `TempleCard` を新規作成（今後の一覧・詳細ページ #8/#9 でも再利用予定）。
- **レスポンシブ対応**: カードは `grid-cols-1 → sm:2 → lg:3` で段階的に変化。
- **デザイン**: daisyUI（card / badge / hero / btn）+ Tailwind と `matcha` テーマを踏襲。
- **プレースホルダ追加**: おすすめカードの遷移先 `/greenteas/[id]`・`/temples/[id]` がデッドリンクにならないよう、ComingSoon プレースホルダを追加（詳細実装は #8/#9）。

## 設計メモ

- レンダリング戦略（`docs/migration-plan.md` 2-4）に従い、トップは `export const revalidate = 3600` で **SSG(ISR)** として静的生成。
- API クライアントは `NEXT_PUBLIC_USE_MOCK` でモック/実APIを切り替え可能なまま利用。Rails API 未完成でもモックで表示確認できます。
- おすすめ取得は `Promise.allSettled` で取得失敗時も該当セクションのみ非表示にしてページ全体は描画。
- 画像は CarrierWave/外部URLをそのまま表示する方針のため `<img>` を使用（next/image は未使用）。

## 動作確認

- [x] `npm run lint` 警告・エラーなし
- [x] `NEXT_PUBLIC_USE_MOCK=true npm run build` 成功（`/` は Static / Revalidate 1h で prerender）
- [x] `npm start` でトップページを配信し、おすすめ抹茶店3件・神社3件・各セクション見出し・詳細リンクが描画されることを確認

> 注: 描画内容は配信HTMLで確認しています（ブラウザでの目視確認は未実施）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCG2dVP43a5hB51eVDuQAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced home page with personalized recommendations for green tea shops and temples
  * Added "Explore" section with quick navigation to browse green tea shops, temples, and nearby locations
  * Created detail pages for green tea shops and temples (coming soon)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->