### PR TITLE
feat: 抹茶店 一覧・詳細ページを実装 (#20)

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -1,15 +1,197 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { HiArrowLeft, HiHeart } from "react-icons/hi2";
+import Hairline from "@/components/brand/Hairline";
+import { ToriiIcon } from "@/components/brand/icons";
+import { ApiError, getGreentea } from "@/lib/api";
+import type { GreenteaDetail, NearbySpot } from "@/types";
 
-export const metadata: Metadata = {
-  title: "抹茶店の詳細",
-};
+type RouteParams = { id: string };
 
-export default function GreenteaDetailPage() {
+async function fetchGreentea(id: string): Promise<GreenteaDetail> {
+  try {
+    const { greentea } = await getGreentea(id);
+    return greentea;
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const { greentea } = await getGreentea(id);
+    return {
+      title: greentea.name,
+      description: greentea.description,
+    };
+  } catch {
+    return { title: "抹茶店の詳細" };
+  }
+}
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <ComingSoon
-      title="抹茶店の詳細"
-      description="抹茶店の詳細ページは現在準備中です。"
-    />
+    <div className="grid grid-cols-[7em_1fr] gap-3 border-b border-line-soft py-3 last:border-b-0 sm:grid-cols-[8em_1fr]">
+      <dt className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+        {label}
+      </dt>
+      <dd className="font-serif-jp text-sm leading-[1.9] text-ink">{children}</dd>
+    </div>
+  );
+}
+
+function NearbyTemples({ temples }: { temples: NearbySpot[] }) {
+  if (temples.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+        近隣 1.5km 以内に登録された神社仏閣はありません。
+      </p>
+    );
+  }
+  return (
+    <ul className="divide-y divide-line-soft border border-line-soft bg-paper">
+      {temples.map((temple) => (
+        <li key={temple.id}>
+          <Link
+            href={`/temples/${temple.id}`}
+            className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-washi-bg"
+          >
+            <ToriiIcon size={22} color="#905050" />
+            <span className="flex-1 font-mincho text-base text-ink">
+              {temple.name}
+            </span>
+            <span className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+              {formatDistance(temple.distance_meters)}
+            </span>
+            <span aria-hidden="true" className="font-mincho text-base text-muted">
+              →
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default async function GreenteaDetailPage({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}) {
+  const { id } = await params;
+  const greentea = await fetchGreentea(id);
+
+  return (
+    <article className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
+      <div className="mb-6">
+        <Link
+          href="/greenteas"
+          className="inline-flex items-center gap-2 font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          <HiArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          抹茶店一覧へ
+        </Link>
+      </div>
+
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+          抹茶スイーツ / MATCHA SWEETS
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.06em] text-ink sm:text-4xl">
+          {greentea.name}
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+          {greentea.genres.map((genre) => (
+            <span
+              key={genre.id}
+              className="border border-line bg-washi px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-olive"
+            >
+              {genre.name}
+            </span>
+          ))}
+          <span className="inline-flex items-center gap-1.5 border border-line bg-paper px-2.5 py-1 font-sans-jp text-[11px] text-muted">
+            <HiHeart className="h-3.5 w-3.5 text-bengara" aria-hidden="true" />
+            {greentea.likes_count}
+          </span>
+          {greentea.closed && (
+            <span className="border border-bengara bg-bengara px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-paper">
+              閉店
+            </span>
+          )}
+        </div>
+      </header>
+
+      <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+        <div className="aspect-[16/9] w-full">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={greentea.img}
+            alt={greentea.name}
+            className="h-full w-full object-cover"
+          />
+        </div>
+      </figure>
+
+      <section className="mt-10">
+        <p className="font-serif-jp text-base leading-[2.1] text-ink">
+          {greentea.description}
+        </p>
+      </section>
+
+      <section className="mt-10">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          店舗情報
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            INFO
+          </span>
+        </h2>
+        <dl className="mt-4 border border-line-soft bg-paper px-5 sm:px-7">
+          <InfoRow label="住所">{greentea.address}</InfoRow>
+          <InfoRow label="アクセス">{greentea.access}</InfoRow>
+          <InfoRow label="営業時間">{greentea.business_hours}</InfoRow>
+          <InfoRow label="定休日">{greentea.holiday}</InfoRow>
+          {greentea.phone_number && (
+            <InfoRow label="電話番号">{greentea.phone_number}</InfoRow>
+          )}
+          {greentea.homepage && (
+            <InfoRow label="HP">
+              <a
+                href={greentea.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-olive underline underline-offset-4 hover:text-olive-dark"
+              >
+                {greentea.homepage}
+              </a>
+            </InfoRow>
+          )}
+        </dl>
+      </section>
+
+      <section className="mt-12">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          近くの神社仏閣
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            NEARBY ( within 1.5km )
+          </span>
+        </h2>
+        <div className="mt-4">
+          <NearbyTemples temples={greentea.nearby_temples} />
+        </div>
+      </section>
+    </article>
   );
 }

--- a/src/app/greenteas/page.tsx
+++ b/src/app/greenteas/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import Hairline from "@/components/brand/Hairline";
 import Pagination from "@/components/common/Pagination";
 import GreenteaList from "@/components/greentea/GreenteaList";
@@ -31,9 +32,12 @@ export default async function GreenteasPage({
 }) {
   const sp = await searchParams;
   const page = Math.max(1, Number(sp.page) || 1);
-  const genreIdNum = sp.genre ? Number(sp.genre) : undefined;
+  // genre は 0 が有効 ID の可能性に備えて Number.isFinite で判定する。
+  const genreIdNum = sp.genre !== undefined ? Number(sp.genre) : undefined;
   const genreId =
-    genreIdNum && Number.isFinite(genreIdNum) ? genreIdNum : undefined;
+    genreIdNum !== undefined && Number.isFinite(genreIdNum)
+      ? genreIdNum
+      : undefined;
 
   const [{ greenteas, meta }, { genres }] = await Promise.all([
     getGreenteas({
@@ -44,6 +48,15 @@ export default async function GreenteasPage({
   ]);
 
   const preservedQuery = buildPreservedQuery(sp);
+
+  // 範囲外の page= が指定された場合は最終ページへ寄せる（モック実装でも空配列を防ぐ）。
+  if (page > meta.total_pages) {
+    const params = new URLSearchParams(preservedQuery);
+    if (meta.total_pages > 1) params.set("page", String(meta.total_pages));
+    const query = params.toString();
+    redirect(query ? `/greenteas?${query}` : "/greenteas");
+  }
+
   const selectedGenre = genres.find((g) => g.id === genreId);
 
   return (

--- a/src/app/greenteas/page.tsx
+++ b/src/app/greenteas/page.tsx
@@ -1,15 +1,106 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Hairline from "@/components/brand/Hairline";
+import Pagination from "@/components/common/Pagination";
+import GreenteaList from "@/components/greentea/GreenteaList";
+import GreenteaSearchForm from "@/components/greentea/GreenteaSearchForm";
+import { getGenres, getGreenteas } from "@/lib/api";
 
 export const metadata: Metadata = {
   title: "抹茶店",
+  description:
+    "京都の抹茶スイーツ店を一覧で探せます。店名・ジャンルで絞り込み可能。",
 };
 
-export default function GreenteasPage() {
+type SearchParams = {
+  q?: string;
+  genre?: string;
+  page?: string;
+};
+
+function buildPreservedQuery(params: SearchParams): string {
+  const search = new URLSearchParams();
+  if (params.q) search.set("q", params.q);
+  if (params.genre) search.set("genre", params.genre);
+  return search.toString();
+}
+
+export default async function GreenteasPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page) || 1);
+  const genreIdNum = sp.genre ? Number(sp.genre) : undefined;
+  const genreId =
+    genreIdNum && Number.isFinite(genreIdNum) ? genreIdNum : undefined;
+
+  const [{ greenteas, meta }, { genres }] = await Promise.all([
+    getGreenteas({
+      page,
+      q: { name_cont: sp.q, genres_id_eq: genreId },
+    }),
+    getGenres(),
+  ]);
+
+  const preservedQuery = buildPreservedQuery(sp);
+  const selectedGenre = genres.find((g) => g.id === genreId);
+
   return (
-    <ComingSoon
-      title="抹茶店一覧"
-      description="京都の抹茶スイーツ店一覧ページは現在準備中です。"
-    />
+    <section className="mx-auto w-full max-w-6xl px-6 py-12 md:px-12">
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+          抹茶スイーツ / MATCHA SWEETS
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.08em] text-ink">
+          抹茶店をさがす
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <p className="mt-5 max-w-xl font-serif-jp text-sm leading-[2] text-muted">
+          京都の抹茶スイーツが楽しめるお店を一覧でご紹介します。
+        </p>
+      </header>
+
+      <div className="mt-10">
+        <GreenteaSearchForm genres={genres} />
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-baseline justify-between gap-2 border-b border-line-soft pb-3">
+        <p className="font-mincho text-sm text-ink">
+          {meta.total_count > 0 ? (
+            <>
+              全 <span className="font-semibold">{meta.total_count}</span> 件
+              {meta.total_pages > 1 && (
+                <span className="ml-2 font-sans-jp text-xs text-muted">
+                  ( {meta.current_page} / {meta.total_pages} ページ )
+                </span>
+              )}
+            </>
+          ) : (
+            "該当なし"
+          )}
+        </p>
+        {(sp.q || selectedGenre) && (
+          <p className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+            {sp.q && <>キーワード: 「{sp.q}」</>}
+            {sp.q && selectedGenre && " / "}
+            {selectedGenre && <>ジャンル: {selectedGenre.name}</>}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-6">
+        <GreenteaList greenteas={greenteas} />
+      </div>
+
+      <div className="mt-10">
+        <Pagination
+          basePath="/greenteas"
+          currentPage={meta.current_page}
+          totalPages={meta.total_pages}
+          preservedQuery={preservedQuery}
+        />
+      </div>
+    </section>
   );
 }

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+
+type PaginationProps = {
+  basePath: string;
+  currentPage: number;
+  totalPages: number;
+  // 現在のクエリ文字列（page 以外）。URLSearchParams 形式の文字列を期待。
+  preservedQuery?: string;
+};
+
+const PAGE_WINDOW = 2;
+
+function buildPageRange(current: number, total: number): number[] {
+  if (total <= 1) return [1];
+  const start = Math.max(1, current - PAGE_WINDOW);
+  const end = Math.min(total, current + PAGE_WINDOW);
+  const pages: number[] = [];
+  for (let i = start; i <= end; i++) pages.push(i);
+  return pages;
+}
+
+export default function Pagination({
+  basePath,
+  currentPage,
+  totalPages,
+  preservedQuery,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const hrefFor = (page: number) => {
+    const params = new URLSearchParams(preservedQuery ?? "");
+    params.delete("page");
+    if (page > 1) params.set("page", String(page));
+    const query = params.toString();
+    return query ? `${basePath}?${query}` : basePath;
+  };
+
+  const pages = buildPageRange(currentPage, totalPages);
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  const baseLink =
+    "inline-flex h-9 min-w-9 items-center justify-center border border-line bg-paper px-3 font-sans-jp text-[13px] text-ink transition-colors hover:bg-washi-bg";
+  const disabledLink =
+    "inline-flex h-9 min-w-9 items-center justify-center border border-line-soft bg-washi px-3 font-sans-jp text-[13px] text-muted/60";
+  const activeLink =
+    "inline-flex h-9 min-w-9 items-center justify-center border border-olive bg-olive px-3 font-sans-jp text-[13px] text-paper";
+
+  return (
+    <nav
+      aria-label="ページネーション"
+      className="flex flex-wrap items-center justify-center gap-1.5"
+    >
+      {hasPrev ? (
+        <Link href={hrefFor(currentPage - 1)} className={baseLink} rel="prev">
+          ‹ 前へ
+        </Link>
+      ) : (
+        <span className={disabledLink} aria-hidden="true">
+          ‹ 前へ
+        </span>
+      )}
+
+      {pages[0] > 1 && (
+        <>
+          <Link href={hrefFor(1)} className={baseLink}>
+            1
+          </Link>
+          {pages[0] > 2 && (
+            <span className="px-1 font-sans-jp text-[13px] text-muted">…</span>
+          )}
+        </>
+      )}
+
+      {pages.map((page) =>
+        page === currentPage ? (
+          <span key={page} aria-current="page" className={activeLink}>
+            {page}
+          </span>
+        ) : (
+          <Link key={page} href={hrefFor(page)} className={baseLink}>
+            {page}
+          </Link>
+        ),
+      )}
+
+      {pages[pages.length - 1] < totalPages && (
+        <>
+          {pages[pages.length - 1] < totalPages - 1 && (
+            <span className="px-1 font-sans-jp text-[13px] text-muted">…</span>
+          )}
+          <Link href={hrefFor(totalPages)} className={baseLink}>
+            {totalPages}
+          </Link>
+        </>
+      )}
+
+      {hasNext ? (
+        <Link href={hrefFor(currentPage + 1)} className={baseLink} rel="next">
+          次へ ›
+        </Link>
+      ) : (
+        <span className={disabledLink} aria-hidden="true">
+          次へ ›
+        </span>
+      )}
+    </nav>
+  );
+}

--- a/src/components/greentea/GreenteaList.tsx
+++ b/src/components/greentea/GreenteaList.tsx
@@ -1,0 +1,31 @@
+import type { Greentea } from "@/types";
+import GreenteaCard from "./GreenteaCard";
+
+type GreenteaListProps = {
+  greenteas: Greentea[];
+};
+
+export default function GreenteaList({ greenteas }: GreenteaListProps) {
+  if (greenteas.length === 0) {
+    return (
+      <div className="border border-line-soft bg-paper px-6 py-12 text-center">
+        <p className="font-mincho text-base text-ink">
+          該当する抹茶店が見つかりませんでした。
+        </p>
+        <p className="mt-2 font-sans-jp text-xs tracking-[0.1em] text-muted">
+          検索条件を変えてもう一度お試しください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {greenteas.map((greentea) => (
+        <li key={greentea.id}>
+          <GreenteaCard greentea={greentea} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/greentea/GreenteaList.tsx
+++ b/src/components/greentea/GreenteaList.tsx
@@ -1,5 +1,5 @@
 import type { Greentea } from "@/types";
-import GreenteaCard from "./GreenteaCard";
+import GreenteaCard from "@/components/greentea/GreenteaCard";
 
 type GreenteaListProps = {
   greenteas: Greentea[];

--- a/src/components/greentea/GreenteaSearchForm.tsx
+++ b/src/components/greentea/GreenteaSearchForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import type { FormEvent } from "react";
 import type { Genre } from "@/types";
 
@@ -14,8 +14,17 @@ export default function GreenteaSearchForm({ genres }: GreenteaSearchFormProps) 
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
-  const [keyword, setKeyword] = useState(searchParams.get("q") ?? "");
-  const [genreId, setGenreId] = useState(searchParams.get("genre") ?? "");
+  const queryFromUrl = searchParams.get("q") ?? "";
+  const genreFromUrl = searchParams.get("genre") ?? "";
+
+  const [keyword, setKeyword] = useState(queryFromUrl);
+  const [genreId, setGenreId] = useState(genreFromUrl);
+
+  // ブラウザの戻る/進むや外部リンクで URL が変わったとき、フォーム値を URL に追従させる。
+  useEffect(() => {
+    setKeyword(queryFromUrl);
+    setGenreId(genreFromUrl);
+  }, [queryFromUrl, genreFromUrl]);
 
   const submit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/greentea/GreenteaSearchForm.tsx
+++ b/src/components/greentea/GreenteaSearchForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { FormEvent } from "react";
+import type { Genre } from "@/types";
+
+type GreenteaSearchFormProps = {
+  genres: Genre[];
+};
+
+export default function GreenteaSearchForm({ genres }: GreenteaSearchFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [keyword, setKeyword] = useState(searchParams.get("q") ?? "");
+  const [genreId, setGenreId] = useState(searchParams.get("genre") ?? "");
+
+  const submit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (keyword.trim()) params.set("q", keyword.trim());
+    if (genreId) params.set("genre", genreId);
+    // 検索条件変更時は 1 ページ目に戻る
+    const query = params.toString();
+    startTransition(() => {
+      router.push(query ? `/greenteas?${query}` : "/greenteas");
+    });
+  };
+
+  const clear = () => {
+    setKeyword("");
+    setGenreId("");
+    startTransition(() => {
+      router.push("/greenteas");
+    });
+  };
+
+  const hasFilter = Boolean(searchParams.get("q") || searchParams.get("genre"));
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 border border-line bg-paper p-4 sm:flex-row sm:items-end"
+    >
+      <label className="flex flex-1 flex-col gap-1.5">
+        <span className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          キーワード / KEYWORD
+        </span>
+        <input
+          type="search"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="店名で探す"
+          className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1.5 sm:w-48">
+        <span className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          ジャンル / GENRE
+        </span>
+        <select
+          value={genreId}
+          onChange={(e) => setGenreId(e.target.value)}
+          className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink focus:border-olive focus:outline-none"
+        >
+          <option value="">すべて</option>
+          {genres.map((genre) => (
+            <option key={genre.id} value={genre.id}>
+              {genre.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex gap-2 sm:flex-shrink-0">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="h-10 border border-olive bg-olive px-5 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          検索
+        </button>
+        {hasFilter && (
+          <button
+            type="button"
+            onClick={clear}
+            disabled={isPending}
+            className="h-10 border border-line bg-paper px-4 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-washi-bg disabled:opacity-60"
+          >
+            クリア
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #20 の対応。`/greenteas` 一覧（検索・ページネーション）と `/greenteas/[id]` 詳細（近隣神社仏閣表示）を実装しました。  
これまで `ComingSoon` プレースホルダだった抹茶店ページが、モック API 経由で動作するようになります。

Closes #20

## 変更内容

### ページ
- **`/greenteas`（SSR + CSR）**
  - Server Component で `getGreenteas` / `getGenres` を並列取得
  - `searchParams`（`q` / `genre` / `page`）で検索状態を URL に同期
  - 件数・現在ページ・絞り込み条件を表示
- **`/greenteas/[id]`（SSR）**
  - ヒーロー（ジャンル / いいね数 / 閉店バッジ）/ 概要 / 店舗情報 dl / 近隣神社仏閣リスト（1.5km 以内）
  - `generateMetadata` で店名・説明をタイトル / description に反映
  - `ApiError` 404 → `notFound()` で Not Found に振り分け
  - 外部リンクは `target="_blank" rel="noopener noreferrer"`

### コンポーネント（新規）
- `src/components/greentea/GreenteaSearchForm.tsx` — Client。`useRouter` で URL を書き換え、条件変更時は 1 ページ目に戻す。クリアボタン付き。
- `src/components/greentea/GreenteaList.tsx` — Server。グリッド + 空状態。
- `src/components/common/Pagination.tsx` — Server。`preservedQuery` で `q` / `genre` を維持。神社一覧（#21）でも再利用予定。

## 設計の拠り所

- API クライアント・型・モック層は #18 / PR #30 で整備済のものをそのまま利用。
- デザインは「帖（chō）」テーマ（#35）に合わせ、罫線・色面・明朝体主体・角丸ゼロで統一。
- データ取得は Server Components、検索フォームのみ Client Component（CLAUDE.md の規約に準拠）。

## 動作確認

- [x] `npm run lint` パス
- [x] `npx tsc --noEmit` パス
- [x] `NEXT_PUBLIC_USE_MOCK=true npm run build` パス（`/greenteas`・`/greenteas/[id]` ともに ƒ Dynamic として生成）

## Test plan（マニュアル）

- [ ] `/greenteas` でモックの 3 件が一覧表示される
- [ ] キーワード検索（例: 「中村」）で絞り込めて URL が `?q=中村` になる
- [ ] ジャンル絞り込みが効く
- [ ] クリアボタンで `q` / `genre` が消える
- [ ] 検索条件 → ページ遷移 で `q` / `genre` が保持される（Pagination）
- [ ] `/greenteas/1` などで詳細表示、近隣の神社仏閣（≤1.5km）が距離付きで並ぶ
- [ ] `/greenteas/999`（存在しない ID）で Not Found
- [ ] レスポンシブ（SP / タブレット / PC）でレイアウト崩れがない

## 関連

- 後続: #21 神社 一覧・詳細（Pagination を再利用予定） / #22 現在地検索 / #24 いいね・コメント結合
- 依存元: #18（基盤）/ #35（デザイントークン）

assignee: @hiiragi17

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkefB4gqSDT75Z3VBgWofu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Green tea shop detail pages now display complete shop information including name, genres, like counts, contact details, and nearby temples.
  * Green tea shop listing page now supports keyword search and genre filtering for easier discovery.
  * Search results include pagination controls to browse multiple pages of results.
  * Search filters can be cleared to reset and view the full listing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->