### PR TITLE
feat: 神社 一覧・詳細ページを実装 (#21)

### DIFF
--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -41,6 +41,16 @@ function formatDistance(meters: number): string {
   return `${(meters / 1000).toFixed(1)} km`;
 }
 
+// 外部リンクとして表示してよい URL かを判定する（javascript: 等の危険スキームを除外）。
+function isSafeExternalUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="grid grid-cols-[7em_1fr] gap-3 border-b border-line-soft py-3 last:border-b-0 sm:grid-cols-[8em_1fr]">
@@ -163,14 +173,18 @@ export default async function TempleDetailPage({
           )}
           {temple.homepage && (
             <InfoRow label="HP">
-              <a
-                href={temple.homepage}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="break-all text-olive underline underline-offset-4 hover:text-olive-dark"
-              >
-                {temple.homepage}
-              </a>
+              {isSafeExternalUrl(temple.homepage) ? (
+                <a
+                  href={temple.homepage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="break-all text-olive underline underline-offset-4 hover:text-olive-dark"
+                >
+                  {temple.homepage}
+                </a>
+              ) : (
+                <span className="break-all text-muted">{temple.homepage}</span>
+              )}
             </InfoRow>
           )}
         </dl>

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -1,15 +1,192 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { HiArrowLeft, HiHeart } from "react-icons/hi2";
+import Hairline from "@/components/brand/Hairline";
+import { ChawanIcon } from "@/components/brand/icons";
+import { ApiError, getTemple } from "@/lib/api";
+import type { NearbySpot, TempleDetail } from "@/types";
 
-export const metadata: Metadata = {
-  title: "神社の詳細",
-};
+type RouteParams = { id: string };
 
-export default function TempleDetailPage() {
+async function fetchTemple(id: string): Promise<TempleDetail> {
+  try {
+    const { temple } = await getTemple(id);
+    return temple;
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) notFound();
+    throw e;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const { temple } = await getTemple(id);
+    return {
+      title: temple.name,
+      description: temple.description,
+    };
+  } catch {
+    return { title: "神社の詳細" };
+  }
+}
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <ComingSoon
-      title="神社の詳細"
-      description="神社仏閣の詳細ページは現在準備中です。"
-    />
+    <div className="grid grid-cols-[7em_1fr] gap-3 border-b border-line-soft py-3 last:border-b-0 sm:grid-cols-[8em_1fr]">
+      <dt className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+        {label}
+      </dt>
+      <dd className="font-serif-jp text-sm leading-[1.9] text-ink">{children}</dd>
+    </div>
+  );
+}
+
+function NearbyGreenteas({ greenteas }: { greenteas: NearbySpot[] }) {
+  if (greenteas.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+        近隣 1.5km 以内に登録された抹茶店はありません。
+      </p>
+    );
+  }
+  return (
+    <ul className="divide-y divide-line-soft border border-line-soft bg-paper">
+      {greenteas.map((greentea) => (
+        <li key={greentea.id}>
+          <Link
+            href={`/greenteas/${greentea.id}`}
+            className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-washi-bg"
+          >
+            <ChawanIcon size={22} color="#608060" />
+            <span className="flex-1 font-mincho text-base text-ink">
+              {greentea.name}
+            </span>
+            <span className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+              {formatDistance(greentea.distance_meters)}
+            </span>
+            <span aria-hidden="true" className="font-mincho text-base text-muted">
+              →
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default async function TempleDetailPage({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}) {
+  const { id } = await params;
+  const temple = await fetchTemple(id);
+
+  return (
+    <article className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
+      <div className="mb-6">
+        <Link
+          href="/temples"
+          className="inline-flex items-center gap-2 font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          <HiArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          神社仏閣一覧へ
+        </Link>
+      </div>
+
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-bengara">
+          神社仏閣 / SHRINES &amp; TEMPLES
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.06em] text-ink sm:text-4xl">
+          {temple.name}
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+          {temple.areas.map((area) => (
+            <span
+              key={area.id}
+              className="border border-line bg-washi px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-olive"
+            >
+              {area.name}
+            </span>
+          ))}
+          <span className="inline-flex items-center gap-1.5 border border-line bg-paper px-2.5 py-1 font-sans-jp text-[11px] text-muted">
+            <HiHeart className="h-3.5 w-3.5 text-bengara" aria-hidden="true" />
+            {temple.likes_count}
+          </span>
+        </div>
+      </header>
+
+      <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+        <div className="aspect-[16/9] w-full">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={temple.img}
+            alt={temple.name}
+            className="h-full w-full object-cover"
+          />
+        </div>
+      </figure>
+
+      <section className="mt-10">
+        <p className="font-serif-jp text-base leading-[2.1] text-ink">
+          {temple.description}
+        </p>
+      </section>
+
+      <section className="mt-10">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          基本情報
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            INFO
+          </span>
+        </h2>
+        <dl className="mt-4 border border-line-soft bg-paper px-5 sm:px-7">
+          <InfoRow label="住所">{temple.address}</InfoRow>
+          <InfoRow label="アクセス">{temple.access}</InfoRow>
+          <InfoRow label="参拝時間">{temple.business_hours}</InfoRow>
+          <InfoRow label="定休日">{temple.holiday}</InfoRow>
+          {temple.phone_number && (
+            <InfoRow label="電話番号">{temple.phone_number}</InfoRow>
+          )}
+          {temple.homepage && (
+            <InfoRow label="HP">
+              <a
+                href={temple.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-olive underline underline-offset-4 hover:text-olive-dark"
+              >
+                {temple.homepage}
+              </a>
+            </InfoRow>
+          )}
+        </dl>
+      </section>
+
+      <section className="mt-12">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          近くの抹茶店
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            NEARBY ( within 1.5km )
+          </span>
+        </h2>
+        <div className="mt-4">
+          <NearbyGreenteas greenteas={temple.nearby_greenteas} />
+        </div>
+      </section>
+    </article>
   );
 }

--- a/src/app/temples/page.tsx
+++ b/src/app/temples/page.tsx
@@ -1,15 +1,119 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import { redirect } from "next/navigation";
+import Hairline from "@/components/brand/Hairline";
+import Pagination from "@/components/common/Pagination";
+import TempleList from "@/components/temple/TempleList";
+import TempleSearchForm from "@/components/temple/TempleSearchForm";
+import { getAreas, getTemples } from "@/lib/api";
 
 export const metadata: Metadata = {
   title: "神社",
+  description:
+    "京都の神社仏閣を一覧で探せます。名称・エリアで絞り込み可能。",
 };
 
-export default function TemplesPage() {
+type SearchParams = {
+  q?: string;
+  area?: string;
+  page?: string;
+};
+
+function buildPreservedQuery(params: SearchParams): string {
+  const search = new URLSearchParams();
+  if (params.q) search.set("q", params.q);
+  if (params.area) search.set("area", params.area);
+  return search.toString();
+}
+
+export default async function TemplesPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page) || 1);
+  // area は 0 が有効 ID の可能性に備えて Number.isFinite で判定する。
+  const areaIdNum = sp.area !== undefined ? Number(sp.area) : undefined;
+  const areaId =
+    areaIdNum !== undefined && Number.isFinite(areaIdNum)
+      ? areaIdNum
+      : undefined;
+
+  const [{ temples, meta }, { areas }] = await Promise.all([
+    getTemples({
+      page,
+      q: { name_cont: sp.q, areas_id_eq: areaId },
+    }),
+    getAreas(),
+  ]);
+
+  const preservedQuery = buildPreservedQuery(sp);
+
+  // 範囲外の page= が指定された場合は最終ページへ寄せる（モック実装でも空配列を防ぐ）。
+  if (page > meta.total_pages) {
+    const params = new URLSearchParams(preservedQuery);
+    if (meta.total_pages > 1) params.set("page", String(meta.total_pages));
+    const query = params.toString();
+    redirect(query ? `/temples?${query}` : "/temples");
+  }
+
+  const selectedArea = areas.find((a) => a.id === areaId);
+
   return (
-    <ComingSoon
-      title="神社一覧"
-      description="京都の神社仏閣一覧ページは現在準備中です。"
-    />
+    <section className="mx-auto w-full max-w-6xl px-6 py-12 md:px-12">
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-bengara">
+          神社仏閣 / SHRINES &amp; TEMPLES
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.08em] text-ink">
+          神社仏閣をさがす
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <p className="mt-5 max-w-xl font-serif-jp text-sm leading-[2] text-muted">
+          京都の神社・お寺を一覧でご紹介します。
+        </p>
+      </header>
+
+      <div className="mt-10">
+        <TempleSearchForm areas={areas} />
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-baseline justify-between gap-2 border-b border-line-soft pb-3">
+        <p className="font-mincho text-sm text-ink">
+          {meta.total_count > 0 ? (
+            <>
+              全 <span className="font-semibold">{meta.total_count}</span> 件
+              {meta.total_pages > 1 && (
+                <span className="ml-2 font-sans-jp text-xs text-muted">
+                  ( {meta.current_page} / {meta.total_pages} ページ )
+                </span>
+              )}
+            </>
+          ) : (
+            "該当なし"
+          )}
+        </p>
+        {(sp.q || selectedArea) && (
+          <p className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+            {sp.q && <>キーワード: 「{sp.q}」</>}
+            {sp.q && selectedArea && " / "}
+            {selectedArea && <>エリア: {selectedArea.name}</>}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-6">
+        <TempleList temples={temples} />
+      </div>
+
+      <div className="mt-10">
+        <Pagination
+          basePath="/temples"
+          currentPage={meta.current_page}
+          totalPages={meta.total_pages}
+          preservedQuery={preservedQuery}
+        />
+      </div>
+    </section>
   );
 }

--- a/src/app/temples/page.tsx
+++ b/src/app/temples/page.tsx
@@ -33,7 +33,9 @@ export default async function TemplesPage({
   const sp = await searchParams;
   const page = Math.max(1, Number(sp.page) || 1);
   // area は 0 が有効 ID の可能性に備えて Number.isFinite で判定する。
-  const areaIdNum = sp.area !== undefined ? Number(sp.area) : undefined;
+  // 空文字列は Number("") === 0 として誤判定されるため除外する。
+  const areaIdNum =
+    sp.area !== undefined && sp.area !== "" ? Number(sp.area) : undefined;
   const areaId =
     areaIdNum !== undefined && Number.isFinite(areaIdNum)
       ? areaIdNum
@@ -50,7 +52,8 @@ export default async function TemplesPage({
   const preservedQuery = buildPreservedQuery(sp);
 
   // 範囲外の page= が指定された場合は最終ページへ寄せる（モック実装でも空配列を防ぐ）。
-  if (page > meta.total_pages) {
+  // total_pages が 0 のときは redirect ループを防ぐためガードする。
+  if (meta.total_pages > 0 && page > meta.total_pages) {
     const params = new URLSearchParams(preservedQuery);
     if (meta.total_pages > 1) params.set("page", String(meta.total_pages));
     const query = params.toString();

--- a/src/components/temple/TempleList.tsx
+++ b/src/components/temple/TempleList.tsx
@@ -1,0 +1,31 @@
+import type { Temple } from "@/types";
+import TempleCard from "@/components/temple/TempleCard";
+
+type TempleListProps = {
+  temples: Temple[];
+};
+
+export default function TempleList({ temples }: TempleListProps) {
+  if (temples.length === 0) {
+    return (
+      <div className="border border-line-soft bg-paper px-6 py-12 text-center">
+        <p className="font-mincho text-base text-ink">
+          該当する神社仏閣が見つかりませんでした。
+        </p>
+        <p className="mt-2 font-sans-jp text-xs tracking-[0.1em] text-muted">
+          検索条件を変えてもう一度お試しください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {temples.map((temple) => (
+        <li key={temple.id}>
+          <TempleCard temple={temple} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/temple/TempleSearchForm.tsx
+++ b/src/components/temple/TempleSearchForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import type { FormEvent } from "react";
+import type { Area } from "@/types";
+
+type TempleSearchFormProps = {
+  areas: Area[];
+};
+
+export default function TempleSearchForm({ areas }: TempleSearchFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const queryFromUrl = searchParams.get("q") ?? "";
+  const areaFromUrl = searchParams.get("area") ?? "";
+
+  const [keyword, setKeyword] = useState(queryFromUrl);
+  const [areaId, setAreaId] = useState(areaFromUrl);
+
+  // ブラウザの戻る/進むや外部リンクで URL が変わったとき、フォーム値を URL に追従させる。
+  useEffect(() => {
+    setKeyword(queryFromUrl);
+    setAreaId(areaFromUrl);
+  }, [queryFromUrl, areaFromUrl]);
+
+  const submit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (keyword.trim()) params.set("q", keyword.trim());
+    if (areaId) params.set("area", areaId);
+    // 検索条件変更時は 1 ページ目に戻る
+    const query = params.toString();
+    startTransition(() => {
+      router.push(query ? `/temples?${query}` : "/temples");
+    });
+  };
+
+  const clear = () => {
+    setKeyword("");
+    setAreaId("");
+    startTransition(() => {
+      router.push("/temples");
+    });
+  };
+
+  const hasFilter = Boolean(searchParams.get("q") || searchParams.get("area"));
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 border border-line bg-paper p-4 sm:flex-row sm:items-end"
+    >
+      <label className="flex flex-1 flex-col gap-1.5">
+        <span className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          キーワード / KEYWORD
+        </span>
+        <input
+          type="search"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="神社名で探す"
+          className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1.5 sm:w-48">
+        <span className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          エリア / AREA
+        </span>
+        <select
+          value={areaId}
+          onChange={(e) => setAreaId(e.target.value)}
+          className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink focus:border-olive focus:outline-none"
+        >
+          <option value="">すべて</option>
+          {areas.map((area) => (
+            <option key={area.id} value={area.id}>
+              {area.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex gap-2 sm:flex-shrink-0">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="h-10 border border-olive bg-olive px-5 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          検索
+        </button>
+        {hasFilter && (
+          <button
+            type="button"
+            onClick={clear}
+            disabled={isPending}
+            className="h-10 border border-line bg-paper px-4 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-washi-bg disabled:opacity-60"
+          >
+            クリア
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #21 の実装です。京都の神社仏閣の **一覧ページ（検索・ページネーション）** と **詳細ページ（近隣の抹茶店表示）** を、すでに完了している #20（抹茶店）と対称になるよう実装しました。

Closes #21

## 変更点

### 新規ファイル

- `src/components/temple/TempleList.tsx` — グリッドリスト + 空状態
- `src/components/temple/TempleSearchForm.tsx` — キーワード + エリア絞り込み（Client Component、URL 同期）

### 差し替え

- `src/app/temples/page.tsx` — ComingSoon → SSR の一覧（`getTemples` + `getAreas` を並列取得）
- `src/app/temples/[id]/page.tsx` — ComingSoon → SSR の詳細（`generateMetadata` 動的化、404 対応、近隣抹茶店表示）

## #20（抹茶店）との差分

| 観点 | 抹茶店 | 神社 |
|---|---|---|
| 絞り込み軸 | `genre` (genres_id_eq) | `area` (areas_id_eq) |
| 近隣表示 | `nearby_temples` + `ToriiIcon` | `nearby_greenteas` + `ChawanIcon` |
| 詳細セクション見出し | 「店舗情報」「近くの神社仏閣」 | 「基本情報」「近くの抹茶店」 |
| `closed` バッジ | あり | なし（`Temple` 型に存在しない） |
| 一覧ヘッダーの小見出し色 | `text-olive`（抹茶） | `text-bengara`（神社） |

その他のレイアウト・配色・タイポは #20 と完全に揃え、Pagination・Hairline・brand トークンを再利用しています。

## レンダリング戦略

`docs/migration-plan.md` 2-4 に従い、一覧・詳細ともに **SSR**。
- 検索フォームは Client Component で URL（`?q=...&area=...&page=...`）と双方向同期。
- 範囲外 `page=` は最終ページへ redirect。
- `area=` は 0 を有効 ID として扱えるよう `Number.isFinite` で判定。

## API 契約

API クライアントは既存の `lib/api/temples.ts` と `lib/api/areas.ts` をそのまま利用。`NEXT_PUBLIC_USE_MOCK_API=true` のときはモック (`src/lib/api/mock/`) が応答するため、Rails API 未完成でも開発・確認可能です。

## 動作確認

- [x] `npm run lint` — 警告 0
- [x] `npm run build` — 成功（`/temples` / `/temples/[id]` が `ƒ` (Dynamic SSR) として出力）
- [ ] モックで一覧表示 / 検索 / エリア絞り込み / ページネーション
- [ ] モックで詳細表示 / 近隣抹茶店リンク
- [ ] 存在しない ID で 404 表示

## 関連 issue

- Closes #21
- 参考: #20（抹茶店 一覧・詳細）
- 依存（解消済み）: #2, #6（issue 上の旧番号。実体は #18 基盤 / #31 共通レイアウト / #35 デザイン刷新）

https://claude.ai/code/session_01FmcXqmUgbDLHjwKqaDjNWV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmcXqmUgbDLHjwKqaDjNWV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced static "Coming Soon" with functional temple listing and detail pages
  * Added search and area filters, pagination with preserved queries and page-boundary handling
  * Temple detail shows name, areas, likes, image, description, conditional phone/website handling, and nearby greentea list (within 1.5km)
* **Improvements**
  * Page metadata (title/description) now generated per page; unsafe homepage URLs render as text

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->