### PR TITLE
[Next.js] 静的ページ・SEO・シェアボタンの実装

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { HiArrowLeft, HiHeart } from "react-icons/hi2";
 import Hairline from "@/components/brand/Hairline";
 import { ToriiIcon } from "@/components/brand/icons";
+import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getGreentea } from "@/lib/api";
 import type { GreenteaDetail, NearbySpot } from "@/types";
 
@@ -133,6 +134,10 @@ export default async function GreenteaDetailPage({
           )}
         </div>
       </header>
+
+      <div className="mt-6 flex justify-center">
+        <ShareButtons title={greentea.name} />
+      </div>
 
       <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
         <div className="aspect-[16/9] w-full">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,13 +25,31 @@ const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
 });
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://matcha-to-jinja.vercel.app";
+const SITE_DESCRIPTION =
+  "京都の抹茶スイーツ店と神社仏閣を、近さでつなぐ非公式ガイド。お店のそばの神社、神社のそばの甘味処を見つけられます。";
+
 export const metadata: Metadata = {
   title: {
     default: "抹茶と神社。",
     template: "%s | 抹茶と神社。",
   },
-  description:
-    "京都の抹茶スイーツ店と神社仏閣を、近さでつなぐ非公式ガイド。お店のそばの神社、神社のそばの甘味処を見つけられます。",
+  description: SITE_DESCRIPTION,
+  metadataBase: new URL(SITE_URL),
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    siteName: "抹茶と神社。",
+    title: "抹茶と神社。",
+    description: SITE_DESCRIPTION,
+    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "抹茶と神社。" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "抹茶と神社。",
+    description: SITE_DESCRIPTION,
+    images: ["/og-image.png"],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,16 @@ const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
 });
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://matcha-to-jinja.vercel.app";
+const DEFAULT_SITE_URL = "https://matcha-to-jinja.vercel.app";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL;
+const METADATA_BASE = (() => {
+  try {
+    return new URL(SITE_URL);
+  } catch {
+    return new URL(DEFAULT_SITE_URL);
+  }
+})();
+
 const SITE_DESCRIPTION =
   "京都の抹茶スイーツ店と神社仏閣を、近さでつなぐ非公式ガイド。お店のそばの神社、神社のそばの甘味処を見つけられます。";
 
@@ -35,7 +44,7 @@ export const metadata: Metadata = {
     template: "%s | 抹茶と神社。",
   },
   description: SITE_DESCRIPTION,
-  metadataBase: new URL(SITE_URL),
+  metadataBase: METADATA_BASE,
   openGraph: {
     type: "website",
     locale: "ja_JP",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import Hairline from "@/components/brand/Hairline";
+
+export default function NotFound() {
+  return (
+    <section className="flex min-h-[70vh] flex-col items-center justify-center px-6 text-center">
+      <p className="font-mincho text-[64px] font-semibold leading-none tracking-[0.05em] text-line">
+        404
+      </p>
+      <p className="mt-4 font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+        ページが見つかりません / NOT FOUND
+      </p>
+      <h1 className="mt-3 font-mincho text-2xl font-semibold tracking-[0.05em] text-ink">
+        お探しのページは見つかりませんでした
+      </h1>
+      <Hairline width={40} className="mt-5" />
+      <p className="mt-5 max-w-md font-serif-jp text-sm leading-[2] text-muted">
+        URLが変更されたか、ページが削除された可能性があります。
+        <br />
+        トップページから再度お探しください。
+      </p>
+      <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
+        <Link
+          href="/"
+          className="border border-olive px-6 py-2.5 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          トップへ戻る
+        </Link>
+        <Link
+          href="/greenteas"
+          className="border border-line px-6 py-2.5 font-mincho text-[13px] tracking-[0.15em] text-muted transition-colors hover:border-olive hover:text-ink"
+        >
+          抹茶店を探す
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,15 +1,95 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Hairline from "@/components/brand/Hairline";
 
 export const metadata: Metadata = {
   title: "プライバシーポリシー",
+  description: "抹茶と神社。のプライバシーポリシーです。",
 };
+
+type Section = { heading: string; body: string | string[] };
+
+const SECTIONS: Section[] = [
+  {
+    heading: "1. 収集する情報",
+    body: [
+      "本サイトでは、ユーザーが会員登録・ログインする際にメールアドレスおよびSNSアカウント情報（Twitter / LINE）を取得します。",
+      "また、アクセス解析のためにアクセスログ（IPアドレス・閲覧ページ・ブラウザ情報等）を自動的に記録する場合があります。",
+    ],
+  },
+  {
+    heading: "2. 情報の利用目的",
+    body: [
+      "収集した情報は、ログイン認証・お気に入り機能・コメント機能の提供に使用します。",
+      "取得した情報を第三者に販売・提供することはありません。",
+    ],
+  },
+  {
+    heading: "3. Cookie",
+    body: "本サイトはセッション管理のためにCookieを使用します。ブラウザの設定によりCookieを無効化することができますが、一部機能が利用できなくなる場合があります。",
+  },
+  {
+    heading: "4. 外部サービス",
+    body: [
+      "本サイトはGoogle Maps APIを利用しており、地図表示時にGoogleのサービスが適用されます。Google社のプライバシーポリシーについてはGoogle社のWebサイトをご参照ください。",
+      "ログイン機能にはTwitter（X）・LINEのOAuthを使用します。各サービスのプライバシーポリシーも併せてご確認ください。",
+    ],
+  },
+  {
+    heading: "5. 情報の管理",
+    body: "収集した個人情報は適切な安全対策を講じて管理します。法令に基づく場合を除き、本人の同意なく第三者に開示することはありません。",
+  },
+  {
+    heading: "6. お問い合わせ",
+    body: "本ポリシーに関するお問い合わせは、GitHubリポジトリのIssueにてご連絡ください。",
+  },
+  {
+    heading: "7. ポリシーの変更",
+    body: "本ポリシーは予告なく変更される場合があります。変更後はサイト上に掲示した時点で効力を持ちます。",
+  },
+];
 
 export default function PrivacyPage() {
   return (
-    <ComingSoon
-      title="プライバシーポリシー"
-      description="プライバシーポリシーページは現在準備中です。"
-    />
+    <article className="mx-auto w-full max-w-3xl px-6 py-14 md:px-12">
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+          プライバシーポリシー / PRIVACY POLICY
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+          プライバシーポリシー
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <p className="mt-5 font-serif-jp text-sm leading-[2] text-muted">
+          本サイトにおける個人情報の取り扱いについて説明します。
+        </p>
+      </header>
+
+      <div className="mt-12 space-y-10">
+        {SECTIONS.map((section) => (
+          <section key={section.heading}>
+            <h2 className="font-mincho text-lg tracking-[0.08em] text-ink border-b border-line pb-2">
+              {section.heading}
+            </h2>
+            <div className="mt-4 space-y-3">
+              {Array.isArray(section.body) ? (
+                section.body.map((para, i) => (
+                  <p key={i} className="font-serif-jp text-sm leading-[2.1] text-ink">
+                    {para}
+                  </p>
+                ))
+              ) : (
+                <p className="font-serif-jp text-sm leading-[2.1] text-ink">
+                  {section.body}
+                </p>
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <p className="mt-14 text-right font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+        最終更新: 2026年5月
+      </p>
+    </article>
   );
 }

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { HiArrowLeft, HiHeart } from "react-icons/hi2";
 import Hairline from "@/components/brand/Hairline";
 import { ChawanIcon } from "@/components/brand/icons";
+import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getTemple } from "@/lib/api";
 import type { NearbySpot, TempleDetail } from "@/types";
 
@@ -138,6 +139,10 @@ export default async function TempleDetailPage({
           </span>
         </div>
       </header>
+
+      <div className="mt-6 flex justify-center">
+        <ShareButtons title={temple.name} />
+      </div>
 
       <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
         <div className="aspect-[16/9] w-full">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,15 +1,85 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Hairline from "@/components/brand/Hairline";
 
 export const metadata: Metadata = {
   title: "利用規約",
+  description: "抹茶と神社。の利用規約です。",
 };
+
+type Section = { heading: string; body: string | string[] };
+
+const SECTIONS: Section[] = [
+  {
+    heading: "1. 本サイトについて",
+    body: "「抹茶と神社。」（以下「本サイト」）は、京都の抹茶スイーツ店と神社仏閣の情報を個人が非公式にまとめたファンサイトです。掲載店舗・施設とは一切の資本・業務上の関係はありません。",
+  },
+  {
+    heading: "2. 情報の正確性",
+    body: [
+      "掲載している営業時間・定休日・住所・電話番号などの情報は、公開時点での内容を参考にしていますが、正確性・最新性を保証するものではありません。",
+      "ご訪問前には必ず各店舗・施設の公式サイトまたは電話にてご確認ください。",
+    ],
+  },
+  {
+    heading: "3. 画像・著作権",
+    body: "本サイトに表示される画像の著作権は、それぞれの撮影者・運営者に帰属します。無断転載・複製はお控えください。",
+  },
+  {
+    heading: "4. 免責事項",
+    body: "本サイトの情報を利用したことによって生じたいかなる損害についても、運営者は一切の責任を負いません。",
+  },
+  {
+    heading: "5. 外部リンク",
+    body: "本サイトは各店舗・施設の公式サイトへのリンクを含む場合があります。リンク先のコンテンツについては各サイトの運営者が責任を負います。",
+  },
+  {
+    heading: "6. 規約の変更",
+    body: "運営者は予告なく本規約を変更する場合があります。変更後の規約はサイト上に掲示した時点で効力を持ちます。",
+  },
+];
 
 export default function TermsPage() {
   return (
-    <ComingSoon
-      title="利用規約"
-      description="利用規約ページは現在準備中です。"
-    />
+    <article className="mx-auto w-full max-w-3xl px-6 py-14 md:px-12">
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+          利用規約 / TERMS OF USE
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+          利用規約
+        </h1>
+        <Hairline width={40} className="mt-5" />
+        <p className="mt-5 font-serif-jp text-sm leading-[2] text-muted">
+          本サイトをご利用いただく前に、以下の利用規約をお読みください。
+        </p>
+      </header>
+
+      <div className="mt-12 space-y-10">
+        {SECTIONS.map((section) => (
+          <section key={section.heading}>
+            <h2 className="font-mincho text-lg tracking-[0.08em] text-ink border-b border-line pb-2">
+              {section.heading}
+            </h2>
+            <div className="mt-4 space-y-3">
+              {Array.isArray(section.body) ? (
+                section.body.map((para, i) => (
+                  <p key={i} className="font-serif-jp text-sm leading-[2.1] text-ink">
+                    {para}
+                  </p>
+                ))
+              ) : (
+                <p className="font-serif-jp text-sm leading-[2.1] text-ink">
+                  {section.body}
+                </p>
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <p className="mt-14 text-right font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+        最終更新: 2026年5月
+      </p>
+    </article>
   );
 }

--- a/src/components/common/ShareButtons.tsx
+++ b/src/components/common/ShareButtons.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RiTwitterXLine } from "react-icons/ri";
+import { SiLine } from "react-icons/si";
+
+type ShareButtonsProps = {
+  title: string;
+};
+
+export default function ShareButtons({ title }: ShareButtonsProps) {
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    setUrl(window.location.href);
+  }, []);
+
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`;
+  const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        SHARE
+      </span>
+      <a
+        href={twitterUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="X（Twitter）でシェア"
+        className="flex h-8 w-8 items-center justify-center border border-line text-ink transition-colors hover:border-ink hover:bg-ink hover:text-paper"
+      >
+        <RiTwitterXLine className="h-3.5 w-3.5" aria-hidden="true" />
+      </a>
+      <a
+        href={lineUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="LINEでシェア"
+        className="flex h-8 w-8 items-center justify-center border border-line text-ink transition-colors hover:border-[#06C755] hover:bg-[#06C755] hover:text-paper"
+      >
+        <SiLine className="h-3.5 w-3.5" aria-hidden="true" />
+      </a>
+    </div>
+  );
+}

--- a/src/components/common/ShareButtons.tsx
+++ b/src/components/common/ShareButtons.tsx
@@ -15,6 +15,8 @@ export default function ShareButtons({ title }: ShareButtonsProps) {
     setUrl(window.location.href);
   }, []);
 
+  if (!url) return null;
+
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;
 


### PR DESCRIPTION
## 概要

Issue #25 の対応。利用規約・プライバシーポリシーページの実装、404ページの新規作成、OGPメタデータの追加、Twitter/LINEシェアボタンの実装を行った。

Closes #25

## 変更内容

- **OGP / SEO**: `layout.tsx` に `openGraph`・`twitter` Card メタデータを追加（`metadataBase` 設定含む）
- **利用規約** (`/terms`): ComingSoon を廃止し、非公式ファンサイト向け全6条の本文を実装
- **プライバシーポリシー** (`/privacy`): ComingSoon を廃止し、全7条の本文を実装
- **404ページ** (`not-found.tsx`): 帖テーマに沿ったデザインで新規作成。トップ・抹茶店一覧へのリンクを設置
- **ShareButtons コンポーネント**: Twitter/X と LINE のシェアボタン（Client Component）を `src/components/common/ShareButtons.tsx` に追加
- 抹茶店詳細・神社詳細ページに ShareButtons を組み込み

## デザイン方針

帖（chō）テーマのデザイントークン（`bg-washi` / `text-ink` / `border-line` / `font-mincho` 等）を統一して使用。角丸なし・影なしのフラットな罫線スタイルを踏襲。

## テスト計画

- [ ] `/terms` ページが正しく表示される
- [ ] `/privacy` ページが正しく表示される
- [ ] 存在しないURLにアクセスすると 404 ページが表示される
- [ ] 抹茶店詳細・神社詳細ページにシェアボタンが表示される
- [ ] Twitter/LINEのシェアリンクが正しいURLを含んでいる
- [ ] OGPタグが `<head>` に出力されている（ブラウザの開発者ツールで確認）

https://claude.ai/code/session_01YTBRTq47yvw3wckZe8mrys

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTBRTq47yvw3wckZe8mrys)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added share buttons to green tea and temple detail pages, enabling sharing on X (Twitter) and LINE.
  * New 404 error page with navigation links to homepage and tea listings.
  * Complete Privacy Policy page now available.
  * Complete Terms of Use page now available.
  * Enhanced site-wide metadata for improved social media sharing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->