### PR TITLE
feat: 現在地検索ページを実装 (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ NEXT_PUBLIC_USE_MOCK=true
 
 # Google Maps（#22 現在地検索で使用）
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
+# Map ID（Cloud Console で発行。Advanced Markers の利用に必要。未設定時は DEMO_MAP_ID）
+NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
 
 # NextAuth.js（#23 認証で使用）
 NEXTAUTH_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "matcha-jinja-app",
       "version": "0.1.0",
       "dependencies": {
+        "@vis.gl/react-google-maps": "^1.8.3",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -239,6 +240,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1297,6 +1307,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.0.tgz",
+      "integrity": "sha512-u4SHiRC3m27lPa4vDBxh2AI7mDcHcheX6GSHn1Mwi0Gap8/uhM2kFppiFTnWASXLHZO+1ahHciLeEIV+Sjqk/A==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1896,6 +1912,21 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -3232,7 +3263,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vis.gl/react-google-maps": "^1.8.3",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -1,15 +1,30 @@
 import type { Metadata } from "next";
-import ComingSoon from "@/components/common/ComingSoon";
+import Hairline from "@/components/brand/Hairline";
+import NearbyMap from "@/components/map/NearbyMap";
 
 export const metadata: Metadata = {
   title: "現在地から探す",
+  description:
+    "現在地から徒歩圏内の抹茶スイーツ店と神社仏閣を地図で探せます。半径を切り替えて、近くのお茶と神社をひと目に。",
 };
 
 export default function NearbyPage() {
   return (
-    <ComingSoon
-      title="現在地から探す"
-      description="現在地周辺の抹茶店・神社を地図で探すページは現在準備中です。"
-    />
+    <div className="mx-auto max-w-5xl px-4 py-10 sm:py-14">
+      <header className="mb-8 flex flex-col items-center text-center">
+        <p className="font-sans-jp text-xs tracking-[0.3em] text-bengara">
+          NEARBY
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl tracking-[0.1em] text-ink sm:text-4xl">
+          現在地から探す
+        </h1>
+        <Hairline width={48} className="mt-4" />
+        <p className="mt-5 max-w-2xl font-serif-jp text-sm leading-relaxed text-muted sm:text-base">
+          ブラウザの位置情報を使って、いまいる場所のまわりの抹茶店と神社仏閣を地図に並べます。
+          鳥居マークが神社、茶碗マークが抹茶店です。
+        </p>
+      </header>
+      <NearbyMap />
+    </div>
   );
 }

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  AdvancedMarker,
+  APIProvider,
+  InfoWindow,
+  Map,
+  Pin,
+  useMap,
+} from "@vis.gl/react-google-maps";
+import { ApiError } from "@/lib/api/error";
+import { getNearby } from "@/lib/api/nearby";
+import type { NearbyResponse, NearbySpot } from "@/types";
+import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import Hairline from "@/components/brand/Hairline";
+
+const RADIUS_OPTIONS = [0.5, 1.0, 1.5, 2.0] as const;
+type Radius = (typeof RADIUS_OPTIONS)[number];
+
+// 京都市中心部のフォールバック（位置情報拒否時の初期表示）
+const KYOTO_CENTER = { lat: 35.0116, lng: 135.7681 };
+
+type Origin = { lat: number; lng: number };
+type SelectedSpot = { kind: "greentea" | "temple"; spot: NearbySpot };
+
+type GeoState =
+  | { status: "idle" }
+  | { status: "requesting" }
+  | { status: "granted"; origin: Origin }
+  | { status: "denied" }
+  | { status: "error"; message: string };
+
+type FetchState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; data: NearbyResponse }
+  | { status: "error"; message: string };
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`;
+  return `${(meters / 1000).toFixed(1)}km`;
+}
+
+export default function NearbyMap() {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
+  const [geo, setGeo] = useState<GeoState>({ status: "idle" });
+  const [radius, setRadius] = useState<Radius>(1.5);
+  const [fetchState, setFetchState] = useState<FetchState>({ status: "idle" });
+  const [selected, setSelected] = useState<SelectedSpot | null>(null);
+
+  const requestLocation = useCallback(() => {
+    if (!("geolocation" in navigator)) {
+      setGeo({
+        status: "error",
+        message: "お使いのブラウザは位置情報に対応していません。",
+      });
+      return;
+    }
+    setGeo({ status: "requesting" });
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setGeo({
+          status: "granted",
+          origin: { lat: pos.coords.latitude, lng: pos.coords.longitude },
+        });
+      },
+      (err) => {
+        if (err.code === err.PERMISSION_DENIED) {
+          setGeo({ status: "denied" });
+        } else {
+          setGeo({
+            status: "error",
+            message: "現在地を取得できませんでした。時間をおいて再度お試しください。",
+          });
+        }
+      },
+      { enableHighAccuracy: false, timeout: 10_000, maximumAge: 60_000 },
+    );
+  }, []);
+
+  useEffect(() => {
+    requestLocation();
+  }, [requestLocation]);
+
+  const origin = geo.status === "granted" ? geo.origin : null;
+
+  useEffect(() => {
+    if (!origin) return;
+    let cancelled = false;
+    setFetchState({ status: "loading" });
+    setSelected(null);
+    getNearby({ lat: origin.lat, lng: origin.lng, radius })
+      .then((data) => {
+        if (!cancelled) setFetchState({ status: "success", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message =
+          err instanceof ApiError
+            ? `近隣スポットの取得に失敗しました（${err.status}）。`
+            : "近隣スポットの取得に失敗しました。";
+        setFetchState({ status: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [origin, radius]);
+
+  if (!apiKey) {
+    return (
+      <ConfigError
+        message="Google Maps の API キーが設定されていません。NEXT_PUBLIC_GOOGLE_MAPS_API_KEY を .env.local に設定してください。"
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <RadiusSelector
+        value={radius}
+        onChange={setRadius}
+        disabled={geo.status !== "granted"}
+      />
+
+      <APIProvider apiKey={apiKey} libraries={["marker"]}>
+        <div className="relative">
+          <div className="border border-line bg-paper">
+            <div className="h-[60vh] min-h-[420px] w-full">
+              <Map
+                mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID ?? "DEMO_MAP_ID"}
+                defaultCenter={origin ?? KYOTO_CENTER}
+                defaultZoom={15}
+                gestureHandling="greedy"
+                disableDefaultUI={false}
+                clickableIcons={false}
+              >
+                {origin && <OriginMarker origin={origin} />}
+                {fetchState.status === "success" && (
+                  <SpotMarkers
+                    spots={fetchState.data}
+                    onSelect={setSelected}
+                  />
+                )}
+                {selected && (
+                  <InfoWindow
+                    position={{
+                      lat: selected.spot.latitude,
+                      lng: selected.spot.longitude,
+                    }}
+                    onCloseClick={() => setSelected(null)}
+                  >
+                    <SpotInfo kind={selected.kind} spot={selected.spot} />
+                  </InfoWindow>
+                )}
+                {origin && (
+                  <MapRecenter
+                    center={origin}
+                    deps={[origin.lat, origin.lng, radius]}
+                  />
+                )}
+              </Map>
+            </div>
+          </div>
+        </div>
+      </APIProvider>
+
+      <StatusPanel
+        geo={geo}
+        fetchState={fetchState}
+        onRetry={requestLocation}
+      />
+
+      {fetchState.status === "success" && (
+        <SpotLists
+          data={fetchState.data}
+          onSelect={setSelected}
+        />
+      )}
+    </div>
+  );
+}
+
+function RadiusSelector({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Radius;
+  onChange: (r: Radius) => void;
+  disabled: boolean;
+}) {
+  return (
+    <fieldset
+      className="border border-line bg-paper px-5 py-4"
+      aria-label="検索半径"
+    >
+      <legend className="px-2 font-mincho text-sm tracking-[0.2em] text-olive">
+        検索半径
+      </legend>
+      <div className="flex flex-wrap gap-2">
+        {RADIUS_OPTIONS.map((r) => {
+          const active = r === value;
+          return (
+            <button
+              key={r}
+              type="button"
+              onClick={() => onChange(r)}
+              disabled={disabled}
+              aria-pressed={active}
+              className={[
+                "border px-4 py-1.5 font-sans-jp text-sm tracking-[0.1em] transition-colors",
+                active
+                  ? "border-olive bg-olive text-paper"
+                  : "border-line bg-paper text-ink hover:border-olive hover:text-olive",
+                disabled ? "cursor-not-allowed opacity-50" : "",
+              ].join(" ")}
+            >
+              {r.toFixed(1)} km
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+function OriginMarker({ origin }: { origin: Origin }) {
+  return (
+    <AdvancedMarker position={origin} title="現在地">
+      <Pin background="#4a90a4" borderColor="#3d3322" glyphColor="#fbf6e5" />
+    </AdvancedMarker>
+  );
+}
+
+function SpotMarkers({
+  spots,
+  onSelect,
+}: {
+  spots: NearbyResponse;
+  onSelect: (s: SelectedSpot) => void;
+}) {
+  return (
+    <>
+      {spots.greenteas.map((s) => (
+        <AdvancedMarker
+          key={`g-${s.id}`}
+          position={{ lat: s.latitude, lng: s.longitude }}
+          title={s.name}
+          onClick={() => onSelect({ kind: "greentea", spot: s })}
+        >
+          <MarkerBadge kind="greentea" />
+        </AdvancedMarker>
+      ))}
+      {spots.temples.map((s) => (
+        <AdvancedMarker
+          key={`t-${s.id}`}
+          position={{ lat: s.latitude, lng: s.longitude }}
+          title={s.name}
+          onClick={() => onSelect({ kind: "temple", spot: s })}
+        >
+          <MarkerBadge kind="temple" />
+        </AdvancedMarker>
+      ))}
+    </>
+  );
+}
+
+function MarkerBadge({ kind }: { kind: "greentea" | "temple" }) {
+  const isGreentea = kind === "greentea";
+  return (
+    <div
+      className={[
+        "flex h-9 w-9 items-center justify-center border bg-paper shadow-[0_2px_0_rgba(61,51,34,0.15)]",
+        isGreentea ? "border-matcha" : "border-bengara",
+      ].join(" ")}
+    >
+      {isGreentea ? (
+        <ChawanIcon size={22} color="#608060" />
+      ) : (
+        <ToriiIcon size={22} color="#905050" />
+      )}
+    </div>
+  );
+}
+
+function SpotInfo({
+  kind,
+  spot,
+}: {
+  kind: "greentea" | "temple";
+  spot: NearbySpot;
+}) {
+  const href = kind === "greentea" ? `/greenteas/${spot.id}` : `/temples/${spot.id}`;
+  const label = kind === "greentea" ? "抹茶店" : "神社仏閣";
+  return (
+    <div className="flex min-w-[180px] flex-col gap-2 font-serif-jp text-ink">
+      <span className="font-sans-jp text-[10px] tracking-[0.2em] text-muted">
+        {label}
+      </span>
+      <span className="font-mincho text-base leading-tight">{spot.name}</span>
+      <span className="font-sans-jp text-xs text-muted">
+        現在地から {formatDistance(spot.distance_meters)}
+      </span>
+      <Link
+        href={href}
+        className="font-sans-jp text-xs tracking-[0.15em] text-olive underline underline-offset-4 hover:text-olive-dark"
+      >
+        詳細を見る →
+      </Link>
+    </div>
+  );
+}
+
+function StatusPanel({
+  geo,
+  fetchState,
+  onRetry,
+}: {
+  geo: GeoState;
+  fetchState: FetchState;
+  onRetry: () => void;
+}) {
+  if (geo.status === "requesting") {
+    return <Notice tone="info">現在地を取得中…</Notice>;
+  }
+  if (geo.status === "denied") {
+    return (
+      <Notice tone="warn" action={{ label: "もう一度試す", onClick: onRetry }}>
+        位置情報の利用が拒否されました。ブラウザの設定で位置情報を許可してから再度お試しください。地図は京都市中心部を表示しています。
+      </Notice>
+    );
+  }
+  if (geo.status === "error") {
+    return (
+      <Notice tone="warn" action={{ label: "もう一度試す", onClick: onRetry }}>
+        {geo.message}
+      </Notice>
+    );
+  }
+  if (fetchState.status === "loading") {
+    return <Notice tone="info">近隣スポットを検索中…</Notice>;
+  }
+  if (fetchState.status === "error") {
+    return <Notice tone="warn">{fetchState.message}</Notice>;
+  }
+  if (fetchState.status === "success") {
+    const total =
+      fetchState.data.greenteas.length + fetchState.data.temples.length;
+    if (total === 0) {
+      return (
+        <Notice tone="info">
+          指定した範囲には登録されたスポットがありません。半径を広げてお試しください。
+        </Notice>
+      );
+    }
+  }
+  return null;
+}
+
+function Notice({
+  children,
+  tone,
+  action,
+}: {
+  children: React.ReactNode;
+  tone: "info" | "warn";
+  action?: { label: string; onClick: () => void };
+}) {
+  const border = tone === "warn" ? "border-bengara" : "border-line";
+  const text = tone === "warn" ? "text-bengara-dark" : "text-ink";
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-3 border ${border} bg-paper px-5 py-3`}
+      role={tone === "warn" ? "alert" : "status"}
+    >
+      <p className={`flex-1 font-serif-jp text-sm leading-relaxed ${text}`}>
+        {children}
+      </p>
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="border border-olive px-3 py-1 font-sans-jp text-xs tracking-[0.15em] text-olive hover:bg-olive hover:text-paper"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function SpotLists({
+  data,
+  onSelect,
+}: {
+  data: NearbyResponse;
+  onSelect: (s: SelectedSpot) => void;
+}) {
+  return (
+    <section className="grid gap-6 lg:grid-cols-2">
+      <SpotColumn
+        title="抹茶店"
+        kind="greentea"
+        spots={data.greenteas}
+        onSelect={onSelect}
+      />
+      <SpotColumn
+        title="神社仏閣"
+        kind="temple"
+        spots={data.temples}
+        onSelect={onSelect}
+      />
+    </section>
+  );
+}
+
+function SpotColumn({
+  title,
+  kind,
+  spots,
+  onSelect,
+}: {
+  title: string;
+  kind: "greentea" | "temple";
+  spots: NearbySpot[];
+  onSelect: (s: SelectedSpot) => void;
+}) {
+  const isGreentea = kind === "greentea";
+  return (
+    <div className="border border-line bg-paper">
+      <header className="flex items-center justify-between border-b border-line-soft px-5 py-3">
+        <h2 className="font-mincho text-base tracking-[0.15em] text-ink">
+          {title}
+          <span
+            className={`ml-3 font-sans-jp text-xs tracking-[0.1em] ${
+              isGreentea ? "text-matcha" : "text-bengara"
+            }`}
+          >
+            {spots.length} 件
+          </span>
+        </h2>
+        <Hairline width={28} />
+      </header>
+      {spots.length === 0 ? (
+        <p className="px-5 py-6 text-center font-serif-jp text-sm text-muted">
+          該当するスポットはありません。
+        </p>
+      ) : (
+        <ul className="divide-y divide-line-soft">
+          {spots.map((s) => {
+            const href = isGreentea ? `/greenteas/${s.id}` : `/temples/${s.id}`;
+            return (
+              <li key={s.id} className="flex items-center gap-3 px-5 py-3">
+                <button
+                  type="button"
+                  onClick={() => onSelect({ kind, spot: s })}
+                  className="flex flex-1 items-center gap-3 text-left"
+                  aria-label={`${s.name} を地図で表示`}
+                >
+                  {isGreentea ? (
+                    <ChawanIcon size={22} color="#608060" />
+                  ) : (
+                    <ToriiIcon size={22} color="#905050" />
+                  )}
+                  <span className="flex-1 font-mincho text-base text-ink">
+                    {s.name}
+                  </span>
+                  <span className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+                    {formatDistance(s.distance_meters)}
+                  </span>
+                </button>
+                <Link
+                  href={href}
+                  className="font-sans-jp text-xs tracking-[0.15em] text-olive underline underline-offset-4 hover:text-olive-dark"
+                >
+                  詳細
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// origin / radius が変わるたびに地図中心を現在地へ戻す。
+function MapRecenter({
+  center,
+  deps,
+}: {
+  center: Origin;
+  deps: unknown[];
+}) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    map.panTo(center);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, ...deps]);
+  return null;
+}
+
+function ConfigError({ message }: { message: string }) {
+  return (
+    <div className="border border-bengara bg-paper px-5 py-6">
+      <p className="font-serif-jp text-sm leading-relaxed text-bengara-dark">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -45,6 +45,7 @@ function formatDistance(meters: number): string {
 
 export default function NearbyMap() {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
+  const hasMapsConfig = Boolean(apiKey);
   const [geo, setGeo] = useState<GeoState>({ status: "idle" });
   const [radius, setRadius] = useState<Radius>(1.5);
   const [fetchState, setFetchState] = useState<FetchState>({ status: "idle" });
@@ -81,14 +82,14 @@ export default function NearbyMap() {
   }, []);
 
   useEffect(() => {
-    if (!apiKey) return;
+    if (!hasMapsConfig) return;
     requestLocation();
-  }, [apiKey, requestLocation]);
+  }, [hasMapsConfig, requestLocation]);
 
   const origin = geo.status === "granted" ? geo.origin : null;
 
   useEffect(() => {
-    if (!origin) return;
+    if (!hasMapsConfig || !origin) return;
     let cancelled = false;
     setFetchState({ status: "loading" });
     setSelected(null);
@@ -107,9 +108,9 @@ export default function NearbyMap() {
     return () => {
       cancelled = true;
     };
-  }, [origin, radius]);
+  }, [hasMapsConfig, origin, radius]);
 
-  if (!apiKey) {
+  if (!hasMapsConfig) {
     return (
       <ConfigError
         message="Google Maps の API キーが設定されていません。NEXT_PUBLIC_GOOGLE_MAPS_API_KEY を .env.local に設定してください。"
@@ -148,15 +149,23 @@ export default function NearbyMap() {
                   />
                 )}
                 {selected && (
-                  <InfoWindow
-                    position={{
-                      lat: selected.spot.latitude,
-                      lng: selected.spot.longitude,
-                    }}
-                    onCloseClick={() => setSelected(null)}
-                  >
-                    <SpotInfo kind={selected.kind} spot={selected.spot} />
-                  </InfoWindow>
+                  <>
+                    <MapFocusOnSelection
+                      position={{
+                        lat: selected.spot.latitude,
+                        lng: selected.spot.longitude,
+                      }}
+                    />
+                    <InfoWindow
+                      position={{
+                        lat: selected.spot.latitude,
+                        lng: selected.spot.longitude,
+                      }}
+                      onCloseClick={() => setSelected(null)}
+                    >
+                      <SpotInfo kind={selected.kind} spot={selected.spot} />
+                    </InfoWindow>
+                  </>
                 )}
                 {origin && (
                   <MapRecenter
@@ -488,6 +497,18 @@ function SpotColumn({
       )}
     </div>
   );
+}
+
+// 選択スポット変更時に地図中心をそのスポットへ移動。1.5km 超の半径だと
+// 選択マーカーが画面外になりうるため、リスト/マーカーいずれの選択でも追従させる。
+function MapFocusOnSelection({ position }: { position: Origin }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    map.panTo(position);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, position.lat, position.lng]);
+  return null;
 }
 
 // origin / radius が変わるたびに地図中心を現在地へ戻す。

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -81,8 +81,9 @@ export default function NearbyMap() {
   }, []);
 
   useEffect(() => {
+    if (!apiKey) return;
     requestLocation();
-  }, [requestLocation]);
+  }, [apiKey, requestLocation]);
 
   const origin = geo.status === "granted" ? geo.origin : null;
 
@@ -129,7 +130,10 @@ export default function NearbyMap() {
           <div className="border border-line bg-paper">
             <div className="h-[60vh] min-h-[420px] w-full">
               <Map
-                mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID ?? "DEMO_MAP_ID"}
+                mapId={
+                  process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID?.trim() ||
+                  "DEMO_MAP_ID"
+                }
                 defaultCenter={origin ?? KYOTO_CENTER}
                 defaultZoom={15}
                 gestureHandling="greedy"

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -93,6 +93,8 @@ export async function mockClient<T>(
         .map((t) => ({
           id: t.id,
           name: t.name,
+          latitude: t.latitude,
+          longitude: t.longitude,
           distance_meters: distanceMeters(greentea, t),
         }))
         .filter((t) => t.distance_meters <= 1500)
@@ -136,6 +138,8 @@ export async function mockClient<T>(
         .map((g) => ({
           id: g.id,
           name: g.name,
+          latitude: g.latitude,
+          longitude: g.longitude,
           distance_meters: distanceMeters(temple, g),
         }))
         .filter((g) => g.distance_meters <= 1500)
@@ -184,6 +188,8 @@ export async function mockClient<T>(
       }): NearbySpot => ({
         id: item.id,
         name: item.name,
+        latitude: item.latitude,
+        longitude: item.longitude,
         distance_meters: distanceMeters(origin, item),
       });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -13,6 +13,8 @@ export interface Meta {
 export interface NearbySpot {
   id: number;
   name: string;
+  latitude: number;
+  longitude: number;
   distance_meters: number;
 }
 


### PR DESCRIPTION
## 概要

Issue #22 の対応。`/nearby` を ComingSoon プレースホルダから本実装に差し替え、ブラウザ Geolocation API と Google Maps で現在地周辺の抹茶店・神社仏閣を地図表示するページを実装しました。

Closes #22

## 採用ライブラリ

**`@vis.gl/react-google-maps`** を採用しました。

| 観点 | @vis.gl/react-google-maps | @react-google-maps/api |
|---|---|---|
| メンテナンス | **Google 公式（Google Maps Platform チーム）** | 古参・メンテ鈍化気味 |
| React 19 / Next.js 15 | 公式に対応 | 不明確 |
| Advanced Markers | ネイティブ対応 | 個別実装が必要 |
| TS 型 | 充実 | 充実 |

新規プロジェクト・Next.js 15 + React 19 という前提で、長期的に安全な公式を選びました。

## 変更内容

### ライブラリ
- `@vis.gl/react-google-maps@^1.8.3` を追加

### ページ
- **`src/app/nearby/page.tsx`** — Server Component（metadata 付き）で見出しを描画し、`<NearbyMap />` を Client Component として埋め込む構成（CSR）。

### コンポーネント（新規）
- **`src/components/map/NearbyMap.tsx`** — `"use client"`。本ページの UX を完結。
  - **Geolocation**: マウント時に `getCurrentPosition` を要求。状態は `idle / requesting / granted / denied / error` で管理。拒否・エラー時は再試行ボタンを表示し、地図は京都市中心部にフォールバック。
  - **半径セレクター**: 0.5 / 1.0 / 1.5 / 2.0 km。変更で即時に再取得。
  - **マーカー**: 現在地（青 Pin）/ 抹茶店（茶碗アイコン）/ 神社（鳥居アイコン）。`AdvancedMarker` + ブランドアイコン（#36 で導入した `ChawanIcon` / `ToriiIcon`）を再利用。
  - **InfoWindow**: マーカー or 地図下のリスト項目クリックで開き、種別ラベル・名前・距離・詳細ページへのリンクを表示。
  - **リスト**: 抹茶店 / 神社それぞれを地図下にカラム表示（件数バッジ付き）。
  - **再センター**: `useMap()` で `origin` / `radius` 変更時に現在地へパン。

### 型・モック
- **`src/types/api.ts`**: `NearbySpot` に `latitude` / `longitude` を追加。マーカー描画に必須のため。
- **`src/lib/api/mock/index.ts`**: `/nearby` / `/greenteas/:id` / `/temples/:id` のレスポンスで lat / lng を含めて返すよう更新。

> 補足: Rails 側 #17（近隣検索 API）のレスポンス契約も同形（id / name / latitude / longitude / distance_meters）にする想定です。

### 環境変数
- **`.env.example`**: `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` を追記。Advanced Markers の利用には Map ID が必要で、未設定時はライブラリの `DEMO_MAP_ID` にフォールバックします。

## 設計の拠り所

- レンダリング戦略（`docs/migration-plan.md` 2-4）に従い、`/nearby` は **CSR**。
- デザインは「帖（chō）」テーマ（#36）の罫線・色面・明朝体主体のフラット意匠を踏襲。マーカー・InfoWindow・リスト・通知パネルすべて `border-line` / `bg-paper` / `font-mincho` などのトークンを利用。
- API クライアントは既存の `getNearby` をそのまま利用（`NEXT_PUBLIC_USE_MOCK=true` でモック動作）。

## 動作確認

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` パス（警告 0）
- [x] `NEXT_PUBLIC_USE_MOCK=true NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=dummy npm run build` 成功
  - `/nearby` → ○ Static / 19.3 kB / First Load JS 124 kB

## Test plan（マニュアル）

- [ ] `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` を実キーで設定し、`/nearby` を開く
- [ ] 位置情報の許可ダイアログが出て、許可すると現在地マーカー（青）が描画される
- [ ] 半径ボタンを切り替えるとマーカー集合と地図中心が更新される
- [ ] 抹茶店マーカー（茶碗）/ 神社マーカー（鳥居）をクリックで InfoWindow が開く
- [ ] InfoWindow 内のリンクが詳細ページに遷移する
- [ ] 地図下リストの項目クリックで該当マーカーの InfoWindow が開く
- [ ] 位置情報を拒否すると警告と再試行ボタンが出て、地図は京都市中心部にフォールバック
- [ ] モバイル幅でレイアウトが崩れない

## 関連 issue

- Closes #22
- 後続: #23（OAuth）/ #24（いいね・コメント結合）/ #27（Vercel デプロイ）
- API 契約参照: #17（Rails 近隣検索 API — `NearbySpot` に lat / lng を含む形で合わせる想定）

https://claude.ai/code/session_01RoQ1kpDHngCqZcXiJAre63

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoQ1kpDHngCqZcXiJAre63)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched "Nearby" page with an interactive map displaying nearby greentea and temple spots based on your device's current location
  * Added customizable radius selection controls to refine your search area
  * Integrated spot information windows with detailed location data and categorized spot listings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/matcha-to-jinja/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->