### PR TITLE
feat: いいね・コメント機能を UI 先行で実装 (#24)

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { HiArrowLeft, HiHeart } from "react-icons/hi2";
+import { HiArrowLeft } from "react-icons/hi2";
 import Hairline from "@/components/brand/Hairline";
 import { ToriiIcon } from "@/components/brand/icons";
+import CommentSection from "@/components/common/CommentSection";
+import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getGreentea } from "@/lib/api";
+import { auth } from "@/lib/auth";
 import type { GreenteaDetail, NearbySpot } from "@/types";
 
 type RouteParams = { id: string };
 
-async function fetchGreentea(id: string): Promise<GreenteaDetail> {
+async function fetchGreentea(
+  id: string,
+  authToken?: string,
+): Promise<GreenteaDetail> {
   try {
-    const { greentea } = await getGreentea(id);
+    const { greentea } = await getGreentea(id, authToken);
     return greentea;
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
@@ -92,7 +98,8 @@ export default async function GreenteaDetailPage({
   params: Promise<RouteParams>;
 }) {
   const { id } = await params;
-  const greentea = await fetchGreentea(id);
+  const session = await auth();
+  const greentea = await fetchGreentea(id, session?.railsJwt);
 
   return (
     <article className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
@@ -123,10 +130,13 @@ export default async function GreenteaDetailPage({
               {genre.name}
             </span>
           ))}
-          <span className="inline-flex items-center gap-1.5 border border-line bg-paper px-2.5 py-1 font-sans-jp text-[11px] text-muted">
-            <HiHeart className="h-3.5 w-3.5 text-bengara" aria-hidden="true" />
-            {greentea.likes_count}
-          </span>
+          <LikeButton
+            kind="greentea"
+            id={greentea.id}
+            initialCount={greentea.likes_count}
+            initialLiked={greentea.liked_by_current_user ?? false}
+            callbackUrl={`/greenteas/${greentea.id}`}
+          />
           {greentea.closed && (
             <span className="border border-bengara bg-bengara px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-paper">
               閉店
@@ -195,6 +205,23 @@ export default async function GreenteaDetailPage({
         </h2>
         <div className="mt-4">
           <NearbyTemples temples={greentea.nearby_temples} />
+        </div>
+      </section>
+
+      <section className="mt-12">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          コメント
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            COMMENTS
+          </span>
+        </h2>
+        <div className="mt-4">
+          <CommentSection
+            kind="greentea"
+            targetId={greentea.id}
+            initialComments={greentea.comments}
+            callbackUrl={`/greenteas/${greentea.id}`}
+          />
         </div>
       </section>
     </article>

--- a/src/app/mypage/greentea-likes/page.tsx
+++ b/src/app/mypage/greentea-likes/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { HiArrowLeft } from "react-icons/hi2";
+import Hairline from "@/components/brand/Hairline";
+import LikedSpotsList from "@/components/common/LikedSpotsList";
+
+export const metadata: Metadata = {
+  title: "お気に入りの抹茶店",
+};
+
+export default function GreenteaLikesPage() {
+  return (
+    <section className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
+      <div className="mb-6">
+        <Link
+          href="/mypage"
+          className="inline-flex items-center gap-2 font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          <HiArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          マイページへ
+        </Link>
+      </div>
+
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+          お気に入り / FAVORITES
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+          抹茶店
+        </h1>
+        <Hairline width={40} className="mt-5" />
+      </header>
+
+      <div className="mt-10">
+        <LikedSpotsList kind="greentea" />
+      </div>
+    </section>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -52,9 +52,36 @@ export default function MyPage() {
       </h1>
       <Hairline width={40} className="mt-5" />
 
-      <p className="mt-10 font-serif-jp text-sm leading-[2] text-muted">
-        お気に入り一覧の表示は現在準備中です（#24）。
-      </p>
+      <div className="mt-10 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <Link
+          href="/mypage/greentea-likes"
+          className="border border-line-soft bg-paper px-6 py-7 transition-colors hover:bg-washi-bg"
+        >
+          <p className="font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            FAVORITES — GREENTEA
+          </p>
+          <p className="mt-3 font-mincho text-xl text-ink">
+            お気に入りの抹茶店
+          </p>
+          <p className="mt-3 font-serif-jp text-xs leading-[1.9] text-muted">
+            これまでに気になった抹茶スイーツのお店を一覧で。
+          </p>
+        </Link>
+        <Link
+          href="/mypage/temple-likes"
+          className="border border-line-soft bg-paper px-6 py-7 transition-colors hover:bg-washi-bg"
+        >
+          <p className="font-sans-jp text-[10px] tracking-[0.3em] text-bengara">
+            FAVORITES — TEMPLES
+          </p>
+          <p className="mt-3 font-mincho text-xl text-ink">
+            お気に入りの神社仏閣
+          </p>
+          <p className="mt-3 font-serif-jp text-xs leading-[1.9] text-muted">
+            参拝・散策で気に入った社寺をいつでも見返せます。
+          </p>
+        </Link>
+      </div>
     </section>
   );
 }

--- a/src/app/mypage/temple-likes/page.tsx
+++ b/src/app/mypage/temple-likes/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { HiArrowLeft } from "react-icons/hi2";
+import Hairline from "@/components/brand/Hairline";
+import LikedSpotsList from "@/components/common/LikedSpotsList";
+
+export const metadata: Metadata = {
+  title: "お気に入りの神社仏閣",
+};
+
+export default function TempleLikesPage() {
+  return (
+    <section className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
+      <div className="mb-6">
+        <Link
+          href="/mypage"
+          className="inline-flex items-center gap-2 font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          <HiArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          マイページへ
+        </Link>
+      </div>
+
+      <header className="flex flex-col items-center text-center">
+        <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-bengara">
+          お気に入り / FAVORITES
+        </p>
+        <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+          神社仏閣
+        </h1>
+        <Hairline width={40} className="mt-5" />
+      </header>
+
+      <div className="mt-10">
+        <LikedSpotsList kind="temple" />
+      </div>
+    </section>
+  );
+}

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { HiArrowLeft, HiHeart } from "react-icons/hi2";
+import { HiArrowLeft } from "react-icons/hi2";
 import Hairline from "@/components/brand/Hairline";
 import { ChawanIcon } from "@/components/brand/icons";
+import CommentSection from "@/components/common/CommentSection";
+import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getTemple } from "@/lib/api";
+import { auth } from "@/lib/auth";
 import type { NearbySpot, TempleDetail } from "@/types";
 
 type RouteParams = { id: string };
 
-async function fetchTemple(id: string): Promise<TempleDetail> {
+async function fetchTemple(
+  id: string,
+  authToken?: string,
+): Promise<TempleDetail> {
   try {
-    const { temple } = await getTemple(id);
+    const { temple } = await getTemple(id, authToken);
     return temple;
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) notFound();
@@ -102,7 +108,8 @@ export default async function TempleDetailPage({
   params: Promise<RouteParams>;
 }) {
   const { id } = await params;
-  const temple = await fetchTemple(id);
+  const session = await auth();
+  const temple = await fetchTemple(id, session?.railsJwt);
 
   return (
     <article className="mx-auto w-full max-w-5xl px-6 py-12 md:px-12">
@@ -133,10 +140,13 @@ export default async function TempleDetailPage({
               {area.name}
             </span>
           ))}
-          <span className="inline-flex items-center gap-1.5 border border-line bg-paper px-2.5 py-1 font-sans-jp text-[11px] text-muted">
-            <HiHeart className="h-3.5 w-3.5 text-bengara" aria-hidden="true" />
-            {temple.likes_count}
-          </span>
+          <LikeButton
+            kind="temple"
+            id={temple.id}
+            initialCount={temple.likes_count}
+            initialLiked={temple.liked_by_current_user ?? false}
+            callbackUrl={`/temples/${temple.id}`}
+          />
         </div>
       </header>
 
@@ -204,6 +214,23 @@ export default async function TempleDetailPage({
         </h2>
         <div className="mt-4">
           <NearbyGreenteas greenteas={temple.nearby_greenteas} />
+        </div>
+      </section>
+
+      <section className="mt-12">
+        <h2 className="font-mincho text-lg tracking-[0.12em] text-ink">
+          コメント
+          <span className="ml-3 font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            COMMENTS
+          </span>
+        </h2>
+        <div className="mt-4">
+          <CommentSection
+            kind="temple"
+            targetId={temple.id}
+            initialComments={temple.comments}
+            callbackUrl={`/temples/${temple.id}`}
+          />
         </div>
       </section>
     </article>

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { HiTrash } from "react-icons/hi2";
+import {
+  ApiError,
+  createGreenteaComment,
+  createTempleComment,
+  deleteGreenteaComment,
+  deleteTempleComment,
+} from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import type { Comment } from "@/types";
+
+type CommentSectionProps = {
+  kind: "greentea" | "temple";
+  targetId: number;
+  initialComments: Comment[];
+  callbackUrl: string;
+};
+
+const MAX_BODY_LENGTH = 500;
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export default function CommentSection({
+  kind,
+  targetId,
+  initialComments,
+  callbackUrl,
+}: CommentSectionProps) {
+  const authToken = useAuthToken();
+  const [comments, setComments] = useState<Comment[]>(initialComments);
+  const [body, setBody] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [submitting, startSubmit] = useTransition();
+  const [deleting, startDelete] = useTransition();
+
+  const trimmed = body.trim();
+  const tooLong = body.length > MAX_BODY_LENGTH;
+  const canSubmit = !!authToken && trimmed.length > 0 && !tooLong && !submitting;
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!authToken || trimmed.length === 0 || tooLong) return;
+    setSubmitError(null);
+
+    startSubmit(async () => {
+      try {
+        const { comment } =
+          kind === "greentea"
+            ? await createGreenteaComment(targetId, trimmed, authToken)
+            : await createTempleComment(targetId, trimmed, authToken);
+        setComments((prev) => [
+          { ...comment, owned_by_current_user: true },
+          ...prev,
+        ]);
+        setBody("");
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 401) {
+          setSubmitError("ログインの有効期限が切れました。再度ログインしてください。");
+          return;
+        }
+        setSubmitError("投稿に失敗しました。時間を置いてお試しください。");
+      }
+    });
+  };
+
+  const handleDelete = (commentId: number) => {
+    if (!authToken) return;
+    if (typeof window !== "undefined") {
+      const ok = window.confirm("このコメントを削除しますか？");
+      if (!ok) return;
+    }
+    setDeleteError(null);
+    const snapshot = comments;
+    setComments((prev) => prev.filter((c) => c.id !== commentId));
+
+    startDelete(async () => {
+      try {
+        if (kind === "greentea") {
+          await deleteGreenteaComment(commentId, authToken);
+        } else {
+          await deleteTempleComment(commentId, authToken);
+        }
+      } catch (e) {
+        setComments(snapshot);
+        if (e instanceof ApiError && e.status === 401) {
+          setDeleteError("ログインが必要です。");
+          return;
+        }
+        setDeleteError("削除に失敗しました。");
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      {authToken ? (
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-3 border border-line-soft bg-paper px-5 py-5"
+        >
+          <label
+            htmlFor="comment-body"
+            className="font-sans-jp text-[10px] tracking-[0.3em] text-olive"
+          >
+            コメントを書く / WRITE
+          </label>
+          <textarea
+            id="comment-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={4}
+            maxLength={MAX_BODY_LENGTH + 100}
+            placeholder="感想や訪問のメモを残してみましょう"
+            disabled={submitting}
+            className="w-full resize-y border border-line bg-washi px-3 py-2 font-serif-jp text-sm leading-[1.9] text-ink focus:outline-none focus:ring-1 focus:ring-olive disabled:opacity-60"
+          />
+          <div className="flex items-center justify-between gap-3">
+            <p
+              className={`font-sans-jp text-[10px] tracking-[0.15em] ${
+                tooLong ? "text-bengara" : "text-muted"
+              }`}
+            >
+              {body.length} / {MAX_BODY_LENGTH}
+            </p>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="border border-olive bg-olive px-5 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-paper transition-colors hover:bg-olive-dark disabled:cursor-not-allowed disabled:border-line disabled:bg-line disabled:text-muted"
+            >
+              {submitting ? "送信中…" : "投稿する"}
+            </button>
+          </div>
+          {submitError && (
+            <p role="alert" className="font-sans-jp text-xs text-bengara">
+              {submitError}
+            </p>
+          )}
+        </form>
+      ) : (
+        <div className="border border-line-soft bg-paper px-5 py-5">
+          <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+            コメントの投稿にはログインが必要です。
+          </p>
+          <Link
+            href={`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+            className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+          >
+            ログインへ
+          </Link>
+        </div>
+      )}
+
+      {deleteError && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {deleteError}
+        </p>
+      )}
+
+      {comments.length === 0 ? (
+        <p className="border border-line-soft bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+          まだコメントはありません。
+        </p>
+      ) : (
+        <ul className="divide-y divide-line-soft border border-line-soft bg-paper">
+          {comments.map((comment) => (
+            <li key={comment.id} className="px-5 py-4">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="font-mincho text-sm text-ink">
+                  {comment.user.name}
+                </span>
+                <span className="font-sans-jp text-[10px] tracking-[0.15em] text-muted">
+                  {formatDate(comment.created_at)}
+                </span>
+              </div>
+              <p className="mt-2 whitespace-pre-wrap font-serif-jp text-sm leading-[1.9] text-ink">
+                {comment.body}
+              </p>
+              {comment.owned_by_current_user && (
+                <div className="mt-3 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(comment.id)}
+                    disabled={deleting}
+                    className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[10px] tracking-[0.1em] text-muted transition-colors hover:border-bengara hover:text-bengara disabled:opacity-60"
+                  >
+                    <HiTrash className="h-3 w-3" aria-hidden="true" />
+                    削除
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -101,6 +101,10 @@ export default function CommentSection({
           setDeleteError("ログインが必要です。");
           return;
         }
+        if (e instanceof ApiError && e.status === 403) {
+          setDeleteError("このコメントを削除する権限がありません。");
+          return;
+        }
         setDeleteError("削除に失敗しました。");
       }
     });
@@ -124,6 +128,8 @@ export default function CommentSection({
             value={body}
             onChange={(e) => setBody(e.target.value)}
             rows={4}
+            // ハードカットは + 100 文字までで、上限超過は文字数カウンタを
+            // 赤くしてユーザーに気付かせ送信ボタンを無効化する UX を取る。
             maxLength={MAX_BODY_LENGTH + 100}
             placeholder="感想や訪問のメモを残してみましょう"
             disabled={submitting}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { HiHeart, HiOutlineHeart } from "react-icons/hi2";
+import {
+  ApiError,
+  likeGreentea,
+  likeTemple,
+  unlikeGreentea,
+  unlikeTemple,
+} from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+
+type LikeButtonProps = {
+  kind: "greentea" | "temple";
+  id: number;
+  initialCount: number;
+  initialLiked: boolean;
+  // ログイン誘導先の callbackUrl（現在のページに戻すため）。
+  callbackUrl: string;
+};
+
+export default function LikeButton({
+  kind,
+  id,
+  initialCount,
+  initialLiked,
+  callbackUrl,
+}: LikeButtonProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const [liked, setLiked] = useState(initialLiked);
+  const [count, setCount] = useState(initialCount);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async () => {
+    if (!authToken) {
+      router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+      return;
+    }
+
+    setError(null);
+    const nextLiked = !liked;
+    const prevLiked = liked;
+    const prevCount = count;
+    setLiked(nextLiked);
+    setCount(count + (nextLiked ? 1 : -1));
+
+    startTransition(async () => {
+      try {
+        if (kind === "greentea") {
+          if (nextLiked) await likeGreentea(id, authToken);
+          else await unlikeGreentea(id, authToken);
+        } else {
+          if (nextLiked) await likeTemple(id, authToken);
+          else await unlikeTemple(id, authToken);
+        }
+      } catch (e) {
+        setLiked(prevLiked);
+        setCount(prevCount);
+        if (e instanceof ApiError && e.status === 401) {
+          router.push(
+            `/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`,
+          );
+          return;
+        }
+        setError("通信に失敗しました。もう一度お試しください。");
+      }
+    });
+  };
+
+  return (
+    <div className="inline-flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={pending}
+        aria-pressed={liked}
+        aria-label={liked ? "お気に入りを解除" : "お気に入りに追加"}
+        className={`inline-flex items-center gap-1.5 border px-2.5 py-1 font-sans-jp text-[11px] transition-colors disabled:opacity-60 ${
+          liked
+            ? "border-bengara bg-bengara text-paper hover:bg-bengara-dark"
+            : "border-line bg-paper text-muted hover:border-bengara hover:text-bengara"
+        }`}
+      >
+        {liked ? (
+          <HiHeart className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <HiOutlineHeart className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        <span>{count}</span>
+      </button>
+      {error && (
+        <p role="alert" className="font-sans-jp text-[10px] text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -36,6 +36,9 @@ export default function LikeButton({
   const [error, setError] = useState<string | null>(null);
 
   const toggle = async () => {
+    // useTransition の pending は startTransition 後にしか立たないため、
+    // 楽観的更新と startTransition の間に差し込まれる連打を別途ガードする。
+    if (pending) return;
     if (!authToken) {
       router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
       return;

--- a/src/components/common/LikedSpotsList.tsx
+++ b/src/components/common/LikedSpotsList.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import useSWR from "swr";
+import GreenteaCard from "@/components/greentea/GreenteaCard";
+import TempleCard from "@/components/temple/TempleCard";
+import { ApiError, getGreenteaLikes, getTempleLikes } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+
+type LikedSpotsListProps = {
+  kind: "greentea" | "temple";
+};
+
+export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
+  const authToken = useAuthToken();
+  const callbackUrl =
+    kind === "greentea" ? "/mypage/greentea-likes" : "/mypage/temple-likes";
+
+  const { data, error, isLoading } = useSWR(
+    authToken ? [`/${kind}_likes`, authToken] : null,
+    async () => {
+      if (kind === "greentea") {
+        return getGreenteaLikes(authToken!);
+      }
+      return getTempleLikes(authToken!);
+    },
+  );
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          お気に入り一覧の表示にはログインが必要です。
+        </p>
+        <Link
+          href={`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (error) {
+    const msg =
+      error instanceof ApiError && error.status === 401
+        ? "ログインの有効期限が切れました。再度ログインしてください。"
+        : "お気に入りの取得に失敗しました。時間を置いてお試しください。";
+    return (
+      <p role="alert" className="font-sans-jp text-xs text-bengara">
+        {msg}
+      </p>
+    );
+  }
+
+  if (!data) return null;
+
+  if (kind === "greentea") {
+    const items = "greentea_likes" in data ? data.greentea_likes : [];
+    if (items.length === 0) {
+      return (
+        <p className="border border-line-soft bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+          お気に入りに追加した抹茶店はまだありません。
+        </p>
+      );
+    }
+    return (
+      <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((like) => (
+          <li key={like.id}>
+            <GreenteaCard greentea={like.greentea} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  const items = "temple_likes" in data ? data.temple_likes : [];
+  if (items.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+        お気に入りに追加した神社仏閣はまだありません。
+      </p>
+    );
+  }
+  return (
+    <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((like) => (
+        <li key={like.id}>
+          <TempleCard temple={like.temple} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/common/LikedSpotsList.tsx
+++ b/src/components/common/LikedSpotsList.tsx
@@ -4,26 +4,37 @@ import Link from "next/link";
 import useSWR from "swr";
 import GreenteaCard from "@/components/greentea/GreenteaCard";
 import TempleCard from "@/components/temple/TempleCard";
-import { ApiError, getGreenteaLikes, getTempleLikes } from "@/lib/api";
+import {
+  ApiError,
+  getGreenteaLikes,
+  getTempleLikes,
+} from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
+import type {
+  GreenteaLikeListResponse,
+  TempleLikeListResponse,
+} from "@/types";
 
 type LikedSpotsListProps = {
   kind: "greentea" | "temple";
 };
+
+type LikesResponse = GreenteaLikeListResponse | TempleLikeListResponse;
+type SwrKey = readonly [string, string];
 
 export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
   const authToken = useAuthToken();
   const callbackUrl =
     kind === "greentea" ? "/mypage/greentea-likes" : "/mypage/temple-likes";
 
-  const { data, error, isLoading } = useSWR(
-    authToken ? [`/${kind}_likes`, authToken] : null,
-    async () => {
-      if (kind === "greentea") {
-        return getGreenteaLikes(authToken!);
-      }
-      return getTempleLikes(authToken!);
-    },
+  // フェッチャーは SWR から渡されるキー（authToken を含む）からトークンを取り出す。
+  // クロージャ越しの authToken に依存するとキャッシュ無効化のタイミングがずれる。
+  const fetcher = ([, token]: SwrKey): Promise<LikesResponse> =>
+    kind === "greentea" ? getGreenteaLikes(token) : getTempleLikes(token);
+
+  const { data, error, isLoading } = useSWR<LikesResponse, ApiError, SwrKey | null>(
+    authToken ? ([`/${kind}_likes`, authToken] as const) : null,
+    fetcher,
   );
 
   if (!authToken) {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -6,22 +6,33 @@ const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
 export { ApiError } from "./error";
 
+export type ApiClientOptions = RequestInit & {
+  // Rails 発行の JWT。指定時は `Authorization: Bearer <token>` を付与する。
+  // mock モードでもユーザー識別に使う（"mock:<id>" 形式）。
+  authToken?: string;
+};
+
 export async function apiClient<T>(
   endpoint: string,
-  options?: RequestInit,
+  options?: ApiClientOptions,
 ): Promise<T> {
-  if (USE_MOCK) {
-    return mockClient<T>(endpoint, options);
-  }
+  const { authToken, ...init } = options ?? {};
 
   // Headers インスタンスや [key, value][] で渡されても欠落しないようマージする。
-  const headers = new Headers(options?.headers);
+  const headers = new Headers(init.headers);
   if (!headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
+  if (authToken && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${authToken}`);
+  }
+
+  if (USE_MOCK) {
+    return mockClient<T>(endpoint, { ...init, headers });
+  }
 
   const res = await fetch(`${API_BASE_URL}/api/v1${endpoint}`, {
-    ...options,
+    ...init,
     headers,
     credentials: "include",
   });

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -47,7 +47,17 @@ export async function apiClient<T>(
     throw new ApiError(res.status, data);
   }
 
-  return res.json() as Promise<T>;
+  // DELETE 等の成功時は 204 No Content / Content-Length: 0 が返るのが通常で、
+  // 空ボディに対して res.json() は SyntaxError を投げる。
+  // 楽観的更新のロールバック誤発火を避けるため、ボディが空なら undefined を返す。
+  if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+    return undefined as T;
+  }
+  const text = await res.text();
+  if (text.length === 0) {
+    return undefined as T;
+  }
+  return JSON.parse(text) as T;
 }
 
 // Ransack 形式（q[name_cont] 等）を含むクエリ文字列を組み立てる。

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -17,10 +17,15 @@ export async function apiClient<T>(
   options?: ApiClientOptions,
 ): Promise<T> {
   const { authToken, ...init } = options ?? {};
+  const method = (init.method ?? "GET").toUpperCase();
 
   // Headers インスタンスや [key, value][] で渡されても欠落しないようマージする。
   const headers = new Headers(init.headers);
-  if (!headers.has("Content-Type")) {
+  // GET/DELETE はボディを持たないため Content-Type を付けない。
+  // 付けると一部サーバー/プロキシで CORS preflight が増えたり、Rails が
+  // 406 Not Acceptable を返すケースがある。
+  const hasBody = method !== "GET" && method !== "DELETE";
+  if (hasBody && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
   if (authToken && !headers.has("Authorization")) {

--- a/src/lib/api/comments.ts
+++ b/src/lib/api/comments.ts
@@ -1,0 +1,63 @@
+import type { CommentListResponse, CommentResponse } from "@/types";
+import { apiClient, buildQuery } from "./client";
+
+// 一覧は対象スポットごとに引く。Rails 側は ?greentea_id= / ?temple_id= で絞り込む想定。
+export function getGreenteaComments(
+  greenteaId: number,
+): Promise<CommentListResponse> {
+  return apiClient<CommentListResponse>(
+    `/greenteacomments${buildQuery({ greentea_id: greenteaId })}`,
+  );
+}
+
+export function getTempleComments(
+  templeId: number,
+): Promise<CommentListResponse> {
+  return apiClient<CommentListResponse>(
+    `/templecomments${buildQuery({ temple_id: templeId })}`,
+  );
+}
+
+export function createGreenteaComment(
+  greenteaId: number,
+  body: string,
+  authToken: string,
+): Promise<CommentResponse> {
+  return apiClient<CommentResponse>("/greenteacomments", {
+    method: "POST",
+    body: JSON.stringify({ greentea_id: greenteaId, body }),
+    authToken,
+  });
+}
+
+export function createTempleComment(
+  templeId: number,
+  body: string,
+  authToken: string,
+): Promise<CommentResponse> {
+  return apiClient<CommentResponse>("/templecomments", {
+    method: "POST",
+    body: JSON.stringify({ temple_id: templeId, body }),
+    authToken,
+  });
+}
+
+export function deleteGreenteaComment(
+  commentId: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/greenteacomments/${commentId}`, {
+    method: "DELETE",
+    authToken,
+  });
+}
+
+export function deleteTempleComment(
+  commentId: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/templecomments/${commentId}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/api/greenteas.ts
+++ b/src/lib/api/greenteas.ts
@@ -9,14 +9,20 @@ export type GreenteaSearchParams = {
   };
 };
 
+// authToken を渡すと liked_by_current_user / コメントの owned_by_current_user が反映される。
+// 未指定（未ログイン or 公開ページ）でも公開情報は取得できる。
 export function getGreenteas(
   params?: GreenteaSearchParams,
+  authToken?: string,
 ): Promise<GreenteaListResponse> {
-  return apiClient<GreenteaListResponse>(`/greenteas${buildQuery(params)}`);
+  return apiClient<GreenteaListResponse>(`/greenteas${buildQuery(params)}`, {
+    authToken,
+  });
 }
 
 export function getGreentea(
   id: number | string,
+  authToken?: string,
 ): Promise<GreenteaDetailResponse> {
-  return apiClient<GreenteaDetailResponse>(`/greenteas/${id}`);
+  return apiClient<GreenteaDetailResponse>(`/greenteas/${id}`, { authToken });
 }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export { apiClient, buildQuery, ApiError } from "./client";
+export type { ApiClientOptions } from "./client";
 export { getGreenteas, getGreentea } from "./greenteas";
 export type { GreenteaSearchParams } from "./greenteas";
 export { getTemples, getTemple } from "./temples";
@@ -7,3 +8,19 @@ export { getAreas } from "./areas";
 export { getGenres } from "./genres";
 export { getNearby } from "./nearby";
 export type { NearbySearchParams } from "./nearby";
+export {
+  getGreenteaLikes,
+  getTempleLikes,
+  likeGreentea,
+  unlikeGreentea,
+  likeTemple,
+  unlikeTemple,
+} from "./likes";
+export {
+  getGreenteaComments,
+  getTempleComments,
+  createGreenteaComment,
+  createTempleComment,
+  deleteGreenteaComment,
+  deleteTempleComment,
+} from "./comments";

--- a/src/lib/api/likes.ts
+++ b/src/lib/api/likes.ts
@@ -1,0 +1,61 @@
+import type {
+  GreenteaLikeListResponse,
+  GreenteaLikeResponse,
+  TempleLikeListResponse,
+  TempleLikeResponse,
+} from "@/types";
+import { apiClient } from "./client";
+
+export function getGreenteaLikes(
+  authToken: string,
+): Promise<GreenteaLikeListResponse> {
+  return apiClient<GreenteaLikeListResponse>("/greentea_likes", { authToken });
+}
+
+export function getTempleLikes(
+  authToken: string,
+): Promise<TempleLikeListResponse> {
+  return apiClient<TempleLikeListResponse>("/temple_likes", { authToken });
+}
+
+export function likeGreentea(
+  greenteaId: number,
+  authToken: string,
+): Promise<GreenteaLikeResponse> {
+  return apiClient<GreenteaLikeResponse>("/greentea_likes", {
+    method: "POST",
+    body: JSON.stringify({ greentea_id: greenteaId }),
+    authToken,
+  });
+}
+
+export function unlikeGreentea(
+  greenteaId: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/greentea_likes/${greenteaId}`, {
+    method: "DELETE",
+    authToken,
+  });
+}
+
+export function likeTemple(
+  templeId: number,
+  authToken: string,
+): Promise<TempleLikeResponse> {
+  return apiClient<TempleLikeResponse>("/temple_likes", {
+    method: "POST",
+    body: JSON.stringify({ temple_id: templeId }),
+    authToken,
+  });
+}
+
+export function unlikeTemple(
+  templeId: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/temple_likes/${templeId}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/api/mock/data.ts
+++ b/src/lib/api/mock/data.ts
@@ -1,8 +1,13 @@
 import type { Greentea, Temple, Genre, Area, Comment } from "@/types";
 
+// 受け取る userId は二重プレフィックス構造になっている点に注意:
+//   1. auth.ts authorize:   user.id = "mock-<name>"
+//   2. auth.ts jwt callback: token.railsJwt = "mock:" + user.id  →  "mock:mock-<name>"
+//   3. extractMockUserId:    "mock:" を剥がして "mock-<name>" を userId として返す
+// したがってここに渡る userId は通常 "mock-<name>" であり、先頭の "mock-" を
+// 剥がすと表示名 <name> が得られる。形式が違うトークンが渡るケースの保険として
+// プレフィックスが無いときはそのまま返す。
 export function mockUserName(userId: string): string {
-  // Authorization の "mock:<name>" 形式から表示名を取り出す。
-  // signIn 時にここへ任意の表示名を入れる前提（src/lib/auth.ts 参照）。
   return userId.startsWith("mock-") ? userId.slice("mock-".length) : userId;
 }
 

--- a/src/lib/api/mock/data.ts
+++ b/src/lib/api/mock/data.ts
@@ -1,5 +1,11 @@
 import type { Greentea, Temple, Genre, Area, Comment } from "@/types";
 
+export function mockUserName(userId: string): string {
+  // Authorization の "mock:<name>" 形式から表示名を取り出す。
+  // signIn 時にここへ任意の表示名を入れる前提（src/lib/auth.ts 参照）。
+  return userId.startsWith("mock-") ? userId.slice("mock-".length) : userId;
+}
+
 export const mockGenres: Genre[] = [
   { id: 1, name: "パフェ" },
   { id: 2, name: "ドリンク" },
@@ -12,14 +18,15 @@ export const mockAreas: Area[] = [
   { id: 3, name: "右京区" },
 ];
 
-const mockComments: Comment[] = [
-  {
-    id: 1,
-    body: "抹茶パフェが最高でした！",
-    user: { id: 1, name: "抹茶好き" },
-    created_at: "2024-01-15T10:30:00Z",
-  },
-];
+// 既存スポットに紐づくサンプルコメント（モック初期表示用）。
+// ユーザー ID は数値で持っているが、モックユーザーは文字列 ID なので
+// 削除権限の判定には引っかからない（= seed コメントは消せない）。
+const seedComment: Comment = {
+  id: 1,
+  body: "抹茶パフェが最高でした！",
+  user: { id: 1, name: "抹茶好き" },
+  created_at: "2024-01-15T10:30:00Z",
+};
 
 export const mockGreenteas: Greentea[] = [
   {
@@ -126,5 +133,9 @@ export const mockTemples: Temple[] = [
   },
 ];
 
-export const mockGreenteaComments = mockComments;
-export const mockTempleComments = mockComments;
+export const seedGreenteaComments: Record<number, Comment[]> = {
+  1: [seedComment],
+};
+export const seedTempleComments: Record<number, Comment[]> = {
+  1: [{ ...seedComment, id: 2, body: "建仁寺の風神雷神図、圧巻でした。" }],
+};

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -1,22 +1,51 @@
 import type {
   AreaListResponse,
+  Comment,
+  CommentListResponse,
+  CommentResponse,
   GenreListResponse,
+  Greentea,
   GreenteaDetailResponse,
+  GreenteaLike,
+  GreenteaLikeListResponse,
+  GreenteaLikeResponse,
   GreenteaListResponse,
   NearbyResponse,
   NearbySpot,
+  Temple,
   TempleDetailResponse,
+  TempleLike,
+  TempleLikeListResponse,
+  TempleLikeResponse,
   TempleListResponse,
 } from "@/types";
 import { ApiError } from "../error";
 import {
   mockAreas,
   mockGenres,
-  mockGreenteaComments,
   mockGreenteas,
-  mockTempleComments,
   mockTemples,
+  mockUserName,
+  seedGreenteaComments,
+  seedTempleComments,
 } from "./data";
+import {
+  addGreenteaComment,
+  addGreenteaLike,
+  addTempleComment,
+  addTempleLike,
+  deleteGreenteaComment,
+  deleteTempleComment,
+  extractMockUserId,
+  getGreenteaLikeDelta,
+  getGreenteaLikedIds,
+  getTempleLikeDelta,
+  getTempleLikedIds,
+  listGreenteaComments,
+  listTempleComments,
+  removeGreenteaLike,
+  removeTempleLike,
+} from "./state";
 
 const PER_PAGE = 12;
 
@@ -53,6 +82,60 @@ function notFound(endpoint: string): never {
   throw new ApiError(404, { error: `Mock route not found: ${endpoint}` });
 }
 
+function unauthorized(): never {
+  throw new ApiError(401, { error: "Authentication required" });
+}
+
+function withLikeState(
+  greentea: Greentea,
+  userId: string | null,
+): Greentea {
+  const likedIds = userId ? getGreenteaLikedIds(userId) : null;
+  return {
+    ...greentea,
+    likes_count: greentea.likes_count + getGreenteaLikeDelta(greentea.id),
+    liked_by_current_user: likedIds?.has(greentea.id) ?? false,
+  };
+}
+
+function withTempleLikeState(
+  temple: Temple,
+  userId: string | null,
+): Temple {
+  const likedIds = userId ? getTempleLikedIds(userId) : null;
+  return {
+    ...temple,
+    likes_count: temple.likes_count + getTempleLikeDelta(temple.id),
+    liked_by_current_user: likedIds?.has(temple.id) ?? false,
+  };
+}
+
+function mergedGreenteaComments(
+  greenteaId: number,
+  viewerId: string | null,
+): Comment[] {
+  return [
+    ...listGreenteaComments(greenteaId, viewerId),
+    ...(seedGreenteaComments[greenteaId] ?? []),
+  ];
+}
+
+function mergedTempleComments(
+  templeId: number,
+  viewerId: string | null,
+): Comment[] {
+  return [
+    ...listTempleComments(templeId, viewerId),
+    ...(seedTempleComments[templeId] ?? []),
+  ];
+}
+
+function requireMockUser(headers: Headers): string {
+  const userId = extractMockUserId(headers);
+  if (!userId) unauthorized();
+  return userId;
+}
+
 export async function mockClient<T>(
   endpoint: string,
   options?: RequestInit,
@@ -61,6 +144,8 @@ export async function mockClient<T>(
   const url = new URL(endpoint, "http://mock.local");
   const path = url.pathname;
   const params = url.searchParams;
+  const headers = new Headers(options?.headers);
+  const userId = extractMockUserId(headers);
 
   if (method === "GET") {
     if (path === "/greenteas") {
@@ -78,16 +163,18 @@ export async function mockClient<T>(
         );
       }
 
-      const { items: greenteas, meta } = paginate(items, page);
+      const { items: paged, meta } = paginate(items, page);
+      const greenteas = paged.map((g) => withLikeState(g, userId));
       return { greenteas, meta } satisfies GreenteaListResponse as T;
     }
 
     const greenteaMatch = path.match(/^\/greenteas\/(\d+)$/);
     if (greenteaMatch) {
-      const greentea = mockGreenteas.find(
+      const base = mockGreenteas.find(
         (g) => g.id === Number(greenteaMatch[1]),
       );
-      if (!greentea) notFound(endpoint);
+      if (!base) notFound(endpoint);
+      const greentea = withLikeState(base, userId);
 
       const nearby_temples: NearbySpot[] = mockTemples
         .map((t) => ({
@@ -103,9 +190,8 @@ export async function mockClient<T>(
       return {
         greentea: {
           ...greentea,
-          liked_by_current_user: false,
           nearby_temples,
-          comments: mockGreenteaComments,
+          comments: mergedGreenteaComments(greentea.id, userId),
         },
       } satisfies GreenteaDetailResponse as T;
     }
@@ -125,14 +211,16 @@ export async function mockClient<T>(
         );
       }
 
-      const { items: temples, meta } = paginate(items, page);
+      const { items: paged, meta } = paginate(items, page);
+      const temples = paged.map((t) => withTempleLikeState(t, userId));
       return { temples, meta } satisfies TempleListResponse as T;
     }
 
     const templeMatch = path.match(/^\/temples\/(\d+)$/);
     if (templeMatch) {
-      const temple = mockTemples.find((t) => t.id === Number(templeMatch[1]));
-      if (!temple) notFound(endpoint);
+      const base = mockTemples.find((t) => t.id === Number(templeMatch[1]));
+      if (!base) notFound(endpoint);
+      const temple = withTempleLikeState(base, userId);
 
       const nearby_greenteas: NearbySpot[] = mockGreenteas
         .map((g) => ({
@@ -148,9 +236,8 @@ export async function mockClient<T>(
       return {
         temple: {
           ...temple,
-          liked_by_current_user: false,
           nearby_greenteas,
-          comments: mockTempleComments,
+          comments: mergedTempleComments(temple.id, userId),
         },
       } satisfies TempleDetailResponse as T;
     }
@@ -202,7 +289,198 @@ export async function mockClient<T>(
         temples: mockTemples.map(toSpot).filter(within).sort(byDistance),
       } satisfies NearbyResponse as T;
     }
+
+    if (path === "/greentea_likes") {
+      const uid = requireMockUser(headers);
+      const liked = getGreenteaLikedIds(uid);
+      const greentea_likes: GreenteaLike[] = mockGreenteas
+        .filter((g) => liked.has(g.id))
+        .map((g) => ({
+          id: g.id,
+          greentea: withLikeState(g, uid),
+          created_at: new Date().toISOString(),
+        }));
+      return { greentea_likes } satisfies GreenteaLikeListResponse as T;
+    }
+
+    if (path === "/temple_likes") {
+      const uid = requireMockUser(headers);
+      const liked = getTempleLikedIds(uid);
+      const temple_likes: TempleLike[] = mockTemples
+        .filter((t) => liked.has(t.id))
+        .map((t) => ({
+          id: t.id,
+          temple: withTempleLikeState(t, uid),
+          created_at: new Date().toISOString(),
+        }));
+      return { temple_likes } satisfies TempleLikeListResponse as T;
+    }
+
+    if (path === "/greenteacomments") {
+      const greenteaId = Number(params.get("greentea_id"));
+      if (!Number.isFinite(greenteaId) || greenteaId <= 0) {
+        throw new ApiError(400, { error: "greentea_id is required" });
+      }
+      return {
+        comments: mergedGreenteaComments(greenteaId, userId),
+      } satisfies CommentListResponse as T;
+    }
+
+    if (path === "/templecomments") {
+      const templeId = Number(params.get("temple_id"));
+      if (!Number.isFinite(templeId) || templeId <= 0) {
+        throw new ApiError(400, { error: "temple_id is required" });
+      }
+      return {
+        comments: mergedTempleComments(templeId, userId),
+      } satisfies CommentListResponse as T;
+    }
+  }
+
+  if (method === "POST") {
+    if (path === "/greentea_likes") {
+      const uid = requireMockUser(headers);
+      const { greentea_id } = parseJsonBody<{ greentea_id?: number }>(
+        options?.body,
+      );
+      if (!greentea_id) {
+        throw new ApiError(400, { error: "greentea_id is required" });
+      }
+      const greentea = mockGreenteas.find((g) => g.id === greentea_id);
+      if (!greentea) notFound(endpoint);
+      addGreenteaLike(uid, greentea.id);
+      return {
+        greentea_like: {
+          id: greentea.id,
+          greentea: withLikeState(greentea, uid),
+          created_at: new Date().toISOString(),
+        },
+      } satisfies GreenteaLikeResponse as T;
+    }
+
+    if (path === "/temple_likes") {
+      const uid = requireMockUser(headers);
+      const { temple_id } = parseJsonBody<{ temple_id?: number }>(
+        options?.body,
+      );
+      if (!temple_id) {
+        throw new ApiError(400, { error: "temple_id is required" });
+      }
+      const temple = mockTemples.find((t) => t.id === temple_id);
+      if (!temple) notFound(endpoint);
+      addTempleLike(uid, temple.id);
+      return {
+        temple_like: {
+          id: temple.id,
+          temple: withTempleLikeState(temple, uid),
+          created_at: new Date().toISOString(),
+        },
+      } satisfies TempleLikeResponse as T;
+    }
+
+    if (path === "/greenteacomments") {
+      const uid = requireMockUser(headers);
+      const { greentea_id, body } = parseJsonBody<{
+        greentea_id?: number;
+        body?: string;
+      }>(options?.body);
+      if (!greentea_id || !body || body.trim().length === 0) {
+        throw new ApiError(400, {
+          error: "greentea_id and non-empty body are required",
+        });
+      }
+      const comment = addGreenteaComment(greentea_id, uid, {
+        body: body.trim(),
+        user: { id: hashUserId(uid), name: mockUserName(uid) },
+      });
+      return { comment } satisfies CommentResponse as T;
+    }
+
+    if (path === "/templecomments") {
+      const uid = requireMockUser(headers);
+      const { temple_id, body } = parseJsonBody<{
+        temple_id?: number;
+        body?: string;
+      }>(options?.body);
+      if (!temple_id || !body || body.trim().length === 0) {
+        throw new ApiError(400, {
+          error: "temple_id and non-empty body are required",
+        });
+      }
+      const comment = addTempleComment(temple_id, uid, {
+        body: body.trim(),
+        user: { id: hashUserId(uid), name: mockUserName(uid) },
+      });
+      return { comment } satisfies CommentResponse as T;
+    }
+  }
+
+  if (method === "DELETE") {
+    // Rails API 契約上は :id だが、UI が like 行 ID を保持しないため、
+    // mock 実装は :id を greentea_id / temple_id として扱う。
+    // 連携時は Rails 側で `find_by(user:, greentea_id: params[:id])` 相当を実装する想定。
+    const greenteaLikeMatch = path.match(/^\/greentea_likes\/(\d+)$/);
+    if (greenteaLikeMatch) {
+      const uid = requireMockUser(headers);
+      const id = Number(greenteaLikeMatch[1]);
+      if (!removeGreenteaLike(uid, id)) {
+        throw new ApiError(404, { error: "like not found" });
+      }
+      return undefined as T;
+    }
+
+    const templeLikeMatch = path.match(/^\/temple_likes\/(\d+)$/);
+    if (templeLikeMatch) {
+      const uid = requireMockUser(headers);
+      const id = Number(templeLikeMatch[1]);
+      if (!removeTempleLike(uid, id)) {
+        throw new ApiError(404, { error: "like not found" });
+      }
+      return undefined as T;
+    }
+
+    const greenteaCommentMatch = path.match(/^\/greenteacomments\/(\d+)$/);
+    if (greenteaCommentMatch) {
+      const uid = requireMockUser(headers);
+      const id = Number(greenteaCommentMatch[1]);
+      if (!deleteGreenteaComment(id, uid)) {
+        throw new ApiError(404, { error: "comment not found" });
+      }
+      return undefined as T;
+    }
+
+    const templeCommentMatch = path.match(/^\/templecomments\/(\d+)$/);
+    if (templeCommentMatch) {
+      const uid = requireMockUser(headers);
+      const id = Number(templeCommentMatch[1]);
+      if (!deleteTempleComment(id, uid)) {
+        throw new ApiError(404, { error: "comment not found" });
+      }
+      return undefined as T;
+    }
   }
 
   notFound(endpoint);
+}
+
+function parseJsonBody<T>(body: BodyInit | null | undefined): T {
+  if (typeof body !== "string" || body.length === 0) {
+    throw new ApiError(400, { error: "request body is required" });
+  }
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new ApiError(400, { error: "invalid JSON body" });
+  }
+}
+
+// 表示用にユーザー ID（mock-<name>）を数値化する。コメント user.id は Rails 上で
+// 数値だが、モックでは便宜上の安定したハッシュ。
+function hashUserId(userId: string): number {
+  let h = 0;
+  for (let i = 0; i < userId.length; i++) {
+    h = (Math.imul(31, h) + userId.charCodeAt(i)) | 0;
+  }
+  // 削除権限は state 側で文字列 ID と比較するため、ここの数値は表示用のみ。
+  return Math.abs(h);
 }

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -443,7 +443,11 @@ export async function mockClient<T>(
     if (greenteaCommentMatch) {
       const uid = requireMockUser(headers);
       const id = Number(greenteaCommentMatch[1]);
-      if (!deleteGreenteaComment(id, uid)) {
+      const result = deleteGreenteaComment(id, uid);
+      if (result === "forbidden") {
+        throw new ApiError(403, { error: "not allowed to delete this comment" });
+      }
+      if (result === "not_found") {
         throw new ApiError(404, { error: "comment not found" });
       }
       return undefined as T;
@@ -453,7 +457,11 @@ export async function mockClient<T>(
     if (templeCommentMatch) {
       const uid = requireMockUser(headers);
       const id = Number(templeCommentMatch[1]);
-      if (!deleteTempleComment(id, uid)) {
+      const result = deleteTempleComment(id, uid);
+      if (result === "forbidden") {
+        throw new ApiError(403, { error: "not allowed to delete this comment" });
+      }
+      if (result === "not_found") {
         throw new ApiError(404, { error: "comment not found" });
       }
       return undefined as T;

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -3,22 +3,45 @@
 //
 // ユーザーは Authorization: Bearer "mock:<id>" から識別する。
 // Rails JWT (#15) 連携後はこのファイル自体が不要になる想定。
+//
+// Next.js dev サーバーは HMR で module-level の変数がリセットされてしまい、
+// 開発中にいいね・コメントが突然消えて混乱するため、globalThis にぶら下げる。
 
 import type { Comment } from "@/types";
 
 type UserId = string;
 type CommentRecord = { comment: Comment; ownerId: UserId };
 
-const greenteaLikes = new Map<UserId, Set<number>>();
-const templeLikes = new Map<UserId, Set<number>>();
+export type DeleteResult = "deleted" | "not_found" | "forbidden";
 
-const greenteaComments = new Map<number, CommentRecord[]>();
-const templeComments = new Map<number, CommentRecord[]>();
+type MockStore = {
+  greenteaLikes: Map<UserId, Set<number>>;
+  templeLikes: Map<UserId, Set<number>>;
+  greenteaComments: Map<number, CommentRecord[]>;
+  templeComments: Map<number, CommentRecord[]>;
+  greenteaLikeCountDelta: Map<number, number>;
+  templeLikeCountDelta: Map<number, number>;
+  nextCommentId: { value: number };
+};
 
-const greenteaLikeCountDelta = new Map<number, number>();
-const templeLikeCountDelta = new Map<number, number>();
+const globalKey = Symbol.for("matcha-to-jinja.mock-store");
+type GlobalWithStore = typeof globalThis & { [globalKey]?: MockStore };
 
-let nextCommentId = 1000;
+const store: MockStore = ((): MockStore => {
+  const g = globalThis as GlobalWithStore;
+  if (!g[globalKey]) {
+    g[globalKey] = {
+      greenteaLikes: new Map(),
+      templeLikes: new Map(),
+      greenteaComments: new Map(),
+      templeComments: new Map(),
+      greenteaLikeCountDelta: new Map(),
+      templeLikeCountDelta: new Map(),
+      nextCommentId: { value: 1000 },
+    };
+  }
+  return g[globalKey]!;
+})();
 
 function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
   let set = map.get(key);
@@ -42,20 +65,20 @@ function ensureList<K>(
 }
 
 export function getGreenteaLikedIds(userId: UserId): Set<number> {
-  return greenteaLikes.get(userId) ?? new Set();
+  return store.greenteaLikes.get(userId) ?? new Set();
 }
 
 export function getTempleLikedIds(userId: UserId): Set<number> {
-  return templeLikes.get(userId) ?? new Set();
+  return store.templeLikes.get(userId) ?? new Set();
 }
 
 export function addGreenteaLike(userId: UserId, greenteaId: number): boolean {
-  const set = ensureSet(greenteaLikes, userId);
+  const set = ensureSet(store.greenteaLikes, userId);
   if (set.has(greenteaId)) return false;
   set.add(greenteaId);
-  greenteaLikeCountDelta.set(
+  store.greenteaLikeCountDelta.set(
     greenteaId,
-    (greenteaLikeCountDelta.get(greenteaId) ?? 0) + 1,
+    (store.greenteaLikeCountDelta.get(greenteaId) ?? 0) + 1,
   );
   return true;
 }
@@ -64,49 +87,49 @@ export function removeGreenteaLike(
   userId: UserId,
   greenteaId: number,
 ): boolean {
-  const set = greenteaLikes.get(userId);
+  const set = store.greenteaLikes.get(userId);
   if (!set?.delete(greenteaId)) return false;
-  greenteaLikeCountDelta.set(
+  store.greenteaLikeCountDelta.set(
     greenteaId,
-    (greenteaLikeCountDelta.get(greenteaId) ?? 0) - 1,
+    (store.greenteaLikeCountDelta.get(greenteaId) ?? 0) - 1,
   );
   return true;
 }
 
 export function addTempleLike(userId: UserId, templeId: number): boolean {
-  const set = ensureSet(templeLikes, userId);
+  const set = ensureSet(store.templeLikes, userId);
   if (set.has(templeId)) return false;
   set.add(templeId);
-  templeLikeCountDelta.set(
+  store.templeLikeCountDelta.set(
     templeId,
-    (templeLikeCountDelta.get(templeId) ?? 0) + 1,
+    (store.templeLikeCountDelta.get(templeId) ?? 0) + 1,
   );
   return true;
 }
 
 export function removeTempleLike(userId: UserId, templeId: number): boolean {
-  const set = templeLikes.get(userId);
+  const set = store.templeLikes.get(userId);
   if (!set?.delete(templeId)) return false;
-  templeLikeCountDelta.set(
+  store.templeLikeCountDelta.set(
     templeId,
-    (templeLikeCountDelta.get(templeId) ?? 0) - 1,
+    (store.templeLikeCountDelta.get(templeId) ?? 0) - 1,
   );
   return true;
 }
 
 export function getGreenteaLikeDelta(greenteaId: number): number {
-  return greenteaLikeCountDelta.get(greenteaId) ?? 0;
+  return store.greenteaLikeCountDelta.get(greenteaId) ?? 0;
 }
 
 export function getTempleLikeDelta(templeId: number): number {
-  return templeLikeCountDelta.get(templeId) ?? 0;
+  return store.templeLikeCountDelta.get(templeId) ?? 0;
 }
 
 export function listGreenteaComments(
   greenteaId: number,
   viewerId: UserId | null,
 ): Comment[] {
-  return (greenteaComments.get(greenteaId) ?? []).map((r) => ({
+  return (store.greenteaComments.get(greenteaId) ?? []).map((r) => ({
     ...r.comment,
     owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
   }));
@@ -116,7 +139,7 @@ export function listTempleComments(
   templeId: number,
   viewerId: UserId | null,
 ): Comment[] {
-  return (templeComments.get(templeId) ?? []).map((r) => ({
+  return (store.templeComments.get(templeId) ?? []).map((r) => ({
     ...r.comment,
     owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
   }));
@@ -129,10 +152,10 @@ export function addGreenteaComment(
 ): Comment {
   const created: Comment = {
     ...comment,
-    id: nextCommentId++,
+    id: store.nextCommentId.value++,
     created_at: new Date().toISOString(),
   };
-  ensureList(greenteaComments, greenteaId).unshift({
+  ensureList(store.greenteaComments, greenteaId).unshift({
     comment: created,
     ownerId,
   });
@@ -146,43 +169,44 @@ export function addTempleComment(
 ): Comment {
   const created: Comment = {
     ...comment,
-    id: nextCommentId++,
+    id: store.nextCommentId.value++,
     created_at: new Date().toISOString(),
   };
-  ensureList(templeComments, templeId).unshift({ comment: created, ownerId });
+  ensureList(store.templeComments, templeId).unshift({
+    comment: created,
+    ownerId,
+  });
   return created;
 }
 
 export function deleteGreenteaComment(
   commentId: number,
   userId: UserId,
-): boolean {
-  for (const list of greenteaComments.values()) {
-    const idx = list.findIndex(
-      (r) => r.comment.id === commentId && r.ownerId === userId,
-    );
+): DeleteResult {
+  for (const list of store.greenteaComments.values()) {
+    const idx = list.findIndex((r) => r.comment.id === commentId);
     if (idx >= 0) {
+      if (list[idx].ownerId !== userId) return "forbidden";
       list.splice(idx, 1);
-      return true;
+      return "deleted";
     }
   }
-  return false;
+  return "not_found";
 }
 
 export function deleteTempleComment(
   commentId: number,
   userId: UserId,
-): boolean {
-  for (const list of templeComments.values()) {
-    const idx = list.findIndex(
-      (r) => r.comment.id === commentId && r.ownerId === userId,
-    );
+): DeleteResult {
+  for (const list of store.templeComments.values()) {
+    const idx = list.findIndex((r) => r.comment.id === commentId);
     if (idx >= 0) {
+      if (list[idx].ownerId !== userId) return "forbidden";
       list.splice(idx, 1);
-      return true;
+      return "deleted";
     }
   }
-  return false;
+  return "not_found";
 }
 
 // Authorization: Bearer "mock:<id>" からユーザー ID を取り出す。

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -1,0 +1,197 @@
+// モックモード（NEXT_PUBLIC_USE_MOCK=true）でのみ使うインメモリ状態。
+// 本番では使わないため永続化は意図しない。プロセスが落ちると消える。
+//
+// ユーザーは Authorization: Bearer "mock:<id>" から識別する。
+// Rails JWT (#15) 連携後はこのファイル自体が不要になる想定。
+
+import type { Comment } from "@/types";
+
+type UserId = string;
+type CommentRecord = { comment: Comment; ownerId: UserId };
+
+const greenteaLikes = new Map<UserId, Set<number>>();
+const templeLikes = new Map<UserId, Set<number>>();
+
+const greenteaComments = new Map<number, CommentRecord[]>();
+const templeComments = new Map<number, CommentRecord[]>();
+
+const greenteaLikeCountDelta = new Map<number, number>();
+const templeLikeCountDelta = new Map<number, number>();
+
+let nextCommentId = 1000;
+
+function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  return set;
+}
+
+function ensureList<K>(
+  map: Map<K, CommentRecord[]>,
+  key: K,
+): CommentRecord[] {
+  let list = map.get(key);
+  if (!list) {
+    list = [];
+    map.set(key, list);
+  }
+  return list;
+}
+
+export function getGreenteaLikedIds(userId: UserId): Set<number> {
+  return greenteaLikes.get(userId) ?? new Set();
+}
+
+export function getTempleLikedIds(userId: UserId): Set<number> {
+  return templeLikes.get(userId) ?? new Set();
+}
+
+export function addGreenteaLike(userId: UserId, greenteaId: number): boolean {
+  const set = ensureSet(greenteaLikes, userId);
+  if (set.has(greenteaId)) return false;
+  set.add(greenteaId);
+  greenteaLikeCountDelta.set(
+    greenteaId,
+    (greenteaLikeCountDelta.get(greenteaId) ?? 0) + 1,
+  );
+  return true;
+}
+
+export function removeGreenteaLike(
+  userId: UserId,
+  greenteaId: number,
+): boolean {
+  const set = greenteaLikes.get(userId);
+  if (!set?.delete(greenteaId)) return false;
+  greenteaLikeCountDelta.set(
+    greenteaId,
+    (greenteaLikeCountDelta.get(greenteaId) ?? 0) - 1,
+  );
+  return true;
+}
+
+export function addTempleLike(userId: UserId, templeId: number): boolean {
+  const set = ensureSet(templeLikes, userId);
+  if (set.has(templeId)) return false;
+  set.add(templeId);
+  templeLikeCountDelta.set(
+    templeId,
+    (templeLikeCountDelta.get(templeId) ?? 0) + 1,
+  );
+  return true;
+}
+
+export function removeTempleLike(userId: UserId, templeId: number): boolean {
+  const set = templeLikes.get(userId);
+  if (!set?.delete(templeId)) return false;
+  templeLikeCountDelta.set(
+    templeId,
+    (templeLikeCountDelta.get(templeId) ?? 0) - 1,
+  );
+  return true;
+}
+
+export function getGreenteaLikeDelta(greenteaId: number): number {
+  return greenteaLikeCountDelta.get(greenteaId) ?? 0;
+}
+
+export function getTempleLikeDelta(templeId: number): number {
+  return templeLikeCountDelta.get(templeId) ?? 0;
+}
+
+export function listGreenteaComments(
+  greenteaId: number,
+  viewerId: UserId | null,
+): Comment[] {
+  return (greenteaComments.get(greenteaId) ?? []).map((r) => ({
+    ...r.comment,
+    owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
+  }));
+}
+
+export function listTempleComments(
+  templeId: number,
+  viewerId: UserId | null,
+): Comment[] {
+  return (templeComments.get(templeId) ?? []).map((r) => ({
+    ...r.comment,
+    owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
+  }));
+}
+
+export function addGreenteaComment(
+  greenteaId: number,
+  ownerId: UserId,
+  comment: Omit<Comment, "id" | "created_at">,
+): Comment {
+  const created: Comment = {
+    ...comment,
+    id: nextCommentId++,
+    created_at: new Date().toISOString(),
+  };
+  ensureList(greenteaComments, greenteaId).unshift({
+    comment: created,
+    ownerId,
+  });
+  return created;
+}
+
+export function addTempleComment(
+  templeId: number,
+  ownerId: UserId,
+  comment: Omit<Comment, "id" | "created_at">,
+): Comment {
+  const created: Comment = {
+    ...comment,
+    id: nextCommentId++,
+    created_at: new Date().toISOString(),
+  };
+  ensureList(templeComments, templeId).unshift({ comment: created, ownerId });
+  return created;
+}
+
+export function deleteGreenteaComment(
+  commentId: number,
+  userId: UserId,
+): boolean {
+  for (const list of greenteaComments.values()) {
+    const idx = list.findIndex(
+      (r) => r.comment.id === commentId && r.ownerId === userId,
+    );
+    if (idx >= 0) {
+      list.splice(idx, 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+export function deleteTempleComment(
+  commentId: number,
+  userId: UserId,
+): boolean {
+  for (const list of templeComments.values()) {
+    const idx = list.findIndex(
+      (r) => r.comment.id === commentId && r.ownerId === userId,
+    );
+    if (idx >= 0) {
+      list.splice(idx, 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Authorization: Bearer "mock:<id>" からユーザー ID を取り出す。
+// 形式が異なるトークン（実 JWT 等）が来た場合は null。
+export function extractMockUserId(headers: Headers): string | null {
+  const auth = headers.get("Authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  const token = auth.slice("Bearer ".length);
+  if (!token.startsWith("mock:")) return null;
+  const id = token.slice("mock:".length);
+  return id.length > 0 ? id : null;
+}

--- a/src/lib/api/temples.ts
+++ b/src/lib/api/temples.ts
@@ -11,10 +11,16 @@ export type TempleSearchParams = {
 
 export function getTemples(
   params?: TempleSearchParams,
+  authToken?: string,
 ): Promise<TempleListResponse> {
-  return apiClient<TempleListResponse>(`/temples${buildQuery(params)}`);
+  return apiClient<TempleListResponse>(`/temples${buildQuery(params)}`, {
+    authToken,
+  });
 }
 
-export function getTemple(id: number | string): Promise<TempleDetailResponse> {
-  return apiClient<TempleDetailResponse>(`/temples/${id}`);
+export function getTemple(
+  id: number | string,
+  authToken?: string,
+): Promise<TempleDetailResponse> {
+  return apiClient<TempleDetailResponse>(`/temples/${id}`, { authToken });
 }

--- a/src/lib/api/useAuthToken.ts
+++ b/src/lib/api/useAuthToken.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+
+// クライアントコンポーネント用に、現在のセッションから Rails JWT（または mock 用トークン）を返す。
+// 未ログイン時は undefined。likes / comments のように認証が必要な API 呼び出しの引数に使う。
+export function useAuthToken(): string | undefined {
+  const { data: session } = useSession();
+  return session?.railsJwt;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -62,11 +62,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     strategy: "jwt",
   },
   callbacks: {
-    async jwt({ token, account }) {
+    async jwt({ token, account, user }) {
       if (account?.provider) {
         token.provider = account.provider;
         // TODO(#15 連携): account.access_token を Rails の
         // POST /api/v1/auth/:provider に渡し、Rails 発行の JWT を token.railsJwt に保存する。
+        // モック provider は Rails が無いので、ここで擬似 JWT を発行して
+        // apiClient のヘッダ付与経路を本番と統一する（mock/index.ts が Bearer "mock:<id>" を識別）。
+        if (account.provider === "mock" && user?.id) {
+          token.railsJwt = `mock:${user.id}`;
+        }
       }
       return token;
     },

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -5,4 +5,13 @@ export interface Comment {
   body: string;
   user: User;
   created_at: string;
+  owned_by_current_user?: boolean;
+}
+
+export interface CommentListResponse {
+  comments: Comment[];
+}
+
+export interface CommentResponse {
+  comment: Comment;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,17 @@
 export type { Genre } from "./genre";
 export type { Area } from "./area";
 export type { User } from "./user";
-export type { Comment } from "./comment";
+export type { Comment, CommentListResponse, CommentResponse } from "./comment";
 export type { Greentea } from "./greentea";
 export type { Temple } from "./temple";
+export type {
+  GreenteaLike,
+  TempleLike,
+  GreenteaLikeListResponse,
+  TempleLikeListResponse,
+  GreenteaLikeResponse,
+  TempleLikeResponse,
+} from "./like";
 export type {
   Meta,
   NearbySpot,

--- a/src/types/like.ts
+++ b/src/types/like.ts
@@ -1,0 +1,30 @@
+import type { Greentea } from "./greentea";
+import type { Temple } from "./temple";
+
+export interface GreenteaLike {
+  id: number;
+  greentea: Greentea;
+  created_at: string;
+}
+
+export interface TempleLike {
+  id: number;
+  temple: Temple;
+  created_at: string;
+}
+
+export interface GreenteaLikeListResponse {
+  greentea_likes: GreenteaLike[];
+}
+
+export interface TempleLikeListResponse {
+  temple_likes: TempleLike[];
+}
+
+export interface GreenteaLikeResponse {
+  greentea_like: GreenteaLike;
+}
+
+export interface TempleLikeResponse {
+  temple_like: TempleLike;
+}


### PR DESCRIPTION
## 概要

Issue #24 の **UI 先行実装**。#41（認証 UI 枠）と同方針で、Rails JWT (#15) / 書き込み API (#16) 連携前でも UI・モックで動作する形に、いいね・コメント・お気に入り一覧をフロント側で完結させた。Rails 側完成後は `src/lib/auth.ts` の `jwt` callback から実 JWT を `token.railsJwt` に乗せるだけで本番動作する。

`#24` は Rails 側 (#15 / #16) も含めて Close 予定のため、本 PR では **進捗のみ**（Close せず）。

## 追加・変更

### 型 (`src/types/`)
- `like.ts`: `GreenteaLike` / `TempleLike` と関連レスポンス
- `comment.ts`: `Comment` に `owned_by_current_user?: boolean` を追加（mock 側で自分のコメントだけ削除 UI を出すために必要）

### API クライアント (`src/lib/api/`)
- `client.ts`: `apiClient` に `authToken` オプションを追加し、指定時 `Authorization: Bearer <token>` を付与
- `likes.ts`: `getGreenteaLikes` / `likeGreentea` / `unlikeGreentea` 等
- `comments.ts`: `getGreenteaComments` / `createGreenteaComment` / `deleteGreenteaComment` 等
- `greenteas.ts` / `temples.ts`: 既存の `get*` に optional な `authToken` を追加（SSR で `liked_by_current_user` / `owned_by_current_user` を反映するため）
- `useAuthToken.ts`: クライアントコンポーネント用に `session.railsJwt` を返すフック

### コンポーネント (`src/components/common/`)
- `LikeButton.tsx`: 楽観的更新トグル。未ログイン時は `/auth/login?callbackUrl=...` へ誘導。`401` でロールバック
- `CommentSection.tsx`: 一覧 + 投稿フォーム（500 文字制限・空白のみは弾く）+ 自分のコメントのみ削除可能（`owned_by_current_user`）
- `LikedSpotsList.tsx`: SWR でお気に入り一覧を取得。未ログイン/読み込み中/エラーを表示

### ページ
- `/greenteas/[id]` / `/temples/[id]`: 既存の「いいね数バッジ」を `LikeButton` に置き換え、末尾に `CommentSection` を追加。サーバー側で `await auth()` から `session.railsJwt` を取り、`getGreentea` / `getTemple` に渡すことで SSR 初期描画から正しい like / own 状態を返す
- `/mypage/greentea-likes` / `/mypage/temple-likes`: 新規。CSR で `LikedSpotsList` を表示
- `/mypage`: 上記 2 ページへの導線カードを追加（旧「準備中」プレースホルダを置き換え）

### モック (`src/lib/api/mock/`)
- `state.ts`: モード起動中のみ有効なインメモリストア（ユーザー別 likes / comments）。コメントは `ownerId: string` を別途保持して所有権判定に使う
- `index.ts`: `/greentea_likes`・`/temple_likes`・`/greenteacomments`・`/templecomments` の GET/POST/DELETE と、抹茶店・神社 GET レスポンスへの like 状態反映を実装

### 認証
- `lib/auth.ts`: mock provider 時に `token.railsJwt = "mock:<userId>"` を発行し、apiClient のヘッダ付与経路を実 JWT 経路と統一（mock client が `Bearer "mock:<id>"` を識別）

## Rails 連携 (#15 / #16) で残る作業

- `lib/auth.ts` の `jwt` callback で `account.access_token` を Rails の `POST /api/v1/auth/:provider` に渡し、Rails 発行 JWT を `token.railsJwt` に格納（UI 側は無改修）
- `DELETE /greentea_likes/:id` の `:id` は UI 側で like 行 ID を保持しないため、mock 実装は `:id` を `greentea_id` / `temple_id` として扱っている。Rails 側で `find_by(user:, greentea_id: params[:id])` 相当の解決を実装する想定
- 詳細レスポンス / コメント一覧レスポンスに `liked_by_current_user` / `owned_by_current_user` を含める

## 動作確認

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` 警告 0
- [x] `NEXT_PUBLIC_USE_MOCK=true npm run build` 成功（14 ルート / 警告 0）
  - `/mypage/greentea-likes`・`/mypage/temple-likes` → ○ Static
  - `/greenteas/[id]`・`/temples/[id]` → ƒ Dynamic（`auth()` 利用のため）
  - 静的ルート（`/`, `/mypage`, `/nearby`, `/privacy`, `/terms`）はそのまま Static

## Test plan（マニュアル）

- [ ] `AUTH_SECRET=dev-secret NEXT_PUBLIC_USE_MOCK=true npm run dev` で起動
- [ ] 未ログイン状態で `/greenteas/1` の LikeButton を押すと `/auth/login?callbackUrl=/greenteas/1` に遷移する
- [ ] mock ログイン後、LikeButton をトグルすると即座に表示が切り替わる（楽観的更新）
- [ ] `/mypage` → 「お気に入りの抹茶店」カードから `/mypage/greentea-likes` に遷移し、いいね済みの抹茶店が並ぶ
- [ ] 詳細ページのコメントフォームから投稿でき、即座にリストの先頭に追加される
- [ ] 自分のコメントには「削除」ボタンが表示され、確認ダイアログ後に削除できる
- [ ] 他人/シードコメント（user.id=1）には削除ボタンが出ない
- [ ] 501 文字以上で文字数カウンタが弁柄色に変わり、送信ボタンが無効化される
- [ ] ログアウトすると詳細ページのコメントフォームが「ログインが必要」案内に切り替わる
- [ ] `/temples/1` / `/mypage/temple-likes` も同様に動作する

## 関連 issue

- Refs #24（Rails 連携を含むため Close せず）
- 後続: #15 (Rails JWT) / #16 (Rails 書き込み API) / #26 (GCP デプロイ) / #27 (Vercel デプロイ)
- 参考: #41（認証 UI 枠 — 本 PR と同じ「UI 先行 → Rails 連携追加」方針）

cc @hiiragi17

https://claude.ai/code/session_brave-hawking-SasOk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7ZqYkRvXeBujDSaWveMq5)_