### PR TITLE
test: API クライアント・モック層・純粋ロジックの Phase 1 テスト (#45)

### DIFF
--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -1,14 +1,206 @@
+import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
-import { buildQuery } from "@/lib/api/client";
+import { server } from "../../../../tests/msw/server";
+import { ApiError, apiClient, buildQuery } from "@/lib/api/client";
 
-// Phase 1 の本格的なテストは #45 で追加する。
-// ここではテストランナーが回ることだけ確認する最小ケース。
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
 describe("buildQuery", () => {
   it("引数なしのときは空文字列を返す", () => {
     expect(buildQuery()).toBe("");
   });
 
+  it("空オブジェクトでも空文字列を返す（先頭の ? を付けない）", () => {
+    expect(buildQuery({})).toBe("");
+  });
+
+  it("有効な値が一つも無ければ空文字列を返す", () => {
+    expect(buildQuery({ a: undefined, b: null, c: "" })).toBe("");
+  });
+
   it("通常の key/value をクエリ文字列に変換する", () => {
     expect(buildQuery({ page: 1 })).toBe("?page=1");
+  });
+
+  it("undefined / null / 空文字は除外する", () => {
+    expect(
+      buildQuery({ page: 2, q: undefined, sort: null, name: "" }),
+    ).toBe("?page=2");
+  });
+
+  it("真偽値・数値も文字列化する", () => {
+    expect(buildQuery({ active: true, archived: false, count: 0 })).toBe(
+      "?active=true&archived=false&count=0",
+    );
+  });
+
+  it("ネストしたオブジェクトを key[nestedKey] 形式（Ransack）に展開する", () => {
+    const q = buildQuery({ q: { name_cont: "辻利", genres_id_eq: 3 } });
+    const params = new URLSearchParams(q.slice(1));
+    expect(params.get("q[name_cont]")).toBe("辻利");
+    expect(params.get("q[genres_id_eq]")).toBe("3");
+  });
+
+  it("ネスト内の undefined / null / 空文字も除外する", () => {
+    const q = buildQuery({
+      q: { name_cont: "中村", genres_id_eq: undefined, areas_id_eq: null },
+    });
+    expect(q).toBe("?" + new URLSearchParams({ "q[name_cont]": "中村" }).toString());
+  });
+});
+
+describe("apiClient", () => {
+  it("GET 時は Content-Type を付けない", async () => {
+    let contentType: string | null = "__unset__";
+    server.use(
+      http.get(endpoint("/ping"), ({ request }) => {
+        contentType = request.headers.get("Content-Type");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient("/ping");
+    expect(contentType).toBeNull();
+  });
+
+  it("POST 時は Content-Type: application/json を自動で付ける", async () => {
+    let contentType: string | null = null;
+    server.use(
+      http.post(endpoint("/echo"), ({ request }) => {
+        contentType = request.headers.get("Content-Type");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient("/echo", { method: "POST", body: JSON.stringify({ a: 1 }) });
+    expect(contentType).toBe("application/json");
+  });
+
+  it("呼び出し側が指定した Content-Type を上書きしない", async () => {
+    let contentType: string | null = null;
+    server.use(
+      http.post(endpoint("/echo"), ({ request }) => {
+        contentType = request.headers.get("Content-Type");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient("/echo", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "raw",
+    });
+    expect(contentType).toBe("text/plain");
+  });
+
+  it("既存の Headers インスタンスとマージしても元のヘッダが欠落しない", async () => {
+    let custom: string | null = null;
+    let contentType: string | null = null;
+    server.use(
+      http.post(endpoint("/echo"), ({ request }) => {
+        custom = request.headers.get("X-Custom");
+        contentType = request.headers.get("Content-Type");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const headers = new Headers();
+    headers.set("X-Custom", "yes");
+
+    await apiClient("/echo", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ a: 1 }),
+    });
+
+    expect(custom).toBe("yes");
+    expect(contentType).toBe("application/json");
+  });
+
+  it("authToken 指定時に Authorization: Bearer ヘッダを付与する", async () => {
+    let auth: string | null = null;
+    server.use(
+      http.get(endpoint("/me"), ({ request }) => {
+        auth = request.headers.get("Authorization");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient("/me", { authToken: "jwt-token" });
+    expect(auth).toBe("Bearer jwt-token");
+  });
+
+  it("既存の Authorization ヘッダは authToken で上書きしない", async () => {
+    let auth: string | null = null;
+    server.use(
+      http.get(endpoint("/me"), ({ request }) => {
+        auth = request.headers.get("Authorization");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient("/me", {
+      authToken: "should-not-win",
+      headers: { Authorization: "Bearer existing" },
+    });
+    expect(auth).toBe("Bearer existing");
+  });
+
+  it("204 No Content では undefined を返す（res.json() の SyntaxError を起こさない）", async () => {
+    server.use(
+      http.delete(endpoint("/items/1"), () =>
+        HttpResponse.text(null, { status: 204 }),
+      ),
+    );
+    await expect(
+      apiClient("/items/1", { method: "DELETE" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("200 でも空ボディなら undefined を返す", async () => {
+    server.use(
+      http.get(endpoint("/empty"), () => HttpResponse.text("", { status: 200 })),
+    );
+    await expect(apiClient("/empty")).resolves.toBeUndefined();
+  });
+
+  it("非 2xx のとき ApiError を throw する（JSON ボディは data に含まれる）", async () => {
+    server.use(
+      http.get(endpoint("/boom"), () =>
+        HttpResponse.json({ error: "bad" }, { status: 422 }),
+      ),
+    );
+
+    await expect(apiClient("/boom")).rejects.toBeInstanceOf(ApiError);
+    await expect(apiClient("/boom")).rejects.toMatchObject({
+      status: 422,
+      data: { error: "bad" },
+    });
+  });
+
+  it("非 JSON のエラーボディでも throw する（data は null）", async () => {
+    server.use(
+      http.get(endpoint("/boom-html"), () =>
+        HttpResponse.text("<html>500</html>", { status: 500 }),
+      ),
+    );
+
+    const err = await apiClient("/boom-html").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+    expect((err as ApiError).data).toBeNull();
+  });
+
+  it("成功レスポンスの JSON を型キャストして返す", async () => {
+    server.use(
+      http.get(endpoint("/json"), () =>
+        HttpResponse.json({ value: 7 }),
+      ),
+    );
+
+    const res = await apiClient<{ value: number }>("/json");
+    expect(res.value).toBe(7);
   });
 });

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+  AreaListResponse,
+  CommentListResponse,
+  CommentResponse,
+  GenreListResponse,
+  GreenteaDetailResponse,
+  GreenteaLikeListResponse,
+  GreenteaLikeResponse,
+  GreenteaListResponse,
+  NearbyResponse,
+  TempleDetailResponse,
+  TempleLikeListResponse,
+  TempleLikeResponse,
+  TempleListResponse,
+} from "@/types";
+import { ApiError } from "../../error";
+import { mockClient } from "../index";
+import { resetMockStore } from "../state";
+
+const auth = (userId: string): RequestInit => ({
+  headers: { Authorization: `Bearer mock:${userId}` },
+});
+
+beforeEach(() => {
+  resetMockStore();
+});
+
+describe("mockClient GET /greenteas", () => {
+  it("ページネーション meta を含む一覧を返す", async () => {
+    const res = await mockClient<GreenteaListResponse>("/greenteas");
+    expect(res.meta).toMatchObject({
+      current_page: 1,
+      total_pages: 1,
+      total_count: 3,
+    });
+    expect(res.greenteas).toHaveLength(3);
+  });
+
+  it("q[name_cont] で名前を絞り込む", async () => {
+    const res = await mockClient<GreenteaListResponse>(
+      "/greenteas?q[name_cont]=中村",
+    );
+    expect(res.greenteas).toHaveLength(1);
+    expect(res.greenteas[0].name).toBe("中村藤吉本店");
+  });
+
+  it("q[genres_id_eq] でジャンルを絞り込む", async () => {
+    const res = await mockClient<GreenteaListResponse>(
+      "/greenteas?q[genres_id_eq]=1",
+    );
+    // パフェ (id=1) を含むのは id 1, 2
+    expect(res.greenteas.map((g) => g.id).sort()).toEqual([1, 2]);
+  });
+});
+
+describe("mockClient GET /greenteas/:id", () => {
+  it("存在する ID は詳細 + nearby_temples（1500m 以内・距離昇順）を返す", async () => {
+    const res = await mockClient<GreenteaDetailResponse>("/greenteas/1");
+    expect(res.greentea.id).toBe(1);
+    expect(res.greentea.nearby_temples.length).toBeGreaterThan(0);
+    // 全件 1500m 以内
+    for (const t of res.greentea.nearby_temples) {
+      expect(t.distance_meters).toBeLessThanOrEqual(1500);
+    }
+    // 距離昇順
+    const distances = res.greentea.nearby_temples.map((t) => t.distance_meters);
+    expect([...distances].sort((a, b) => a - b)).toEqual(distances);
+  });
+
+  it("存在しない ID は ApiError(404)", async () => {
+    await expect(mockClient("/greenteas/99999")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe("mockClient GET /temples & /temples/:id", () => {
+  it("/temples は契約形のレスポンスを返す", async () => {
+    const res = await mockClient<TempleListResponse>("/temples");
+    expect(res.meta.total_count).toBe(3);
+    expect(res.temples[0]).toHaveProperty("areas");
+    expect(res.temples[0]).toHaveProperty("likes_count");
+  });
+
+  it("/temples/:id は近隣抹茶店を距離昇順で返す", async () => {
+    const res = await mockClient<TempleDetailResponse>("/temples/1");
+    expect(res.temple.id).toBe(1);
+    const distances = res.temple.nearby_greenteas.map((g) => g.distance_meters);
+    expect([...distances].sort((a, b) => a - b)).toEqual(distances);
+  });
+
+  it("/temples/99999 は ApiError(404)", async () => {
+    await expect(mockClient("/temples/99999")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe("mockClient GET /areas /genres", () => {
+  it("/areas を返す", async () => {
+    const res = await mockClient<AreaListResponse>("/areas");
+    expect(res.areas.length).toBeGreaterThan(0);
+    expect(res.areas[0]).toHaveProperty("id");
+    expect(res.areas[0]).toHaveProperty("name");
+  });
+
+  it("/genres を返す", async () => {
+    const res = await mockClient<GenreListResponse>("/genres");
+    expect(res.genres.length).toBeGreaterThan(0);
+    expect(res.genres[0]).toHaveProperty("name");
+  });
+});
+
+describe("mockClient GET /nearby", () => {
+  it("lat / lng 欠損で ApiError(400)", async () => {
+    await expect(mockClient("/nearby")).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("lat / lng が数値でなければ ApiError(400)", async () => {
+    await expect(
+      mockClient("/nearby?lat=abc&lng=xyz"),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("radius=1.5 で 1500m 以内のスポットを距離昇順で返す", async () => {
+    const res = await mockClient<NearbyResponse>(
+      "/nearby?lat=35.003&lng=135.771&radius=1.5",
+    );
+    for (const g of res.greenteas) {
+      expect(g.distance_meters).toBeLessThanOrEqual(1500);
+    }
+    for (const t of res.temples) {
+      expect(t.distance_meters).toBeLessThanOrEqual(1500);
+    }
+    const gd = res.greenteas.map((g) => g.distance_meters);
+    expect([...gd].sort((a, b) => a - b)).toEqual(gd);
+    const td = res.temples.map((t) => t.distance_meters);
+    expect([...td].sort((a, b) => a - b)).toEqual(td);
+  });
+});
+
+describe("mockClient likes (greentea)", () => {
+  it("未認証で /greentea_likes GET は 401", async () => {
+    await expect(mockClient("/greentea_likes")).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+
+  it("POST → 一覧に出る / DELETE で消える", async () => {
+    const u = auth("alice");
+
+    const post = await mockClient<GreenteaLikeResponse>("/greentea_likes", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 1 }),
+      ...u,
+    });
+    expect(post.greentea_like.greentea.id).toBe(1);
+    expect(post.greentea_like.greentea.liked_by_current_user).toBe(true);
+
+    const list1 = await mockClient<GreenteaLikeListResponse>(
+      "/greentea_likes",
+      u,
+    );
+    expect(list1.greentea_likes.map((l) => l.greentea.id)).toContain(1);
+
+    await mockClient("/greentea_likes/1", { method: "DELETE", ...u });
+
+    const list2 = await mockClient<GreenteaLikeListResponse>(
+      "/greentea_likes",
+      u,
+    );
+    expect(list2.greentea_likes.map((l) => l.greentea.id)).not.toContain(1);
+  });
+
+  it("重複 POST は冪等（カウントが二重に増えない）", async () => {
+    const u = auth("alice");
+    const post = (n: number) =>
+      mockClient<GreenteaLikeResponse>("/greentea_likes", {
+        method: "POST",
+        body: JSON.stringify({ greentea_id: n }),
+        ...u,
+      });
+
+    const first = await post(1);
+    const second = await post(1);
+    // likes_count は同じ値（+1 のまま）
+    expect(second.greentea_like.greentea.likes_count).toBe(
+      first.greentea_like.greentea.likes_count,
+    );
+  });
+
+  it("ユーザーが違えば liked_by_current_user は別々", async () => {
+    await mockClient("/greentea_likes", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 1 }),
+      ...auth("alice"),
+    });
+
+    const aliceList = await mockClient<GreenteaListResponse>(
+      "/greenteas",
+      auth("alice"),
+    );
+    const bobList = await mockClient<GreenteaListResponse>(
+      "/greenteas",
+      auth("bob"),
+    );
+
+    const aliceG1 = aliceList.greenteas.find((g) => g.id === 1)!;
+    const bobG1 = bobList.greenteas.find((g) => g.id === 1)!;
+    expect(aliceG1.liked_by_current_user).toBe(true);
+    expect(bobG1.liked_by_current_user).toBe(false);
+    // ただし likes_count は共通（delta は global）
+    expect(bobG1.likes_count).toBe(aliceG1.likes_count);
+  });
+});
+
+describe("mockClient likes (temple)", () => {
+  it("POST → 一覧に反映 → DELETE で消える", async () => {
+    const u = auth("alice");
+    await mockClient<TempleLikeResponse>("/temple_likes", {
+      method: "POST",
+      body: JSON.stringify({ temple_id: 2 }),
+      ...u,
+    });
+
+    const list = await mockClient<TempleLikeListResponse>("/temple_likes", u);
+    expect(list.temple_likes.map((l) => l.temple.id)).toContain(2);
+
+    await mockClient("/temple_likes/2", { method: "DELETE", ...u });
+    const after = await mockClient<TempleLikeListResponse>("/temple_likes", u);
+    expect(after.temple_likes.map((l) => l.temple.id)).not.toContain(2);
+  });
+});
+
+describe("mockClient comments", () => {
+  it("/greenteacomments の POST 後、一覧の owned_by_current_user が投稿者だけ true", async () => {
+    const alice = auth("alice");
+    const bob = auth("bob");
+
+    await mockClient<CommentResponse>("/greenteacomments", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 2, body: "Aliceの感想" }),
+      ...alice,
+    });
+
+    const aliceView = await mockClient<CommentListResponse>(
+      "/greenteacomments?greentea_id=2",
+      alice,
+    );
+    const aliceComment = aliceView.comments.find(
+      (c) => c.body === "Aliceの感想",
+    );
+    expect(aliceComment?.owned_by_current_user).toBe(true);
+
+    const bobView = await mockClient<CommentListResponse>(
+      "/greenteacomments?greentea_id=2",
+      bob,
+    );
+    const bobSees = bobView.comments.find((c) => c.body === "Aliceの感想");
+    expect(bobSees?.owned_by_current_user).toBe(false);
+  });
+
+  it("他人のコメント DELETE は ApiError(403)", async () => {
+    const alice = auth("alice");
+    const bob = auth("bob");
+
+    const created = await mockClient<CommentResponse>("/greenteacomments", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 2, body: "削除させない" }),
+      ...alice,
+    });
+
+    await expect(
+      mockClient(`/greenteacomments/${created.comment.id}`, {
+        method: "DELETE",
+        ...bob,
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("自分のコメント DELETE は成功し、一覧から消える", async () => {
+    const alice = auth("alice");
+    const created = await mockClient<CommentResponse>("/greenteacomments", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 2, body: "あとで消す" }),
+      ...alice,
+    });
+
+    await mockClient(`/greenteacomments/${created.comment.id}`, {
+      method: "DELETE",
+      ...alice,
+    });
+
+    const list = await mockClient<CommentListResponse>(
+      "/greenteacomments?greentea_id=2",
+      alice,
+    );
+    expect(list.comments.find((c) => c.id === created.comment.id)).toBeUndefined();
+  });
+
+  it("/templecomments も同じく POST → owned_by_current_user 真偽が分かれる", async () => {
+    const alice = auth("alice");
+    const bob = auth("bob");
+
+    await mockClient<CommentResponse>("/templecomments", {
+      method: "POST",
+      body: JSON.stringify({ temple_id: 1, body: "Bobの感想" }),
+      ...bob,
+    });
+
+    const bobView = await mockClient<CommentListResponse>(
+      "/templecomments?temple_id=1",
+      bob,
+    );
+    const fromBob = bobView.comments.find((c) => c.body === "Bobの感想");
+    expect(fromBob?.owned_by_current_user).toBe(true);
+
+    const aliceView = await mockClient<CommentListResponse>(
+      "/templecomments?temple_id=1",
+      alice,
+    );
+    const fromAliceSees = aliceView.comments.find(
+      (c) => c.body === "Bobの感想",
+    );
+    expect(fromAliceSees?.owned_by_current_user).toBe(false);
+  });
+
+  it("空 body の POST は ApiError(400)", async () => {
+    await expect(
+      mockClient("/greenteacomments", {
+        method: "POST",
+        body: JSON.stringify({ greentea_id: 1, body: "   " }),
+        ...auth("alice"),
+      }),
+    ).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("mockClient routing", () => {
+  it("未定義パスは ApiError(404)", async () => {
+    await expect(mockClient("/unknown")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/src/lib/api/mock/__tests__/state.test.ts
+++ b/src/lib/api/mock/__tests__/state.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  addGreenteaComment,
+  addGreenteaLike,
+  addTempleLike,
+  deleteGreenteaComment,
+  extractMockUserId,
+  getGreenteaLikeDelta,
+  getGreenteaLikedIds,
+  getTempleLikeDelta,
+  getTempleLikedIds,
+  listGreenteaComments,
+  removeGreenteaLike,
+  resetMockStore,
+} from "../state";
+
+beforeEach(() => {
+  resetMockStore();
+});
+
+describe("resetMockStore", () => {
+  it("各テスト前に呼ぶことで前テストの状態が残らない", () => {
+    addGreenteaLike("alice", 1);
+    expect(getGreenteaLikedIds("alice").has(1)).toBe(true);
+
+    resetMockStore();
+    expect(getGreenteaLikedIds("alice").size).toBe(0);
+    expect(getGreenteaLikeDelta(1)).toBe(0);
+  });
+});
+
+describe("greentea likes", () => {
+  it("同一ユーザーの同一スポット重複 like は冪等（delta も 1 のまま）", () => {
+    expect(addGreenteaLike("alice", 1)).toBe(true);
+    expect(addGreenteaLike("alice", 1)).toBe(false);
+    expect(getGreenteaLikedIds("alice").size).toBe(1);
+    expect(getGreenteaLikeDelta(1)).toBe(1);
+  });
+
+  it("remove で delta が -1 され、未 like の remove は false", () => {
+    addGreenteaLike("alice", 1);
+    expect(removeGreenteaLike("alice", 1)).toBe(true);
+    expect(getGreenteaLikedIds("alice").has(1)).toBe(false);
+    expect(getGreenteaLikeDelta(1)).toBe(0);
+
+    expect(removeGreenteaLike("alice", 1)).toBe(false);
+  });
+
+  it("ユーザーごとに like 集合が独立している", () => {
+    addGreenteaLike("alice", 1);
+    addGreenteaLike("bob", 2);
+    expect(getGreenteaLikedIds("alice")).toEqual(new Set([1]));
+    expect(getGreenteaLikedIds("bob")).toEqual(new Set([2]));
+  });
+});
+
+describe("temple likes", () => {
+  it("追加 / 集合 / delta が独立して機能する", () => {
+    addTempleLike("alice", 5);
+    addTempleLike("alice", 7);
+    addTempleLike("bob", 5);
+    expect(getTempleLikedIds("alice")).toEqual(new Set([5, 7]));
+    expect(getTempleLikedIds("bob")).toEqual(new Set([5]));
+    expect(getTempleLikeDelta(5)).toBe(2);
+    expect(getTempleLikeDelta(7)).toBe(1);
+  });
+});
+
+describe("greentea comments", () => {
+  const baseComment = {
+    body: "おいしかった",
+    user: { id: 99, name: "alice-name" },
+  };
+
+  it("追加したコメントは viewer が owner と一致するときだけ owned_by_current_user=true", () => {
+    const created = addGreenteaComment(1, "alice", baseComment);
+    const aliceView = listGreenteaComments(1, "alice");
+    const bobView = listGreenteaComments(1, "bob");
+    const anonView = listGreenteaComments(1, null);
+
+    expect(aliceView.find((c) => c.id === created.id)?.owned_by_current_user).toBe(
+      true,
+    );
+    expect(bobView.find((c) => c.id === created.id)?.owned_by_current_user).toBe(
+      false,
+    );
+    expect(anonView.find((c) => c.id === created.id)?.owned_by_current_user).toBe(
+      false,
+    );
+  });
+
+  it("他人による削除は forbidden、所有者の削除は deleted", () => {
+    const created = addGreenteaComment(1, "alice", baseComment);
+    expect(deleteGreenteaComment(created.id, "bob")).toBe("forbidden");
+    expect(deleteGreenteaComment(created.id, "alice")).toBe("deleted");
+    expect(deleteGreenteaComment(created.id, "alice")).toBe("not_found");
+  });
+});
+
+describe("extractMockUserId", () => {
+  it("Bearer mock:<id> から id を取り出す", () => {
+    const h = new Headers({ Authorization: "Bearer mock:alice" });
+    expect(extractMockUserId(h)).toBe("alice");
+  });
+
+  it("Authorization ヘッダが無いと null", () => {
+    expect(extractMockUserId(new Headers())).toBeNull();
+  });
+
+  it("Bearer 以外のスキームは null", () => {
+    const h = new Headers({ Authorization: "Basic mock:alice" });
+    expect(extractMockUserId(h)).toBeNull();
+  });
+
+  it("mock: プレフィックスが無いトークン（実 JWT 等）は null", () => {
+    const h = new Headers({ Authorization: "Bearer eyJ.real.jwt" });
+    expect(extractMockUserId(h)).toBeNull();
+  });
+
+  it("mock: の後ろが空の場合は null", () => {
+    const h = new Headers({ Authorization: "Bearer mock:" });
+    expect(extractMockUserId(h)).toBeNull();
+  });
+});

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -19,6 +19,7 @@ import type {
   TempleLikeResponse,
   TempleListResponse,
 } from "@/types";
+import { distanceMeters } from "@/lib/utils/distance";
 import type { CurrentUserResponse } from "../auth";
 import { ApiError } from "../error";
 import {
@@ -60,23 +61,6 @@ function paginate<T>(items: T[], page: number) {
       total_count: items.length,
     },
   };
-}
-
-// 緯度経度から概算の距離（メートル）を求める（Haversine）。
-function distanceMeters(
-  from: { latitude: number; longitude: number },
-  to: { latitude: number; longitude: number },
-): number {
-  const R = 6371000;
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(to.latitude - from.latitude);
-  const dLng = toRad(to.longitude - from.longitude);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(from.latitude)) *
-      Math.cos(toRad(to.latitude)) *
-      Math.sin(dLng / 2) ** 2;
-  return Math.round(R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
 }
 
 function notFound(endpoint: string): never {

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -43,6 +43,18 @@ const store: MockStore = ((): MockStore => {
   return g[globalKey]!;
 })();
 
+// テスト用にインメモリストアを初期化する。各テストの beforeEach から呼ぶ想定。
+// 本番では呼ばれない（mock モード自体が本番では無効）。
+export function resetMockStore(): void {
+  store.greenteaLikes.clear();
+  store.templeLikes.clear();
+  store.greenteaComments.clear();
+  store.templeComments.clear();
+  store.greenteaLikeCountDelta.clear();
+  store.templeLikeCountDelta.clear();
+  store.nextCommentId.value = 1000;
+}
+
 function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
   let set = map.get(key);
   if (!set) {

--- a/src/lib/utils/__tests__/distance.test.ts
+++ b/src/lib/utils/__tests__/distance.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { distanceMeters } from "@/lib/utils/distance";
+
+describe("distanceMeters", () => {
+  it("同一点は 0m を返す", () => {
+    const point = { latitude: 35.0036, longitude: 135.7714 };
+    expect(distanceMeters(point, point)).toBe(0);
+  });
+
+  it("京都市内 2 点（祇園 〜 二条城、約 2.4km）の距離を妥当な範囲で返す", () => {
+    // 祇園四条 (≒ 茶寮都路里) と二条城。Haversine 計算では約 2.4km。
+    const gion = { latitude: 35.0036, longitude: 135.7714 };
+    const nijo = { latitude: 35.0142, longitude: 135.7481 };
+    const d = distanceMeters(gion, nijo);
+    expect(d).toBeGreaterThan(2_200);
+    expect(d).toBeLessThan(2_700);
+  });
+
+  it("近接する 2 点（〜500m）の距離を妥当な範囲で返す", () => {
+    // 祇園四条交差点近傍と建仁寺。実距離はおおむね 400〜500m。
+    const a = { latitude: 35.0036, longitude: 135.7714 };
+    const b = { latitude: 35.0, longitude: 135.7741 };
+    const d = distanceMeters(a, b);
+    expect(d).toBeGreaterThan(300);
+    expect(d).toBeLessThan(700);
+  });
+
+  it("対称性: A→B と B→A は同じ距離を返す", () => {
+    const a = { latitude: 35.0036, longitude: 135.7714 };
+    const b = { latitude: 35.0142, longitude: 135.7481 };
+    expect(distanceMeters(a, b)).toBe(distanceMeters(b, a));
+  });
+
+  it("赤道上の 1 度（経度差）は約 111km", () => {
+    const d = distanceMeters(
+      { latitude: 0, longitude: 0 },
+      { latitude: 0, longitude: 1 },
+    );
+    // 赤道周は 40,075km なので 1 度はおよそ 111.32km。
+    expect(d).toBeGreaterThan(110_000);
+    expect(d).toBeLessThan(112_000);
+  });
+});

--- a/src/lib/utils/distance.ts
+++ b/src/lib/utils/distance.ts
@@ -1,0 +1,25 @@
+// Haversine の公式で 2 点間の距離（メートル）を求める。
+// 地球を半径 6371km の球と仮定するため、極近傍や数千 km スケールでは誤差が出る。
+// 京都市内の探索（半径 1.5km 程度）には十分な精度。
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
+
+export type LatLng = {
+  latitude: number;
+  longitude: number;
+};
+
+export function distanceMeters(from: LatLng, to: LatLng): number {
+  const dLat = toRadians(to.latitude - from.latitude);
+  const dLng = toRadians(to.longitude - from.longitude);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(from.latitude)) *
+      Math.cos(toRadians(to.latitude)) *
+      Math.sin(dLng / 2) ** 2;
+  return Math.round(
+    EARTH_RADIUS_METERS * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)),
+  );
+}


### PR DESCRIPTION
## 概要

`docs/test-plan.md` の **Phase 1（優先度 A）**に相当するテストを追加します。
副作用がなく ROI が高い、API クライアント / モック層 / 純粋ロジックを網羅。

Closes #45

## 変更内容

### リファクタ
- `src/lib/api/mock/index.ts` の private な `distanceMeters` を `src/lib/utils/distance.ts` に切り出し
  - `CLAUDE.md` のディレクトリ計画とも整合
  - mock 側は alias 経由で import
- `src/lib/api/mock/state.ts` にテスト用 `resetMockStore()` を追加
  - 各テストの `beforeEach` から呼び、インメモリストアを初期化する

### 追加テスト（79 件 green）

| ファイル | 対象 |
|---|---|
| `src/lib/utils/__tests__/distance.test.ts` | Haversine の同一点 / 京都市内 / 対称性 / 赤道 1度 |
| `src/lib/api/__tests__/client.test.ts` | `buildQuery`（undefined/null/空・ネスト・真偽値）/ `apiClient`（Content-Type 自動付与・既存 headers マージ・authToken と既存 Authorization 上書きしない・204/空ボディ undefined・ApiError JSON/非 JSON ボディ） |
| `src/lib/api/mock/__tests__/mock.test.ts` | `/greenteas` `/greenteas/:id` `/temples` `/temples/:id` `/areas` `/genres` `/nearby` `/greentea_likes` `/temple_likes` `/greenteacomments` `/templecomments` の挙動・404・冪等性・所有権・距離昇順 |
| `src/lib/api/mock/__tests__/state.test.ts` | 重複 like の冪等性・ユーザー別 like 集合・コメント所有権削除・`extractMockUserId` のトークン形式判定 |

## 受け入れ条件

- [x] `src/lib/api/**` および `src/lib/utils/distance.ts` のテストが 30 件以上 green（**79 件**）
- [x] `npm test` / `npm run lint` / `tsc --noEmit` すべて green
- [x] Haversine の切り出しリファクタが既存 mock の挙動に影響しない（既存 contract test が引き続き green）

## 補足

- `resetMockStore` は test-only helper として export していますが、本番では mock モード自体が無効化されているため副作用はありません。
- mockClient を直接呼び出す形のテストにしたため、MSW を経由せず軽量・hermetic に走ります（apiClient のテストのみ MSW を使用）。

## テスト計画

- [x] `npm test` で 79/79 pass
- [x] `npm run lint` で警告なし
- [x] `npx tsc --noEmit` でエラーなし


---
_Generated by [Claude Code](https://claude.ai/code/session_014MaVUvhipZTa1ftbkbZqRK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded API client test coverage including request headers, response handling, and error scenarios
  * Added comprehensive mock API endpoint tests for filtering, pagination, and authorization
  * Added mock store tests for state management and user isolation
  * Added distance calculation tests

* **Refactor**
  * Extracted distance calculation logic to shared utility module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->