### PR TITLE
chore: import スタイル方針 A を明文化し ESLint で深い相対 import を禁止 (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,19 @@ src/
 - **デザインは daisyUI + Tailwind** で既存 greentea_temple のデザインを踏襲する。
 - コメントは「なぜ」が非自明な場合のみ。自明な処理にコメントを足さない。
 
+### import スタイル
+
+`src/` 配下の import パスは、以下の使い分けで統一する。ESLint の `no-restricted-imports` で機械的にチェックする。
+
+- **同階層 (`./xxx`)** — 相対 import を使う。例: `src/lib/api/greenteas.ts` から `import { apiClient } from "./client"`
+- **同一パッケージ内の親 1 階層 (`../xxx`)** — 相対 import を使ってよい。例: `src/lib/api/mock/index.ts` から `import { ApiError } from "../error"`
+- **親 2 階層以上 (`../../`, `../../../`...)** — `@/*` エイリアス必須。深い相対 path は禁止する（ESLint で error）。
+  - 例: ❌ `import { ApiError } from "../../error"` → ✅ `import { ApiError } from "@/lib/api/error"`
+- **`tests/` 配下への参照** — `@tests/*` エイリアスを使う。`@/*` は `src/*` のみを指す。
+  - 例: ✅ `import { server } from "@tests/msw/server"`
+
+`tests/` 内の `./xxx` / `../xxx` の相対 import は同様の基準で OK。
+
 ## 著作権・免責
 
 - 画像は外部URL参照のみ（Rails 側 CarrierWave の URL をそのまま表示）。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,22 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../../*"],
+              message:
+                "親 2 階層以上を遡る相対 import は禁止。@/* または @tests/* エイリアスを使ってください（CLAUDE.md コーディング規約参照）。",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,7 @@ const eslintConfig = [
         {
           patterns: [
             {
-              group: ["../../*"],
+              regex: "^\\.\\./\\.\\./",
               message:
                 "親 2 階層以上を遡る相対 import は禁止。@/* または @tests/* エイリアスを使ってください（CLAUDE.md コーディング規約参照）。",
             },

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
-import { server } from "../../../../tests/msw/server";
+import { server } from "@tests/msw/server";
 import { ApiError, apiClient, buildQuery } from "@/lib/api/client";
 
 const API_BASE_URL =

--- a/src/lib/api/__tests__/contract.test.ts
+++ b/src/lib/api/__tests__/contract.test.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
-import { server } from "../../../../tests/msw/server";
+import { server } from "@tests/msw/server";
 import {
   ApiError,
   exchangeOAuthForJwt,

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -14,7 +14,7 @@ import type {
   TempleLikeResponse,
   TempleListResponse,
 } from "@/types";
-import { ApiError } from "../../error";
+import { ApiError } from "@/lib/api/error";
 import { mockClient } from "../index";
 import { resetMockStore } from "../state";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"]
     },
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@tests": fileURLToPath(new URL("./tests", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
Closes #55

## 概要

`src/` 配下の import スタイル（相対 vs `@/*` エイリアス）の方針を方針 A（現状維持: 同階層・近接の親は相対、深い path はエイリアス）で確定し、CLAUDE.md に明文化 + ESLint で機械的に enforce するようにした。

## 変更内容

### 1. ポリシー明文化（`CLAUDE.md`）
「コーディング規約 → import スタイル」セクションを追加。

- 同階層 `./xxx` → 相対 OK
- 親 1 階層 `../xxx`（同一パッケージ内） → 相対 OK
- 親 2 階層以上 `../../`, `../../../` → `@/*` / `@tests/*` エイリアス必須
- `tests/` への参照は `@tests/*` を使う

### 2. ESLint enforce（`eslint.config.mjs`）
`no-restricted-imports` で `../../*` パターンを `error` に。`../xxx`（1 階層）は引き続き許容するため、同一パッケージ内の短い相対 import の読みやすさは維持。

```js
{
  group: ["../../*"],
  message: "親 2 階層以上を遡る相対 import は禁止。@/* または @tests/* エイリアスを使ってください…",
}
```

### 3. `@tests/*` エイリアス追加
`tests/` ディレクトリは `src/` の外にあり既存の `@/*` では届かないため、新規エイリアスを追加。

- `tsconfig.json`: `"@tests/*": ["./tests/*"]`
- `vitest.config.ts`: `"@tests": fileURLToPath(new URL("./tests", import.meta.url))`

### 4. 既存違反の修正（3 件）
| ファイル | 変更前 | 変更後 |
|---|---|---|
| `src/lib/api/__tests__/client.test.ts` | `../../../../tests/msw/server` | `@tests/msw/server` |
| `src/lib/api/__tests__/contract.test.ts` | `../../../../tests/msw/server` | `@tests/msw/server` |
| `src/lib/api/mock/__tests__/mock.test.ts` | `../../error` | `@/lib/api/error` |

`src/lib/api/mock/index.ts` の `../auth` / `../error`（1 階層）はポリシー A の範囲内のため変更なし。

## 受け入れ条件

- [x] 方針 A を採用（issue 本文で著者の好みとして明記済み）
- [x] CLAUDE.md「コーディング規約」に import スタイルの記述を追加
- [x] ESLint ルールを追加し、既存コード違反を一括修正
- [x] CI が green（手元で `npm run lint` / `npm test` / `npm run build` ともに pass、79 tests passed）

## 関連

- Closes #55
- PR #54 のレビュー指摘が発端

---
_Generated by [Claude Code](https://claude.ai/code/session_011631APbVuDHACGfg7HFYiz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented import path conventions and standards for consistent code structure.

* **Configuration**
  * Enabled linting rules to automatically enforce import path conventions across the codebase.
  * Configured path alias mappings to standardize and simplify imports throughout the project.

* **Refactor**
  * Updated import paths in test files to align with established project standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->