### PR TITLE
test: Client Component と SSR 境界の Phase 2 + 3 テスト追加 (#46)

### DIFF
--- a/src/app/greenteas/[id]/__tests__/page.test.tsx
+++ b/src/app/greenteas/[id]/__tests__/page.test.tsx
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/api/error";
 
-const notFoundMock = vi.fn(() => {
-  // Next.js の notFound() は throw して呼び出し以降の処理を中断する。
-  // テストでは sentinel エラーを投げて呼び出しを検知する。
-  throw new Error("NEXT_NOT_FOUND");
-});
-
-const getGreenteaMock = vi.fn();
-const authMock = vi.fn().mockResolvedValue(null);
+// vi.mock のファクトリは vi.mock 自体と共にホイストされる。top-level const を
+// 直接参照すると TDZ に当たる恐れがあるため、共有 fake は vi.hoisted() で先に作る。
+const { notFoundMock, getGreenteaMock, authMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  getGreenteaMock: vi.fn(),
+  authMock: vi.fn().mockResolvedValue(null),
+}));
 
 vi.mock("next/navigation", () => ({
   notFound: notFoundMock,

--- a/src/app/greenteas/[id]/__tests__/page.test.tsx
+++ b/src/app/greenteas/[id]/__tests__/page.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api/error";
+
+const notFoundMock = vi.fn(() => {
+  // Next.js の notFound() は throw して呼び出し以降の処理を中断する。
+  // テストでは sentinel エラーを投げて呼び出しを検知する。
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+const getGreenteaMock = vi.fn();
+const authMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+  redirect: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getGreentea: getGreenteaMock,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+beforeEach(() => {
+  notFoundMock.mockClear();
+  getGreenteaMock.mockReset();
+});
+
+describe("/greenteas/[id] page — SSR 境界", () => {
+  it("getGreentea が ApiError(404) を投げると notFound() が呼ばれる", async () => {
+    getGreenteaMock.mockRejectedValueOnce(new ApiError(404, null));
+    const { default: Page } = await import("@/app/greenteas/[id]/page");
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "999" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("404 以外の ApiError はそのまま伝播する（notFound は呼ばない）", async () => {
+    getGreenteaMock.mockRejectedValueOnce(new ApiError(500, null));
+    const { default: Page } = await import("@/app/greenteas/[id]/page");
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "1" }) }),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/greenteas/__tests__/page.test.tsx
+++ b/src/app/greenteas/__tests__/page.test.tsx
@@ -77,4 +77,15 @@ describe("/greenteas page — SSR 境界", () => {
     await Page({ searchParams: Promise.resolve({ page: "2" }) });
     expect(redirectMock).not.toHaveBeenCalled();
   });
+
+  it("total_pages が 0 のときは redirect しない（ループ防止）", async () => {
+    getGreenteasMock.mockResolvedValueOnce({
+      greenteas: [],
+      meta: { current_page: 1, total_pages: 0, total_count: 0 },
+    });
+    const { default: Page } = await import("@/app/greenteas/page");
+
+    await Page({ searchParams: Promise.resolve({ page: "5" }) });
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/greenteas/__tests__/page.test.tsx
+++ b/src/app/greenteas/__tests__/page.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redirectMock = vi.fn((url: string) => {
+  // Next.js の redirect() は throw して呼び出し以降の処理を中断する。
+  // テストでは sentinel エラーを投げて呼び出しを検知する。
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+
+const getGreenteasMock = vi.fn();
+const getGenresMock = vi.fn().mockResolvedValue({ genres: [] });
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getGreenteas: getGreenteasMock,
+    getGenres: getGenresMock,
+  };
+});
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  getGreenteasMock.mockReset();
+});
+
+describe("/greenteas page — SSR 境界", () => {
+  it("page= が total_pages を超えると最終ページへ redirect する", async () => {
+    getGreenteasMock.mockResolvedValueOnce({
+      greenteas: [],
+      meta: { current_page: 5, total_pages: 5, total_count: 50 },
+    });
+    const { default: Page } = await import("@/app/greenteas/page");
+
+    await expect(
+      Page({ searchParams: Promise.resolve({ page: "9" }) }),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(redirectMock).toHaveBeenCalledWith("/greenteas?page=5");
+  });
+
+  it("検索条件付きで範囲外の page= を指定しても q / genre が保持される", async () => {
+    getGreenteasMock.mockResolvedValueOnce({
+      greenteas: [],
+      meta: { current_page: 3, total_pages: 3, total_count: 30 },
+    });
+    const { default: Page } = await import("@/app/greenteas/page");
+
+    await expect(
+      Page({
+        searchParams: Promise.resolve({ page: "10", q: "中村", genre: "3" }),
+      }),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const target = redirectMock.mock.calls[0][0] as string;
+    expect(target.startsWith("/greenteas?")).toBe(true);
+    const url = new URL(target, "http://localhost");
+    expect(url.searchParams.get("page")).toBe("3");
+    expect(url.searchParams.get("q")).toBe("中村");
+    expect(url.searchParams.get("genre")).toBe("3");
+  });
+
+  it("page が範囲内なら redirect は呼ばれない", async () => {
+    getGreenteasMock.mockResolvedValueOnce({
+      greenteas: [],
+      meta: { current_page: 2, total_pages: 5, total_count: 50 },
+    });
+    const { default: Page } = await import("@/app/greenteas/page");
+
+    await Page({ searchParams: Promise.resolve({ page: "2" }) });
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/greenteas/__tests__/page.test.tsx
+++ b/src/app/greenteas/__tests__/page.test.tsx
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const redirectMock = vi.fn((url: string) => {
-  // Next.js の redirect() は throw して呼び出し以降の処理を中断する。
-  // テストでは sentinel エラーを投げて呼び出しを検知する。
-  throw new Error(`NEXT_REDIRECT:${url}`);
-});
-
-const getGreenteasMock = vi.fn();
-const getGenresMock = vi.fn().mockResolvedValue({ genres: [] });
+// vi.mock のファクトリは vi.mock 自体と共にホイストされる。top-level const を
+// 直接参照すると TDZ に当たる恐れがあるため、共有 fake は vi.hoisted() で先に作る。
+const { redirectMock, getGreenteasMock, getGenresMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+  getGreenteasMock: vi.fn(),
+  getGenresMock: vi.fn().mockResolvedValue({ genres: [] }),
+}));
 
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,

--- a/src/app/greenteas/page.tsx
+++ b/src/app/greenteas/page.tsx
@@ -50,7 +50,8 @@ export default async function GreenteasPage({
   const preservedQuery = buildPreservedQuery(sp);
 
   // 範囲外の page= が指定された場合は最終ページへ寄せる（モック実装でも空配列を防ぐ）。
-  if (page > meta.total_pages) {
+  // total_pages が 0 のときは redirect ループを防ぐためガードする。
+  if (meta.total_pages > 0 && page > meta.total_pages) {
     const params = new URLSearchParams(preservedQuery);
     if (meta.total_pages > 1) params.set("page", String(meta.total_pages));
     const query = params.toString();

--- a/src/app/temples/[id]/__tests__/page.test.tsx
+++ b/src/app/temples/[id]/__tests__/page.test.tsx
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/api/error";
 
-const notFoundMock = vi.fn(() => {
-  throw new Error("NEXT_NOT_FOUND");
-});
-
-const getTempleMock = vi.fn();
-const authMock = vi.fn().mockResolvedValue(null);
+// vi.mock のファクトリは vi.mock 自体と共にホイストされる。top-level const を
+// 直接参照すると TDZ に当たる恐れがあるため、共有 fake は vi.hoisted() で先に作る。
+const { notFoundMock, getTempleMock, authMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  getTempleMock: vi.fn(),
+  authMock: vi.fn().mockResolvedValue(null),
+}));
 
 vi.mock("next/navigation", () => ({
   notFound: notFoundMock,

--- a/src/app/temples/[id]/__tests__/page.test.tsx
+++ b/src/app/temples/[id]/__tests__/page.test.tsx
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api/error";
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+const getTempleMock = vi.fn();
+const authMock = vi.fn().mockResolvedValue(null);
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+  redirect: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getTemple: getTempleMock,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+beforeEach(() => {
+  notFoundMock.mockClear();
+  getTempleMock.mockReset();
+});
+
+describe("/temples/[id] page — SSR 境界", () => {
+  it("getTemple が ApiError(404) を投げると notFound() が呼ばれる", async () => {
+    getTempleMock.mockRejectedValueOnce(new ApiError(404, null));
+    const { default: Page } = await import("@/app/temples/[id]/page");
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "999" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("404 以外のエラーは notFound を呼ばずに伝播する", async () => {
+    getTempleMock.mockRejectedValueOnce(new ApiError(500, null));
+    const { default: Page } = await import("@/app/temples/[id]/page");
+
+    await expect(
+      Page({ params: Promise.resolve({ id: "1" }) }),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/temples/__tests__/page.test.tsx
+++ b/src/app/temples/__tests__/page.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redirectMock = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+
+const getTemplesMock = vi.fn();
+const getAreasMock = vi.fn().mockResolvedValue({ areas: [] });
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getTemples: getTemplesMock,
+    getAreas: getAreasMock,
+  };
+});
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  getTemplesMock.mockReset();
+});
+
+describe("/temples page — SSR 境界", () => {
+  it("page= が total_pages を超えると最終ページへ redirect する", async () => {
+    getTemplesMock.mockResolvedValueOnce({
+      temples: [],
+      meta: { current_page: 4, total_pages: 4, total_count: 40 },
+    });
+    const { default: Page } = await import("@/app/temples/page");
+
+    await expect(
+      Page({ searchParams: Promise.resolve({ page: "10" }) }),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(redirectMock).toHaveBeenCalledWith("/temples?page=4");
+  });
+
+  it("total_pages が 0 のときは redirect しない（ループ防止）", async () => {
+    getTemplesMock.mockResolvedValueOnce({
+      temples: [],
+      meta: { current_page: 1, total_pages: 0, total_count: 0 },
+    });
+    const { default: Page } = await import("@/app/temples/page");
+
+    await Page({ searchParams: Promise.resolve({ page: "5" }) });
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("検索条件付きで範囲外の page= を指定しても q / area が保持される", async () => {
+    getTemplesMock.mockResolvedValueOnce({
+      temples: [],
+      meta: { current_page: 2, total_pages: 2, total_count: 20 },
+    });
+    const { default: Page } = await import("@/app/temples/page");
+
+    await expect(
+      Page({
+        searchParams: Promise.resolve({ page: "9", q: "清水", area: "1" }),
+      }),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const target = redirectMock.mock.calls[0][0] as string;
+    const url = new URL(target, "http://localhost");
+    expect(url.searchParams.get("page")).toBe("2");
+    expect(url.searchParams.get("q")).toBe("清水");
+    expect(url.searchParams.get("area")).toBe("1");
+  });
+});

--- a/src/app/temples/__tests__/page.test.tsx
+++ b/src/app/temples/__tests__/page.test.tsx
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const redirectMock = vi.fn((url: string) => {
-  throw new Error(`NEXT_REDIRECT:${url}`);
-});
-
-const getTemplesMock = vi.fn();
-const getAreasMock = vi.fn().mockResolvedValue({ areas: [] });
+// vi.mock のファクトリは vi.mock 自体と共にホイストされる。top-level const を
+// 直接参照すると TDZ に当たる恐れがあるため、共有 fake は vi.hoisted() で先に作る。
+const { redirectMock, getTemplesMock, getAreasMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+  getTemplesMock: vi.fn(),
+  getAreasMock: vi.fn().mockResolvedValue({ areas: [] }),
+}));
 
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CommentSection from "@/components/common/CommentSection";
+import { server } from "@tests/msw/server";
+import type { Comment } from "@/types";
+
+const useSessionMock = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+});
+
+function mockLoggedIn() {
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+}
+
+function mockLoggedOut() {
+  useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+}
+
+const baseComment = (overrides: Partial<Comment> = {}): Comment => ({
+  id: 1,
+  body: "おいしかった",
+  user: { id: 10, name: "ゲスト" },
+  created_at: "2026-05-01T00:00:00Z",
+  owned_by_current_user: false,
+  ...overrides,
+});
+
+describe("CommentSection", () => {
+  it("未ログインだとフォームが「ログインが必要」案内に置き換わる", () => {
+    mockLoggedOut();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    expect(
+      screen.getByText(/コメントの投稿にはログインが必要/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: /コメントを書く/ }),
+    ).not.toBeInTheDocument();
+    const loginLink = screen.getByRole("link", { name: /ログインへ/ });
+    expect(loginLink).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
+  it("空白のみは送信ボタンが disabled", async () => {
+    mockLoggedIn();
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    const submit = screen.getByRole("button", { name: /投稿する/ });
+    expect(submit).toBeDisabled();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "   ",
+    );
+    expect(submit).toBeDisabled();
+  });
+
+  it("500 文字超で文字数カウンタが警告色になり、送信ボタンが disabled になる", async () => {
+    mockLoggedIn();
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox", { name: /コメントを書く/ });
+    await user.click(textarea);
+    // userEvent.type は 500 文字で遅いので fireEvent 経由で一発入力する
+    const longText = "あ".repeat(501);
+    // React の制御コンポーネントへ value を直接流し込む
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(textarea, longText);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const counter = screen.getByText(/501 \/ 500/);
+    expect(counter).toHaveClass("text-bengara");
+    expect(screen.getByRole("button", { name: /投稿する/ })).toBeDisabled();
+  });
+
+  it("投稿成功時はリスト先頭に追加される", async () => {
+    mockLoggedIn();
+    server.use(
+      http.post(endpoint("/greenteacomments"), async ({ request }) => {
+        const body = (await request.json()) as { body: string };
+        return HttpResponse.json({
+          comment: {
+            id: 200,
+            body: body.body,
+            user: { id: 10, name: "わたし" },
+            created_at: "2026-06-01T00:00:00Z",
+          },
+        });
+      }),
+    );
+
+    const existing = baseComment({ id: 1, body: "既存コメント" });
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[existing]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "新しい感想",
+    );
+    await user.click(screen.getByRole("button", { name: /投稿する/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("新しい感想")).toBeInTheDocument();
+    });
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("新しい感想");
+    expect(items[1]).toHaveTextContent("既存コメント");
+  });
+
+  it("自分のコメントだけ「削除」ボタンが表示される", () => {
+    mockLoggedIn();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 1, body: "他人", owned_by_current_user: false }),
+          baseComment({ id: 2, body: "自分", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(within(items[0]).queryByRole("button", { name: /削除/ })).toBeNull();
+    expect(
+      within(items[1]).getByRole("button", { name: /削除/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("削除すると確認ダイアログ後にリストから消える", async () => {
+    mockLoggedIn();
+    server.use(
+      http.delete(endpoint("/greenteacomments/2"), () =>
+        HttpResponse.text(null, { status: 204 }),
+      ),
+    );
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 2, body: "削除対象", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    expect(confirmSpy).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.queryByText("削除対象")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/まだコメントはありません/)).toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+
+  it("確認ダイアログをキャンセルすると削除されない", async () => {
+    mockLoggedIn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 2, body: "残す", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    expect(screen.getByText("残す")).toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CommentSection from "@/components/common/CommentSection";
 import { server } from "@tests/msw/server";
 import type { Comment } from "@/types";
@@ -18,6 +18,12 @@ const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
 beforeEach(() => {
   useSessionMock.mockReset();
+});
+
+// window.confirm 等の vi.spyOn を確実に元に戻す。アサーション失敗で
+// 各テスト末尾の mockRestore() に到達しなくても次テストにリークしない。
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 function mockLoggedIn() {
@@ -207,12 +213,11 @@ describe("CommentSection", () => {
       expect(screen.queryByText("削除対象")).not.toBeInTheDocument();
     });
     expect(screen.getByText(/まだコメントはありません/)).toBeInTheDocument();
-    confirmSpy.mockRestore();
   });
 
   it("確認ダイアログをキャンセルすると削除されない", async () => {
     mockLoggedIn();
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
     const user = userEvent.setup();
     render(
       <CommentSection
@@ -227,6 +232,5 @@ describe("CommentSection", () => {
 
     await user.click(screen.getByRole("button", { name: /削除/ }));
     expect(screen.getByText("残す")).toBeInTheDocument();
-    confirmSpy.mockRestore();
   });
 });

--- a/src/components/common/__tests__/LikeButton.test.tsx
+++ b/src/components/common/__tests__/LikeButton.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse, delay } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LikeButton from "@/components/common/LikeButton";
+import { server } from "@tests/msw/server";
+
+const pushMock = vi.fn();
+const useSessionMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+beforeEach(() => {
+  pushMock.mockReset();
+  useSessionMock.mockReset();
+});
+
+function mockLoggedIn() {
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+}
+
+function mockLoggedOut() {
+  useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+}
+
+describe("LikeButton", () => {
+  it("未ログインでクリックすると /auth/login?callbackUrl=... に遷移する", async () => {
+    mockLoggedOut();
+    const user = userEvent.setup();
+    render(
+      <LikeButton
+        kind="greentea"
+        id={1}
+        initialCount={3}
+        initialLiked={false}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
+  it("ログイン済でクリックすると即座にカウントが +1 される（楽観的更新）", async () => {
+    mockLoggedIn();
+    server.use(
+      http.post(endpoint("/greentea_likes"), async () => {
+        await delay(20);
+        return HttpResponse.json({
+          greentea_like: { id: 99, greentea_id: 1, user_id: 1 },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <LikeButton
+        kind="greentea"
+        id={1}
+        initialCount={3}
+        initialLiked={false}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button"));
+    // 楽観的更新は startTransition より前で行われるので、即時に 4 が見える。
+    expect(screen.getByRole("button")).toHaveTextContent("4");
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("API が 401 を返すとカウントがロールバックされ、ログイン誘導が走る", async () => {
+    mockLoggedIn();
+    server.use(
+      http.post(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <LikeButton
+        kind="greentea"
+        id={1}
+        initialCount={3}
+        initialLiked={false}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toHaveTextContent("3");
+    });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
+  it("API が 5xx を返すとカウントがロールバックされ、エラー表示が出て再押下可能になる", async () => {
+    mockLoggedIn();
+    server.use(
+      http.post(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <LikeButton
+        kind="greentea"
+        id={1}
+        initialCount={3}
+        initialLiked={false}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toHaveTextContent("3");
+    });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("alert")).toHaveTextContent(/通信に失敗/);
+    // pending が解除されてボタンが再押下可能
+    await waitFor(() => {
+      expect(screen.getByRole("button")).not.toBeDisabled();
+    });
+  });
+
+  it("連打しても二重リクエストが発生しない（loading 中は disabled）", async () => {
+    mockLoggedIn();
+    let calls = 0;
+    server.use(
+      http.post(endpoint("/temple_likes"), async () => {
+        calls += 1;
+        await delay(50);
+        return HttpResponse.json({
+          temple_like: { id: 1, temple_id: 5, user_id: 1 },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <LikeButton
+        kind="temple"
+        id={5}
+        initialCount={0}
+        initialLiked={false}
+        callbackUrl="/temples/5"
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    // 連打: 1 回目で startTransition が走り、以降は pending で弾かれる。
+    await user.click(button);
+    await user.click(button);
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+    });
+    expect(calls).toBe(1);
+  });
+});

--- a/src/components/common/__tests__/LikeButton.test.tsx
+++ b/src/components/common/__tests__/LikeButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse, delay } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -147,7 +147,7 @@ describe("LikeButton", () => {
     });
   });
 
-  it("連打しても二重リクエストが発生しない（loading 中は disabled）", async () => {
+  it("連打しても二重リクエストが発生しない（pending 立ち上がり前の同期連打も弾く）", async () => {
     mockLoggedIn();
     let calls = 0;
     server.use(
@@ -160,7 +160,6 @@ describe("LikeButton", () => {
       }),
     );
 
-    const user = userEvent.setup();
     render(
       <LikeButton
         kind="temple"
@@ -172,10 +171,14 @@ describe("LikeButton", () => {
     );
 
     const button = screen.getByRole("button");
-    // 連打: 1 回目で startTransition が走り、以降は pending で弾かれる。
-    await user.click(button);
-    await user.click(button);
-    await user.click(button);
+    // disabled が React 再レンダで立ち上がる前の同一イベントループでの連打を踏ませる。
+    // userEvent.click は await ごとに React のフラッシュを待つため、useTransition の
+    // pending=true が反映された 2 回目以降のクリックは disabled で弾かれてしまい、
+    // 「if (pending) return;」の早期 return ガード自体は通っていない。fireEvent で
+    // 同期的に 3 連射し、内部ガードが効くことを確認する。
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(button).not.toBeDisabled();

--- a/src/components/common/__tests__/LikedSpotsList.test.tsx
+++ b/src/components/common/__tests__/LikedSpotsList.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LikedSpotsList from "@/components/common/LikedSpotsList";
+
+const useSessionMock = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+});
+
+describe("LikedSpotsList — マイページの CSR ガード", () => {
+  it("未ログインでは「お気に入り一覧の表示にはログインが必要」案内とログインリンクを表示する", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<LikedSpotsList kind="greentea" />);
+
+    expect(
+      screen.getByText(/お気に入り一覧の表示にはログインが必要/),
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /ログインへ/ });
+    expect(link).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Fmypage%2Fgreentea-likes",
+    );
+  });
+
+  it("temple 種別では callbackUrl が /mypage/temple-likes になる", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<LikedSpotsList kind="temple" />);
+
+    const link = screen.getByRole("link", { name: /ログインへ/ });
+    expect(link).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Fmypage%2Ftemple-likes",
+    );
+  });
+});

--- a/src/components/common/__tests__/Pagination.test.tsx
+++ b/src/components/common/__tests__/Pagination.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Pagination from "@/components/common/Pagination";
+
+describe("Pagination", () => {
+  it("totalPages が 1 以下のときは何も描画しない", () => {
+    const { container } = render(
+      <Pagination basePath="/greenteas" currentPage={1} totalPages={1} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("現在ページは aria-current=\"page\" で表示され、リンクではない", () => {
+    render(
+      <Pagination basePath="/greenteas" currentPage={3} totalPages={5} />,
+    );
+
+    const current = screen.getByText("3", { selector: "[aria-current]" });
+    expect(current).toHaveAttribute("aria-current", "page");
+    expect(current.tagName).not.toBe("A");
+  });
+
+  it("1 ページ目では「前へ」が無効、最終ページでは「次へ」が無効", () => {
+    const { rerender } = render(
+      <Pagination basePath="/greenteas" currentPage={1} totalPages={5} />,
+    );
+
+    const prev1 = screen.getByText(/前へ/);
+    expect(prev1.tagName).toBe("SPAN");
+    expect(prev1).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText(/次へ/).tagName).toBe("A");
+
+    rerender(
+      <Pagination basePath="/greenteas" currentPage={5} totalPages={5} />,
+    );
+    expect(screen.getByText(/前へ/).tagName).toBe("A");
+    const next = screen.getByText(/次へ/);
+    expect(next.tagName).toBe("SPAN");
+    expect(next).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("preservedQuery がリンクの href に保持される", () => {
+    render(
+      <Pagination
+        basePath="/greenteas"
+        currentPage={2}
+        totalPages={5}
+        preservedQuery="q=中村&genre=3"
+      />,
+    );
+
+    const nextLink = screen.getByText(/次へ/);
+    const href = nextLink.getAttribute("href") ?? "";
+    expect(href.startsWith("/greenteas?")).toBe(true);
+    const url = new URL(href, "http://localhost");
+    expect(url.searchParams.get("q")).toBe("中村");
+    expect(url.searchParams.get("genre")).toBe("3");
+    expect(url.searchParams.get("page")).toBe("3");
+  });
+
+  it("1 ページ目に戻るリンクには page= を付けない", () => {
+    render(
+      <Pagination
+        basePath="/greenteas"
+        currentPage={2}
+        totalPages={5}
+        preservedQuery="q=辻利"
+      />,
+    );
+
+    const prevLink = screen.getByText(/前へ/);
+    expect(prevLink.tagName).toBe("A");
+    const href = prevLink.getAttribute("href") ?? "";
+    const url = new URL(href, "http://localhost");
+    expect(url.searchParams.has("page")).toBe(false);
+    expect(url.searchParams.get("q")).toBe("辻利");
+  });
+
+  it("ページ数が多いと先頭ページと省略記号が描画される", () => {
+    render(
+      <Pagination basePath="/greenteas" currentPage={7} totalPages={10} />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /ページネーション/ });
+    expect(within(nav).getByText("1").tagName).toBe("A");
+    expect(within(nav).getAllByText("…").length).toBeGreaterThanOrEqual(1);
+    expect(within(nav).getByText("10").tagName).toBe("A");
+  });
+});

--- a/src/components/greentea/__tests__/GreenteaSearchForm.test.tsx
+++ b/src/components/greentea/__tests__/GreenteaSearchForm.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GreenteaSearchForm from "@/components/greentea/GreenteaSearchForm";
+import type { Genre } from "@/types";
+
+const pushMock = vi.fn();
+let currentSearch = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+const genres: Genre[] = [
+  { id: 1, name: "スイーツ" },
+  { id: 3, name: "カフェ" },
+];
+
+beforeEach(() => {
+  pushMock.mockReset();
+  currentSearch = "";
+});
+
+describe("GreenteaSearchForm", () => {
+  it("検索を実行すると router.push が ?q=... 付き URL で呼ばれる", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaSearchForm genres={genres} />);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /キーワード/ }),
+      "中村",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const arg = pushMock.mock.calls[0][0];
+    expect(arg.startsWith("/greenteas?")).toBe(true);
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.get("q")).toBe("中村");
+  });
+
+  it("条件変更時に page は付かない（1 ページ目に戻る）", async () => {
+    // 既存 URL に page= が乗っている状態
+    currentSearch = "page=4";
+    const user = userEvent.setup();
+    render(<GreenteaSearchForm genres={genres} />);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /キーワード/ }),
+      "辻利",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    const arg = pushMock.mock.calls[0][0];
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.has("page")).toBe(false);
+    expect(url.searchParams.get("q")).toBe("辻利");
+  });
+
+  it("ジャンル選択も q に乗る", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaSearchForm genres={genres} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /ジャンル/ }),
+      "3",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    const arg = pushMock.mock.calls[0][0];
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.get("genre")).toBe("3");
+  });
+
+  it("クリアボタンで q / genre が消える", async () => {
+    currentSearch = "q=中村&genre=3";
+    const user = userEvent.setup();
+    render(<GreenteaSearchForm genres={genres} />);
+
+    // クリアボタンは hasFilter が true のときだけ表示される
+    await user.click(screen.getByRole("button", { name: "クリア" }));
+
+    expect(pushMock).toHaveBeenCalledWith("/greenteas");
+  });
+
+  it("条件未設定では空クエリでベース URL に遷移する", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaSearchForm genres={genres} />);
+
+    await user.click(screen.getByRole("button", { name: "検索" }));
+    expect(pushMock).toHaveBeenCalledWith("/greenteas");
+  });
+});

--- a/src/components/temple/__tests__/TempleSearchForm.test.tsx
+++ b/src/components/temple/__tests__/TempleSearchForm.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TempleSearchForm from "@/components/temple/TempleSearchForm";
+import type { Area } from "@/types";
+
+const pushMock = vi.fn();
+let currentSearch = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+const areas: Area[] = [
+  { id: 1, name: "東山" },
+  { id: 2, name: "嵐山" },
+];
+
+beforeEach(() => {
+  pushMock.mockReset();
+  currentSearch = "";
+});
+
+describe("TempleSearchForm", () => {
+  it("検索でキーワードが URL に乗る", async () => {
+    const user = userEvent.setup();
+    render(<TempleSearchForm areas={areas} />);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /キーワード/ }),
+      "清水",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    const arg = pushMock.mock.calls[0][0];
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.get("q")).toBe("清水");
+  });
+
+  it("条件変更時に page は引き継がない", async () => {
+    currentSearch = "page=4";
+    const user = userEvent.setup();
+    render(<TempleSearchForm areas={areas} />);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /キーワード/ }),
+      "八坂",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    const arg = pushMock.mock.calls[0][0];
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.has("page")).toBe(false);
+  });
+
+  it("エリア選択が URL に乗る", async () => {
+    const user = userEvent.setup();
+    render(<TempleSearchForm areas={areas} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /エリア/ }),
+      "2",
+    );
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    const arg = pushMock.mock.calls[0][0];
+    const url = new URL(arg, "http://localhost");
+    expect(url.searchParams.get("area")).toBe("2");
+  });
+
+  it("クリアで q / area が消える", async () => {
+    currentSearch = "q=清水&area=1";
+    const user = userEvent.setup();
+    render(<TempleSearchForm areas={areas} />);
+
+    await user.click(screen.getByRole("button", { name: "クリア" }));
+    expect(pushMock).toHaveBeenCalledWith("/temples");
+  });
+});


### PR DESCRIPTION
## 概要

`docs/test-plan.md` の **Phase 2（優先度 B）+ Phase 3（優先度 C、最小ケース）** をカバーするテストを追加。

Phase 1（#45）でカバーした API 層／純粋ロジックの上に、状態遷移バグが出やすい Client Component 4 種と、SSR ルーティングの境界（`notFound` / `redirect`）を CI で押さえる。

Closes #46

## 追加したテスト

### Phase 2 — Client Component
- **`LikeButton`** (`src/components/common/__tests__/LikeButton.test.tsx`)
  - 未ログインで `/auth/login?callbackUrl=...` に遷移
  - ログイン済で楽観的更新（カウント即時 +1）
  - API が 401 → ロールバック + ログイン誘導
  - API が 5xx → ロールバック + エラー表示 + 再押下可能
  - 連打しても二重リクエストなし
- **`CommentSection`** (`src/components/common/__tests__/CommentSection.test.tsx`)
  - 未ログイン → 投稿フォームが「ログインが必要」案内に置換
  - 空白のみは submit disabled
  - 500 文字超で文字数カウンタが `text-bengara`、submit disabled
  - 投稿成功 → リスト先頭に追加
  - `owned_by_current_user` の真偽で削除ボタン出し分け
  - `window.confirm` 経由の削除 / キャンセル
- **`Pagination`** (`src/components/common/__tests__/Pagination.test.tsx`)
  - `totalPages<=1` で非描画
  - 現在ページが `aria-current="page"`
  - 端ページで前/次が disabled
  - `preservedQuery` がリンクに保持
  - `page=1` に戻るリンクには `page=` を付けない
  - 中央付近で先頭ページ + `…` を描画
- **`GreenteaSearchForm` / `TempleSearchForm`** (`src/components/{greentea,temple}/__tests__/*.test.tsx`)
  - 検索で `router.push` に `?q=...` 反映
  - 条件変更で `page` が引き継がれない（1 ページ目に戻る）
  - ジャンル／エリア選択が URL に乗る
  - クリアボタンで `q` / `genre|area` が消える

### Phase 3 — SSR 境界
- **`/greenteas/[id]` / `/temples/[id]`** — `ApiError(404)` で `notFound()` 呼び出し、500 は伝播
- **`/greenteas` / `/temples`** — `searchParams.page > total_pages` で最終ページへ `redirect`、`q` / `genre|area` を保持、`total_pages=0` で redirect ループを起こさない
- **`LikedSpotsList`** — `/mypage/{greentea,temple}-likes` の未ログイン CSR ガード（callbackUrl 付き誘導）

## モック戦略

- `next-auth/react` の `useSession` を `vi.mock` で差し替え
- `next/navigation` の `useRouter` / `useSearchParams` / `notFound` / `redirect` を `vi.mock` で差し替え。`notFound` / `redirect` は throw する sentinel として spy し、呼ばれたことを `rejects.toThrow` で検知
- Server Component は MSW ではなく `vi.mock("@/lib/api")` で fetcher を差し替えて引数のレスポンスを返す
- HTTP は MSW ハンドラ（Phase 1 で整備済み）を再利用

## 結果

- `npm test` ＝ **118 件 green**（baseline 79 + 新規 39）
- `npm run lint` ＝ 0 warnings/errors
- `npx tsc --noEmit` ＝ 0 errors

## Test plan
- [x] `npm test` で全件 green
- [x] `npm run lint` で警告なし
- [x] `npx tsc --noEmit` でエラーなし
- [x] テスト対象 4 コンポーネント × 4〜6 ケース、SSR 境界 2〜3 ケースを満たす（issue 受け入れ条件）

https://claude.ai/code/session_01LY5x8XJGXQDMjCDY3bWJmk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY5x8XJGXQDMjCDY3bWJmk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for page navigation, pagination, and redirect behavior across the application
  * Added tests for user authentication flows, comment submissions, and like button interactions
  * Added tests for search form submissions, filters, and character limits
  * Added tests for component rendering and user interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->