### PR TITLE
test: Playwright E2E ゴールデンパス 3 シナリオを追加 (#47)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,37 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: e2e (playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1491,6 +1492,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6817,6 +6834,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@vis.gl/react-google-maps": "^1.8.3",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3000;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+// `next dev` を使う必要がある:
+// `src/lib/auth.ts` の mock Credentials provider は NODE_ENV !== "production" のときだけ
+// 有効化される。`next build && next start` だと NODE_ENV=production になり、
+// シナリオ C（mock ログイン）が通らない。
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_USE_MOCK: "true",
+      AUTH_SECRET: "test",
+      // 認証コールバックの URL 補完にも使われる。
+      NEXTAUTH_URL: BASE_URL,
+      PORT: String(PORT),
+    },
+  },
+});

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -8,11 +8,11 @@ test.describe("シナリオ A: トップ → 一覧 → 詳細", () => {
     page,
   }) => {
     await page.goto("/");
-    // トップにはワードマーク（alt="抹茶と神社。"）の Logo 画像が出る。
-    await expect(page.getByRole("img", { name: "抹茶と神社。" })).toBeVisible();
-
-    // トップの主要導線「抹茶スイーツを探す」から一覧へ。
-    await page.getByRole("link", { name: /抹茶スイーツを探す/ }).click();
+    // トップの主要導線「抹茶スイーツを探す」が出ること（ヘッダロゴと本文ロゴが
+    // 同じ alt を持ち strict mode に引っかかるため、ナビ導線で到達確認する）。
+    const enterLink = page.getByRole("link", { name: /抹茶スイーツを探す/ });
+    await expect(enterLink).toBeVisible();
+    await enterLink.click();
     await page.waitForURL("**/greenteas");
     await expect(
       page.getByRole("heading", { level: 1, name: "抹茶店をさがす" }),
@@ -72,9 +72,10 @@ test.describe("シナリオ C: mock ログイン → Like → お気に入り一
   }) => {
     // mock provider でログイン（NEXT_PUBLIC_USE_MOCK=true により有効化されている）。
     await page.goto("/auth/login");
-    await page
-      .getByRole("textbox", { name: /表示名/ })
-      .fill("テスター");
+    // 表示名はそのまま Authorization ヘッダの `mock:mock-<name>` に乗るため、
+    // 非 ASCII（例: 日本語）を入れると Headers.set が ByteString エラーになる。
+    // SSR ページ（/greenteas/[id]）の fetch で 500 になるので ASCII で入力する。
+    await page.getByRole("textbox", { name: /表示名/ }).fill("tester");
     await page.getByRole("button", { name: /モックでログイン/ }).click();
 
     // ログイン成功で /mypage へリダイレクト。

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -69,13 +69,18 @@ test.describe("シナリオ B: 検索フォームで URL と結果が絞り込�
 test.describe("シナリオ C: mock ログイン → Like → お気に入り一覧", () => {
   test("ログイン後の LikeButton トグルが /mypage/greentea-likes に反映される", async ({
     page,
-  }) => {
+  }, testInfo) => {
     // mock provider でログイン（NEXT_PUBLIC_USE_MOCK=true により有効化されている）。
     await page.goto("/auth/login");
     // 表示名はそのまま Authorization ヘッダの `mock:mock-<name>` に乗るため、
     // 非 ASCII（例: 日本語）を入れると Headers.set が ByteString エラーになる。
     // SSR ページ（/greenteas/[id]）の fetch で 500 になるので ASCII で入力する。
-    await page.getByRole("textbox", { name: /表示名/ }).fill("tester");
+    //
+    // モック store は globalThis に永続化されるため、固定名だと retry 時に
+    // 「既に like 済み」の状態から始まってしまい、`お気に入りに追加` ボタンが
+    // 出ず Playwright の retry で復帰できない。試行ごとに一意な名前を使う。
+    const displayName = `tester-${Date.now()}-${testInfo.retry}`;
+    await page.getByRole("textbox", { name: /表示名/ }).fill(displayName);
     await page.getByRole("button", { name: /モックでログイン/ }).click();
 
     // ログイン成功で /mypage へリダイレクト。
@@ -89,12 +94,23 @@ test.describe("シナリオ C: mock ログイン → Like → お気に入り一
     await expect(likeButton).toBeVisible();
     await likeButton.click();
     // 楽観的更新で aria-label が「解除」に切り替わる。
-    await expect(
-      page.getByRole("button", { name: "お気に入りを解除" }),
-    ).toBeVisible();
+    const unlikeButton = page.getByRole("button", { name: "お気に入りを解除" });
+    await expect(unlikeButton).toBeVisible();
+    // useTransition の async 完了を待つ（mock の store 反映を確実に）。
+    await expect(unlikeButton).toBeEnabled();
 
     // お気に入り一覧に反映される。
-    await page.goto("/mypage/greentea-likes");
+    //
+    // 注: モックの like state はブラウザの globalThis に乗っているため、
+    // page.goto による full reload では document が再ロードされて消える。
+    // /mypage/greentea-likes へは Next.js の soft navigation（Link クリック）
+    // で辿り、JS コンテキストを維持する。
+    await page
+      .getByRole("link", { name: "お気に入り", exact: true })
+      .click();
+    await page.waitForURL("**/mypage");
+    await page.getByRole("link", { name: /お気に入りの抹茶店/ }).click();
+    await page.waitForURL("**/mypage/greentea-likes");
     await expect(
       page.getByRole("heading", { level: 1, name: "抹茶店" }),
     ).toBeVisible();

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+// 最小ゴールデンパス。フル網羅は狙わない（docs/test-plan.md Phase 4）。
+// すべて NEXT_PUBLIC_USE_MOCK=true のモックモードで動作する想定。
+
+test.describe("シナリオ A: トップ → 一覧 → 詳細", () => {
+  test("トップから抹茶店一覧に遷移し、カードから詳細まで辿れる", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // トップにはワードマーク（alt="抹茶と神社。"）の Logo 画像が出る。
+    await expect(page.getByRole("img", { name: "抹茶と神社。" })).toBeVisible();
+
+    // トップの主要導線「抹茶スイーツを探す」から一覧へ。
+    await page.getByRole("link", { name: /抹茶スイーツを探す/ }).click();
+    await page.waitForURL("**/greenteas");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "抹茶店をさがす" }),
+    ).toBeVisible();
+
+    // 1 件目（茶寮都路里）の詳細へ。
+    await page.getByRole("link", { name: "茶寮都路里" }).first().click();
+    await page.waitForURL(/\/greenteas\/\d+$/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "茶寮都路里" }),
+    ).toBeVisible();
+    // 近隣神社セクションが存在する（建仁寺が 1.5km 圏内に入る seed）。
+    await expect(
+      page.getByRole("heading", { level: 2, name: /近くの神社仏閣/ }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("シナリオ B: 検索フォームで URL と結果が絞り込まれる", () => {
+  test("キーワード入力で ?q= が URL に反映され、件数表示が変わる", async ({
+    page,
+  }) => {
+    await page.goto("/greenteas");
+    // 絞り込み前は全 3 件。
+    await expect(page.getByText(/全\s*3\s*件/)).toBeVisible();
+
+    await page
+      .getByRole("searchbox", { name: /キーワード/ })
+      .fill("中村");
+    await page.getByRole("button", { name: "検索" }).click();
+
+    // URL に q が乗る（日本語はエンコードされる）。
+    await expect(page).toHaveURL(/\/greenteas\?q=/);
+    await expect(page).toHaveURL(/q=(%E4%B8%AD%E6%9D%91|中村)/);
+
+    // 中村藤吉本店のみ残る → 全 1 件。
+    await expect(page.getByText(/全\s*1\s*件/)).toBeVisible();
+    await expect(
+      page.getByText("キーワード: 「中村」", { exact: false }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "中村藤吉本店" })).toBeVisible();
+
+    // クリアボタンで条件解除 → 全件に戻る。
+    await page.getByRole("button", { name: "クリア" }).click();
+    await expect(page).toHaveURL(/\/greenteas$/);
+    await expect(page.getByText(/全\s*3\s*件/)).toBeVisible();
+
+    // 注: モックの greentea は 3 件 / PER_PAGE=12 のため、Pagination は
+    // 描画されない（totalPages <= 1）。ページネーション保持の挙動は
+    // Pagination の単体テスト（src/components/common/__tests__/）でカバーする。
+  });
+});
+
+test.describe("シナリオ C: mock ログイン → Like → お気に入り一覧", () => {
+  test("ログイン後の LikeButton トグルが /mypage/greentea-likes に反映される", async ({
+    page,
+  }) => {
+    // mock provider でログイン（NEXT_PUBLIC_USE_MOCK=true により有効化されている）。
+    await page.goto("/auth/login");
+    await page
+      .getByRole("textbox", { name: /表示名/ })
+      .fill("テスター");
+    await page.getByRole("button", { name: /モックでログイン/ }).click();
+
+    // ログイン成功で /mypage へリダイレクト。
+    await page.waitForURL("**/mypage", { timeout: 15_000 });
+
+    // 詳細ページで LikeButton を押下。
+    await page.goto("/greenteas/1");
+    const likeButton = page.getByRole("button", {
+      name: "お気に入りに追加",
+    });
+    await expect(likeButton).toBeVisible();
+    await likeButton.click();
+    // 楽観的更新で aria-label が「解除」に切り替わる。
+    await expect(
+      page.getByRole("button", { name: "お気に入りを解除" }),
+    ).toBeVisible();
+
+    // お気に入り一覧に反映される。
+    await page.goto("/mypage/greentea-likes");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "抹茶店" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "茶寮都路里" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

`docs/test-plan.md` Phase 4 / Issue #47 に従い、Playwright を導入し、`NEXT_PUBLIC_USE_MOCK=true` のモックモードで起動した Next.js に対する最小ゴールデンパス 3 シナリオを CI に乗せます。

Closes #47

## 変更点

### セットアップ
- `@playwright/test` を devDependencies に追加
- `package.json` に `"test:e2e": "playwright test"` を追加
- `playwright.config.ts` を新規作成
  - `testDir: "./tests/e2e"`
  - `webServer.command: "npm run dev"` ＋ `env: { NEXT_PUBLIC_USE_MOCK: "true", AUTH_SECRET: "test", NEXTAUTH_URL, PORT }`
  - **`next dev` を使う理由**: `src/lib/auth.ts` の mock Credentials provider は `NODE_ENV !== "production"` のみ有効。`next build && next start` だとシナリオ C（mock ログイン）が通らない（issue 本文 / `docs/test-plan.md` Phase 4 のメモ参照）
  - `reuseExistingServer: !process.env.CI`
  - 失敗時に trace / screenshot を残す
- `.gitignore` に Playwright のアーティファクト（`test-results` / `playwright-report` / `blob-report` / `playwright/.cache`）を追記

### シナリオ（`tests/e2e/golden-path.spec.ts`）

#### A. トップ → 一覧 → 詳細
- `/` → 「抹茶スイーツを探す」リンク → `/greenteas` 表示
- カード「茶寮都路里」クリック → `/greenteas/1` 表示
- 「近くの神社仏閣」セクションが表示される

#### B. 検索フォームで URL と結果が絞り込まれる
- 絞り込み前は「全 3 件」
- キーワード「中村」入力 → URL に `?q=...` が反映
- 「全 1 件」に絞り込まれ、ヘッダーに「キーワード: 「中村」」が出る
- クリアボタンで `/greenteas` に戻り全件表示

> 注: モックの greentea は 3 件 / `PER_PAGE=12` のため Pagination は描画されない（`totalPages <= 1`）。「ページネーション時に q を保持」の挙動は #46 で `Pagination` の単体テストとして既にカバー済みのため、E2E では検索フィルタの反映までを担保する。

#### C. mock ログイン → LikeButton トグル → お気に入り一覧
- `/auth/login` で表示名を入力して「モックでログイン」 → `/mypage` へ
- `/greenteas/1` で `aria-label="お気に入りに追加"` ボタンを押下
- 楽観的更新で `aria-label="お気に入りを解除"` に切り替わる
- `/mypage/greentea-likes` に遷移 → 「茶寮都路里」が並ぶ

### CI（`.github/workflows/test.yml`）
- 既存の `ci`（lint / test / build）ジョブと並列で `e2e` ジョブを追加
- `npm ci` → `npx playwright install --with-deps chromium` → `npm run test:e2e`
- 失敗時に `playwright-report/` と `test-results/` を artifact としてアップロード（保持 14 日）

## スコープ外（issue に従う）

- Google Maps の実描画確認
- Rails 連携後の結合 E2E（Rails #15 / #16 完成後に別途）
- ビジュアル回帰テスト

## 動作確認

- [x] `npx playwright test --list` で 3 件検出
- [x] `npm run lint` ✅
- [x] `npx tsc --noEmit` ✅
- [x] 既存ユニットテスト `npm test` 119 件 ✅
- [ ] ローカル `npm run test:e2e` の green 確認 — 当作業環境はサンドボックスでブラウザ DL が拒否されるため未確認。**初回 CI 実行で全シナリオ green になることを要確認**
- [ ] CI の E2E ジョブが green
- [ ] 失敗時に trace.zip が artifact として残ることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGSt1gdcQDRrZpBsfn1NLx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced comprehensive end-to-end testing suite covering critical user workflows including navigation, search filtering, user authentication, and favorites management
  * Configured GitHub Actions CI to automatically run end-to-end tests on every build and archive test reports for quality assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->