### PR TITLE
[Next.js] 書き込み系 API のエラーハンドリング統一 + MSW 回帰テスト基盤（#51 先行分）

### DIFF
--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -4,11 +4,14 @@ import Link from "next/link";
 import { useState, useTransition } from "react";
 import { HiTrash } from "react-icons/hi2";
 import {
-  ApiError,
   createGreenteaComment,
   createTempleComment,
   deleteGreenteaComment,
   deleteTempleComment,
+  getApiErrorMessage,
+  isForbidden,
+  isUnauthorized,
+  isValidationError,
 } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
 import type { Comment } from "@/types";
@@ -69,8 +72,12 @@ export default function CommentSection({
         ]);
         setBody("");
       } catch (e) {
-        if (e instanceof ApiError && e.status === 401) {
+        if (isUnauthorized(e)) {
           setSubmitError("ログインの有効期限が切れました。再度ログインしてください。");
+          return;
+        }
+        if (isValidationError(e)) {
+          setSubmitError(getApiErrorMessage(e, "投稿内容を確認してください。"));
           return;
         }
         setSubmitError("投稿に失敗しました。時間を置いてお試しください。");
@@ -97,11 +104,11 @@ export default function CommentSection({
         }
       } catch (e) {
         setComments(snapshot);
-        if (e instanceof ApiError && e.status === 401) {
+        if (isUnauthorized(e)) {
           setDeleteError("ログインが必要です。");
           return;
         }
-        if (e instanceof ApiError && e.status === 403) {
+        if (isForbidden(e)) {
           setDeleteError("このコメントを削除する権限がありません。");
           return;
         }

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { HiHeart, HiOutlineHeart } from "react-icons/hi2";
 import {
-  ApiError,
+  isUnauthorized,
   likeGreentea,
   likeTemple,
   unlikeGreentea,
@@ -63,7 +63,7 @@ export default function LikeButton({
       } catch (e) {
         setLiked(prevLiked);
         setCount(prevCount);
-        if (e instanceof ApiError && e.status === 401) {
+        if (isUnauthorized(e)) {
           router.push(
             `/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`,
           );

--- a/src/components/common/LikedSpotsList.tsx
+++ b/src/components/common/LikedSpotsList.tsx
@@ -8,6 +8,7 @@ import {
   ApiError,
   getGreenteaLikes,
   getTempleLikes,
+  isUnauthorized,
 } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
 import type {
@@ -62,10 +63,9 @@ export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
   }
 
   if (error) {
-    const msg =
-      error instanceof ApiError && error.status === 401
-        ? "ログインの有効期限が切れました。再度ログインしてください。"
-        : "お気に入りの取得に失敗しました。時間を置いてお試しください。";
+    const msg = isUnauthorized(error)
+      ? "ログインの有効期限が切れました。再度ログインしてください。"
+      : "お気に入りの取得に失敗しました。時間を置いてお試しください。";
     return (
       <p role="alert" className="font-sans-jp text-xs text-bengara">
         {msg}

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CommentSection from "@/components/common/CommentSection";
 import { server } from "@tests/msw/server";
+import { commentDeleted, writeError } from "@tests/msw/writeApiHandlers";
 import type { Comment } from "@/types";
 
 const useSessionMock = vi.fn();
@@ -164,6 +165,64 @@ describe("CommentSection", () => {
     expect(items[1]).toHaveTextContent("既存コメント");
   });
 
+  it("投稿が 422 だとサーバーのバリデーションメッセージを表示する", async () => {
+    mockLoggedIn();
+    server.use(
+      writeError("post", "greenteacomments", 422, {
+        errors: ["本文を入力してください"],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "ng",
+    );
+    await user.click(screen.getByRole("button", { name: /投稿する/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "本文を入力してください",
+      );
+    });
+    // 楽観追加していないので、リストは空のまま。
+    expect(screen.getByText(/まだコメントはありません/)).toBeInTheDocument();
+  });
+
+  it("投稿が 401 だと再ログイン案内を表示する", async () => {
+    mockLoggedIn();
+    server.use(writeError("post", "greenteacomments", 401));
+
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "感想",
+    );
+    await user.click(screen.getByRole("button", { name: /投稿する/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/再度ログイン/);
+    });
+  });
+
   it("自分のコメントだけ「削除」ボタンが表示される", () => {
     mockLoggedIn();
     render(
@@ -187,11 +246,7 @@ describe("CommentSection", () => {
 
   it("削除すると確認ダイアログ後にリストから消える", async () => {
     mockLoggedIn();
-    server.use(
-      http.delete(endpoint("/greenteacomments/2"), () =>
-        HttpResponse.text(null, { status: 204 }),
-      ),
-    );
+    server.use(commentDeleted("greentea"));
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const user = userEvent.setup();
@@ -232,5 +287,31 @@ describe("CommentSection", () => {
 
     await user.click(screen.getByRole("button", { name: /削除/ }));
     expect(screen.getByText("残す")).toBeInTheDocument();
+  });
+
+  it("他人のコメント削除で 403 が返るとロールバックして権限エラーを表示する", async () => {
+    mockLoggedIn();
+    server.use(writeError("delete", "greenteacomments", 403));
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 2, body: "消せない", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/権限がありません/);
+    });
+    // ロールバックされ、コメントは残る。
+    expect(screen.getByText("消せない")).toBeInTheDocument();
   });
 });

--- a/src/lib/api/__tests__/error.test.ts
+++ b/src/lib/api/__tests__/error.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  ApiError,
+  getApiErrorMessage,
+  getErrorData,
+  getErrorStatus,
+  isForbidden,
+  isUnauthorized,
+  isValidationError,
+} from "@/lib/api/error";
+
+describe("error ユーティリティ", () => {
+  describe("getErrorStatus / getErrorData", () => {
+    it("ApiError から status と data を取り出す", () => {
+      const err = new ApiError(422, { errors: ["x"] });
+      expect(getErrorStatus(err)).toBe(422);
+      expect(getErrorData(err)).toEqual({ errors: ["x"] });
+    });
+
+    it("ApiError 以外（ネットワーク断等）では null を返す", () => {
+      expect(getErrorStatus(new Error("network"))).toBeNull();
+      expect(getErrorStatus("boom")).toBeNull();
+      expect(getErrorData(new Error("network"))).toBeNull();
+    });
+  });
+
+  describe("isUnauthorized / isForbidden / isValidationError", () => {
+    it("対応する status のときだけ true", () => {
+      expect(isUnauthorized(new ApiError(401, null))).toBe(true);
+      expect(isUnauthorized(new ApiError(403, null))).toBe(false);
+      expect(isForbidden(new ApiError(403, null))).toBe(true);
+      expect(isForbidden(new ApiError(401, null))).toBe(false);
+      expect(isValidationError(new ApiError(422, null))).toBe(true);
+      expect(isValidationError(new ApiError(500, null))).toBe(false);
+    });
+
+    it("ApiError 以外は常に false", () => {
+      expect(isUnauthorized(new Error("x"))).toBe(false);
+      expect(isForbidden(undefined)).toBe(false);
+      expect(isValidationError(null)).toBe(false);
+    });
+  });
+
+  describe("getApiErrorMessage", () => {
+    it("{ errors: [...] } を ' / ' で連結する", () => {
+      const err = new ApiError(422, {
+        errors: ["本文を入力してください", "500文字以内にしてください"],
+      });
+      expect(getApiErrorMessage(err, "fallback")).toBe(
+        "本文を入力してください / 500文字以内にしてください",
+      );
+    });
+
+    it("{ error: '...' } / { message: '...' } を拾う", () => {
+      expect(getApiErrorMessage(new ApiError(422, { error: "だめ" }), "fb")).toBe(
+        "だめ",
+      );
+      expect(
+        getApiErrorMessage(new ApiError(422, { message: "むり" }), "fb"),
+      ).toBe("むり");
+    });
+
+    it("errors が空配列・非文字列のみなら fallback", () => {
+      expect(getApiErrorMessage(new ApiError(422, { errors: [] }), "fb")).toBe(
+        "fb",
+      );
+      expect(
+        getApiErrorMessage(new ApiError(422, { errors: [1, 2] }), "fb"),
+      ).toBe("fb");
+    });
+
+    it("ボディが無い / ApiError 以外なら fallback", () => {
+      expect(getApiErrorMessage(new ApiError(500, null), "fb")).toBe("fb");
+      expect(getApiErrorMessage(new Error("network"), "fb")).toBe("fb");
+    });
+  });
+});

--- a/src/lib/api/__tests__/error.test.ts
+++ b/src/lib/api/__tests__/error.test.ts
@@ -7,7 +7,7 @@ import {
   isForbidden,
   isUnauthorized,
   isValidationError,
-} from "@/lib/api/error";
+} from "../error";
 
 describe("error ユーティリティ", () => {
   describe("getErrorStatus / getErrorData", () => {

--- a/src/lib/api/error.ts
+++ b/src/lib/api/error.ts
@@ -9,3 +9,44 @@ export class ApiError extends Error {
     this.data = data;
   }
 }
+
+// ネットワーク断や予期しない例外（ApiError 以外）では null を返す。
+// 呼び出し側は「status が取れない＝通信レベルの失敗」として扱える。
+export function getErrorStatus(error: unknown): number | null {
+  return error instanceof ApiError ? error.status : null;
+}
+
+export function getErrorData(error: unknown): unknown {
+  return error instanceof ApiError ? error.data : null;
+}
+
+export function isUnauthorized(error: unknown): boolean {
+  return getErrorStatus(error) === 401;
+}
+
+export function isForbidden(error: unknown): boolean {
+  return getErrorStatus(error) === 403;
+}
+
+export function isValidationError(error: unknown): boolean {
+  return getErrorStatus(error) === 422;
+}
+
+// Rails のエラーボディから表示用メッセージを取り出す。
+// 形式ゆれ（{ errors: [...] } / { error: "..." } / { message: "..." }）を吸収し、
+// どれにも当てはまらなければ fallback を返す。
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+  const data = getErrorData(error);
+  if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    if (Array.isArray(obj.errors)) {
+      const messages = obj.errors.filter(
+        (e): e is string => typeof e === "string",
+      );
+      if (messages.length > 0) return messages.join(" / ");
+    }
+    if (typeof obj.error === "string") return obj.error;
+    if (typeof obj.message === "string") return obj.message;
+  }
+  return fallback;
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,5 +1,13 @@
 export { apiClient, buildQuery, ApiError } from "./client";
 export type { ApiClientOptions } from "./client";
+export {
+  getErrorStatus,
+  getErrorData,
+  isUnauthorized,
+  isForbidden,
+  isValidationError,
+  getApiErrorMessage,
+} from "./error";
 export { getGreenteas, getGreentea } from "./greenteas";
 export type { GreenteaSearchParams } from "./greenteas";
 export { getTemples, getTemple } from "./temples";

--- a/tests/msw/writeApiHandlers.ts
+++ b/tests/msw/writeApiHandlers.ts
@@ -1,0 +1,78 @@
+import { delay, http, HttpResponse } from "msw";
+
+// 書き込み系 API（likes / comments）の MSW ハンドラを生成するファクトリ群。
+// グローバルには登録せず、各テストが `server.use(...)` で必要なケースだけ
+// オプトインする（handlers.ts の「原則空」方針を踏襲）。
+// ハッピーパスと 401 / 403 / 422 / 5xx を一箇所で再現し、実 Rails API に
+// 繋ぎ込む際の回帰防止の土台にする。
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+export const apiUrl = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+type Kind = "greentea" | "temple";
+
+export type WriteResource =
+  | "greentea_likes"
+  | "temple_likes"
+  | "greenteacomments"
+  | "templecomments";
+
+const likeResource = (kind: Kind): WriteResource =>
+  kind === "greentea" ? "greentea_likes" : "temple_likes";
+
+const commentResource = (kind: Kind): WriteResource =>
+  kind === "greentea" ? "greenteacomments" : "templecomments";
+
+// いいね POST 成功。delayMs を渡すと、楽観的更新 → 確定の順序検証に使える。
+export function likeCreated(kind: Kind, opts: { delayMs?: number } = {}) {
+  const key = kind === "greentea" ? "greentea_like" : "temple_like";
+  const idKey = kind === "greentea" ? "greentea_id" : "temple_id";
+  return http.post(apiUrl(`/${likeResource(kind)}`), async () => {
+    if (opts.delayMs) await delay(opts.delayMs);
+    return HttpResponse.json({ [key]: { id: 99, [idKey]: 1, user_id: 1 } });
+  });
+}
+
+// いいね削除 成功（204 No Content）。
+export function likeDeleted(kind: Kind) {
+  return http.delete(apiUrl(`/${likeResource(kind)}/:id`), () =>
+    HttpResponse.text(null, { status: 204 }),
+  );
+}
+
+// コメント投稿 成功。リクエスト body をそのまま返し、実 API 形状に合わせる。
+export function commentCreated(kind: Kind) {
+  return http.post(apiUrl(`/${commentResource(kind)}`), async ({ request }) => {
+    const payload = (await request.json()) as { body: string };
+    return HttpResponse.json({
+      comment: {
+        id: 200,
+        body: payload.body,
+        user: { id: 10, name: "わたし" },
+        created_at: "2026-06-01T00:00:00Z",
+      },
+    });
+  });
+}
+
+// コメント削除 成功（204 No Content）。
+export function commentDeleted(kind: Kind) {
+  return http.delete(apiUrl(`/${commentResource(kind)}/:id`), () =>
+    HttpResponse.text(null, { status: 204 }),
+  );
+}
+
+// 任意の書き込み系エンドポイントを指定ステータスで失敗させる。
+// 401 / 403 / 422 / 5xx の回帰ケースを共通化する。
+// body は Rails のバリデーションエラー形（{ errors: [...] }）を既定とする。
+export function writeError(
+  method: "post" | "delete",
+  resource: WriteResource,
+  status: number,
+  body: Record<string, unknown> = { errors: ["エラーが発生しました"] },
+) {
+  const handler = method === "post" ? http.post : http.delete;
+  const path = method === "delete" ? `/${resource}/:id` : `/${resource}`;
+  return handler(apiUrl(path), () => HttpResponse.json(body, { status }));
+}


### PR DESCRIPTION
## 概要

#51（書き込み系 API 繋ぎ込み）のうち、**実 Rails API（#16）を待たずに先行できる部分**を実装しました。
エラーハンドリングの共通化と、書き込み系（likes / comments）の回帰テスト基盤を整えます。

Closes #62

## 変更内容

### 1. エラーハンドリングの統一（`src/lib/api/error.ts`）
- `ApiError` から status / body を取り出すユーティリティを集約
  - `getErrorStatus` / `getErrorData` / `isUnauthorized` / `isForbidden` / `isValidationError` / `getApiErrorMessage`
- `getApiErrorMessage` は Rails のエラーボディ形式ゆれ（`{ errors: [...] }` / `{ error: "..." }` / `{ message: "..." }`）を吸収し、該当なしは fallback を返す
- `index.ts` から再エクスポート

### 2. コンポーネントの分岐を共通化
- `LikeButton` / `CommentSection` / `LikedSpotsList` の `e instanceof ApiError && e.status === ...` を共通ユーティリティ呼び出しに置換
- `CommentSection` の投稿時 422 で、サーバーのバリデーションメッセージを表示するよう追加

### 3. 回帰防止の MSW 基盤（`tests/msw/writeApiHandlers.ts`）
- 書き込み系のハッピーパス + 401 / 403 / 422 / 5xx を再現する共通ハンドラのファクトリを追加
- グローバル登録はせず、各テストが `server.use(...)` でオプトインする（`handlers.ts` の「原則空」方針を踏襲）

### 4. テスト
- `src/lib/api/__tests__/error.test.ts` … ユーティリティの単体テスト
- `CommentSection` … 投稿 422 / 投稿 401 / 削除 403 の回帰テストを追加（共通ハンドラを利用）

## スコープ外（#51 に残す）

- 実 Rails API への疎通（実トークンでの 401/422/403 確定）
- 401 検知時の NextAuth `signOut` 連動（認証切れ挙動は実 API で確定したい）

## 確認

- `npx tsc --noEmit` … エラーなし
- `npx eslint .` … エラーなし
- `npx vitest run` … 16 ファイル / 130 テスト すべて成功

https://claude.ai/code/session_01SmJaPAzQiEBkMkSSww3CPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmJaPAzQiEBkMkSSww3CPY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling and messaging for expired login sessions during comment and like interactions
  * Enhanced display of validation error messages from the server
  * Clarified permission error messaging when users lack access rights

* **Refactor**
  * Standardized error handling utilities throughout the application for consistent, clearer user-facing error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->