### PR TITLE
feat: 401 検知時の signOut + ログイン誘導を共通フックに統一（#51）

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -6,15 +6,23 @@ import { SiLine } from "react-icons/si";
 import Hairline from "@/components/brand/Hairline";
 import MockLoginForm from "@/components/auth/MockLoginForm";
 import { AVAILABLE_PROVIDERS, auth, signIn } from "@/lib/auth";
+import { safeCallbackUrl } from "@/lib/utils/safeCallbackUrl";
 
 export const metadata: Metadata = {
   title: "ログイン",
 };
 
-export default async function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
   const session = await auth();
+  // 401 誘導元（LikeButton / CommentSection 等）が付けた callbackUrl を尊重し、
+  // ログイン後に元のページへ戻す。検証して外部 URL への誘導は防ぐ。
+  const callbackUrl = safeCallbackUrl((await searchParams).callbackUrl);
   if (session?.user) {
-    redirect("/mypage");
+    redirect(callbackUrl);
   }
 
   return (
@@ -35,7 +43,7 @@ export default async function LoginPage() {
           <form
             action={async () => {
               "use server";
-              await signIn("google", { redirectTo: "/mypage" });
+              await signIn("google", { redirectTo: callbackUrl });
             }}
           >
             <button
@@ -52,7 +60,7 @@ export default async function LoginPage() {
           <form
             action={async () => {
               "use server";
-              await signIn("line", { redirectTo: "/mypage" });
+              await signIn("line", { redirectTo: callbackUrl });
             }}
           >
             <button
@@ -74,7 +82,7 @@ export default async function LoginPage() {
               OAuth 連携が未設定のためモック用ログインを表示しています。
               Rails JWT 連携（#15）後に本番 OAuth に切り替えます。
             </p>
-            <MockLoginForm />
+            <MockLoginForm redirectTo={callbackUrl} />
           </div>
         ) : null}
       </div>

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -14,6 +14,7 @@ import {
   isValidationError,
 } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
 import type { Comment } from "@/types";
 
 type CommentSectionProps = {
@@ -44,6 +45,7 @@ export default function CommentSection({
   callbackUrl,
 }: CommentSectionProps) {
   const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
   const [comments, setComments] = useState<Comment[]>(initialComments);
   const [body, setBody] = useState("");
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -73,7 +75,7 @@ export default function CommentSection({
         setBody("");
       } catch (e) {
         if (isUnauthorized(e)) {
-          setSubmitError("ログインの有効期限が切れました。再度ログインしてください。");
+          await handleSessionExpired();
           return;
         }
         if (isValidationError(e)) {
@@ -105,7 +107,7 @@ export default function CommentSection({
       } catch (e) {
         setComments(snapshot);
         if (isUnauthorized(e)) {
-          setDeleteError("ログインが必要です。");
+          await handleSessionExpired();
           return;
         }
         if (isForbidden(e)) {

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -11,6 +11,7 @@ import {
   unlikeTemple,
 } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
 
 type LikeButtonProps = {
   kind: "greentea" | "temple";
@@ -30,6 +31,7 @@ export default function LikeButton({
 }: LikeButtonProps) {
   const router = useRouter();
   const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
   const [liked, setLiked] = useState(initialLiked);
   const [count, setCount] = useState(initialCount);
   const [pending, startTransition] = useTransition();
@@ -64,9 +66,7 @@ export default function LikeButton({
         setLiked(prevLiked);
         setCount(prevCount);
         if (isUnauthorized(e)) {
-          router.push(
-            `/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`,
-          );
+          await handleSessionExpired();
           return;
         }
         setError("通信に失敗しました。もう一度お試しください。");

--- a/src/components/common/LikedSpotsList.tsx
+++ b/src/components/common/LikedSpotsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect } from "react";
 import useSWR from "swr";
 import GreenteaCard from "@/components/greentea/GreenteaCard";
 import TempleCard from "@/components/temple/TempleCard";
@@ -11,6 +12,7 @@ import {
   isUnauthorized,
 } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
 import type {
   GreenteaLikeListResponse,
   TempleLikeListResponse,
@@ -27,6 +29,7 @@ export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
   const authToken = useAuthToken();
   const callbackUrl =
     kind === "greentea" ? "/mypage/greentea-likes" : "/mypage/temple-likes";
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
 
   // フェッチャーは SWR から渡されるキー（authToken を含む）からトークンを取り出す。
   // クロージャ越しの authToken に依存するとキャッシュ無効化のタイミングがずれる。
@@ -37,6 +40,15 @@ export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
     authToken ? ([`/${kind}_likes`, authToken] as const) : null,
     fetcher,
   );
+
+  // 401（セッション切れ）はレンダー中に副作用を起こせないため effect で処理し、
+  // 他コンポーネントと同じく signOut → ログイン誘導へ寄せる。
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) {
+      void handleSessionExpired();
+    }
+  }, [sessionExpired, handleSessionExpired]);
 
   if (!authToken) {
     return (

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -8,9 +8,16 @@ import { commentDeleted, writeError } from "@tests/msw/writeApiHandlers";
 import type { Comment } from "@/types";
 
 const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
 
 vi.mock("next-auth/react", () => ({
   useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
 }));
 
 const API_BASE_URL =
@@ -19,6 +26,9 @@ const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
 beforeEach(() => {
   useSessionMock.mockReset();
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
 });
 
 // window.confirm 等の vi.spyOn を確実に元に戻す。アサーション失敗で
@@ -198,7 +208,7 @@ describe("CommentSection", () => {
     expect(screen.getByText(/まだコメントはありません/)).toBeInTheDocument();
   });
 
-  it("投稿が 401 だと再ログイン案内を表示する", async () => {
+  it("投稿が 401 だと signOut してログインへ誘導する", async () => {
     mockLoggedIn();
     server.use(writeError("post", "greenteacomments", 401));
 
@@ -219,8 +229,11 @@ describe("CommentSection", () => {
     await user.click(screen.getByRole("button", { name: /投稿する/ }));
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent(/再度ログイン/);
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
     });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
   });
 
   it("自分のコメントだけ「削除」ボタンが表示される", () => {

--- a/src/components/common/__tests__/LikeButton.test.tsx
+++ b/src/components/common/__tests__/LikeButton.test.tsx
@@ -7,6 +7,7 @@ import { server } from "@tests/msw/server";
 
 const pushMock = vi.fn();
 const useSessionMock = vi.fn();
+const signOutMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
@@ -14,6 +15,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("next-auth/react", () => ({
   useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
 }));
 
 const API_BASE_URL =
@@ -23,6 +25,8 @@ const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 beforeEach(() => {
   pushMock.mockReset();
   useSessionMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
 });
 
 function mockLoggedIn() {
@@ -85,7 +89,7 @@ describe("LikeButton", () => {
     expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("API が 401 を返すとカウントがロールバックされ、ログイン誘導が走る", async () => {
+  it("API が 401 を返すとカウントがロールバックされ、signOut とログイン誘導が走る", async () => {
     mockLoggedIn();
     server.use(
       http.post(endpoint("/greentea_likes"), () =>
@@ -110,6 +114,9 @@ describe("LikeButton", () => {
       expect(screen.getByRole("button")).toHaveTextContent("3");
     });
     expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
     expect(pushMock).toHaveBeenCalledWith(
       "/auth/login?callbackUrl=%2Fgreenteas%2F1",
     );

--- a/src/components/common/__tests__/LikedSpotsList.test.tsx
+++ b/src/components/common/__tests__/LikedSpotsList.test.tsx
@@ -1,16 +1,43 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import LikedSpotsList from "@/components/common/LikedSpotsList";
+import { server } from "@tests/msw/server";
 
 const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
 
 vi.mock("next-auth/react", () => ({
   useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
 }));
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
 beforeEach(() => {
   useSessionMock.mockReset();
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
 });
+
+// SWR のグローバルキャッシュをテスト間で持ち越さないよう、毎回空 Map で包む。
+function renderWithSwr(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
 
 describe("LikedSpotsList — マイページの CSR ガード", () => {
   it("未ログインでは「お気に入り一覧の表示にはログインが必要」案内とログインリンクを表示する", () => {
@@ -37,6 +64,27 @@ describe("LikedSpotsList — マイページの CSR ガード", () => {
     expect(link).toHaveAttribute(
       "href",
       "/auth/login?callbackUrl=%2Fmypage%2Ftemple-likes",
+    );
+  });
+
+  it("一覧取得が 401 だと signOut してログインへ誘導する", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="greentea" />);
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fmypage%2Fgreentea-likes",
     );
   });
 });

--- a/src/lib/api/__tests__/useSessionExpired.test.tsx
+++ b/src/lib/api/__tests__/useSessionExpired.test.tsx
@@ -33,6 +33,19 @@ describe("useSessionExpiredHandler", () => {
     );
   });
 
+  it("signOut が失敗してもログイン誘導は実行される", async () => {
+    signOutMock.mockRejectedValueOnce(new Error("network"));
+    const { result } = renderHook(() =>
+      useSessionExpiredHandler("/greenteas/1"),
+    );
+
+    await expect(result.current()).rejects.toThrow("network");
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
   it("callbackUrl をエンコードして付与する", async () => {
     const { result } = renderHook(() =>
       useSessionExpiredHandler("/mypage/temple-likes?tab=a&b=c"),

--- a/src/lib/api/__tests__/useSessionExpired.test.tsx
+++ b/src/lib/api/__tests__/useSessionExpired.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+beforeEach(() => {
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+});
+
+describe("useSessionExpiredHandler", () => {
+  it("signOut(redirect:false) を呼んでから callbackUrl 付きでログインへ push する", async () => {
+    const { result } = renderHook(() =>
+      useSessionExpiredHandler("/greenteas/1"),
+    );
+
+    await result.current();
+
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
+  it("callbackUrl をエンコードして付与する", async () => {
+    const { result } = renderHook(() =>
+      useSessionExpiredHandler("/mypage/temple-likes?tab=a&b=c"),
+    );
+
+    await result.current();
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fmypage%2Ftemple-likes%3Ftab%3Da%26b%3Dc",
+    );
+  });
+});

--- a/src/lib/api/useSessionExpired.ts
+++ b/src/lib/api/useSessionExpired.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { signOut } from "next-auth/react";
+import { useCallback } from "react";
+
+// 認証付き API が 401 を返したとき（＝Rails JWT が失効・無効）に呼ぶ共通ハンドラ。
+// クライアントの NextAuth セッションを破棄してからログインへ誘導することで、
+// 「セッションは生きているのに API は弾かれる」不整合状態を残さない。
+// 楽観的更新を持つコンポーネント間で 401 の挙動を統一するために集約する。
+export function useSessionExpiredHandler(
+  callbackUrl: string,
+): () => Promise<void> {
+  const router = useRouter();
+  return useCallback(async () => {
+    // redirect: false で NextAuth の自動遷移を抑止し、callbackUrl 付きの
+    // ログインページへ自前で送る（元のページに戻すため）。
+    await signOut({ redirect: false });
+    router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  }, [router, callbackUrl]);
+}

--- a/src/lib/api/useSessionExpired.ts
+++ b/src/lib/api/useSessionExpired.ts
@@ -15,7 +15,12 @@ export function useSessionExpiredHandler(
   return useCallback(async () => {
     // redirect: false で NextAuth の自動遷移を抑止し、callbackUrl 付きの
     // ログインページへ自前で送る（元のページに戻すため）。
-    await signOut({ redirect: false });
-    router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    // signOut が失敗してもユーザーを壊れたページに残さないよう、
+    // 誘導は finally で必ず実行する（クリーンアップは best-effort）。
+    try {
+      await signOut({ redirect: false });
+    } finally {
+      router.push(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    }
   }, [router, callbackUrl]);
 }

--- a/src/lib/utils/__tests__/safeCallbackUrl.test.ts
+++ b/src/lib/utils/__tests__/safeCallbackUrl.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { safeCallbackUrl } from "@/lib/utils/safeCallbackUrl";
+
+describe("safeCallbackUrl", () => {
+  it("自サイト内の絶対パスはそのまま通す", () => {
+    expect(safeCallbackUrl("/greenteas/1")).toBe("/greenteas/1");
+    expect(safeCallbackUrl("/mypage/temple-likes")).toBe(
+      "/mypage/temple-likes",
+    );
+  });
+
+  it("クエリ付きの内部パスも通す", () => {
+    expect(safeCallbackUrl("/temples?page=2")).toBe("/temples?page=2");
+  });
+
+  it("プロトコル相対 URL（//evil.com）は fallback に倒す", () => {
+    expect(safeCallbackUrl("//evil.com")).toBe("/mypage");
+  });
+
+  it("外部 URL（http/https）は fallback に倒す", () => {
+    expect(safeCallbackUrl("https://evil.com")).toBe("/mypage");
+    expect(safeCallbackUrl("http://evil.com")).toBe("/mypage");
+  });
+
+  it("相対パスや undefined は fallback に倒す", () => {
+    expect(safeCallbackUrl("greenteas/1")).toBe("/mypage");
+    expect(safeCallbackUrl(undefined)).toBe("/mypage");
+  });
+
+  it("配列で渡された場合は先頭要素を検証する", () => {
+    expect(safeCallbackUrl(["/greenteas/1", "/temples"])).toBe("/greenteas/1");
+    expect(safeCallbackUrl(["//evil.com"])).toBe("/mypage");
+  });
+
+  it("fallback は上書きできる", () => {
+    expect(safeCallbackUrl(undefined, "/")).toBe("/");
+  });
+});

--- a/src/lib/utils/safeCallbackUrl.ts
+++ b/src/lib/utils/safeCallbackUrl.ts
@@ -1,0 +1,13 @@
+// ログイン後のリダイレクト先（callbackUrl）を検証する。
+// オープンリダイレクトを防ぐため、自サイト内の絶対パス（"/foo"）のみ許可し、
+// "//evil.com"（プロトコル相対）や "http://..." のような外部 URL は fallback に倒す。
+export function safeCallbackUrl(
+  raw: string | string[] | undefined,
+  fallback = "/mypage",
+): string {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value && value.startsWith("/") && !value.startsWith("//")) {
+    return value;
+  }
+  return fallback;
+}


### PR DESCRIPTION
## 概要

#51「書き込み系 API 繋ぎ込み（likes / comments）」のうち、**モックだけで先行できるエラーハンドリング統一の残タスク**に対応します。

#51 のサブタスクは多くが既存実装（commit `16dde2b`）で対応済みでしたが、「**401 を検知したら NextAuth の `signOut` ＋ ログイン誘導**」だけが未実装で、各コンポーネントの 401 挙動がバラバラでした（LikeButton はログイン誘導のみ・CommentSection はメッセージのみ・LikedSpotsList はメッセージのみ、いずれも `signOut` を呼んでいなかった）。

この PR で 401（セッション切れ）処理を共通フックに集約し、楽観的更新を持つコンポーネント間で挙動を揃えます。「セッションは生きているのに API は弾かれる」不整合状態を残さないようにするのが狙いです。

## 変更内容

- **`src/lib/api/useSessionExpired.ts`（新規）**: `signOut({ redirect: false })` → `callbackUrl` 付きログインページへ誘導する共通フック `useSessionExpiredHandler` を追加。
- **`LikeButton`**: 401 ロールバック後に共通フック経由で `signOut` ＋ ログイン誘導へ統一。
- **`CommentSection`**: 投稿 / 削除の 401 を共通フック経由に変更（従来はメッセージ表示のみ）。
- **`LikedSpotsList`**: SWR の 401 エラーを `useEffect` で検知し、同じく `signOut` ＋ 誘導へ。
- **テスト**: 各コンポーネントの 401 テストを更新し、共通フックの単体テストを追加。

## 確認

- [x] `npm test` — 17 files / 133 tests passed
- [x] `npm run lint` — No ESLint warnings or errors
- [x] `npx tsc --noEmit` — エラーなし

## issue の分割について

#51 の残タスクのうち、**モックでは確定できず実 Rails API（greentea_temple #16）と認証繋ぎ込みに依存する**もの（実 API 疎通 / 重複 POST の冪等性 / DELETE の id 整合 / `owned_by_current_user` の実付与 / 文字数バリデーションの Rails 一致 など）は、新しく **#64** として切り出しました。

関連: #51 / #64

https://claude.ai/code/session_01PjwEmqztdMJkEdbRxGaGXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjwEmqztdMJkEdbRxGaGXJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified session expiration handling across the app for consistent user experience during authentication timeouts
  * Users are automatically redirected to login with automatic return to their original page after re-authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->