### PR TITLE
docs: README をプロジェクト実態に合わせて整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm run dev
 
 ## ディレクトリ構成（抜粋）
 
-```
+```text
 src/
   app/            # ルーティング（greenteas / temples / nearby / mypage / auth ...）
   components/     # layout / greentea / temple / map / common / auth / brand

--- a/README.md
+++ b/README.md
@@ -1,36 +1,112 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# 抹茶と神社。(matcha-to-jinja)
 
-## Getting Started
+京都の抹茶スイーツ店と神社仏閣を組み合わせて紹介する Web アプリの **Next.js フロントエンド**。
 
-First, run the development server:
+既存の Rails アプリ [greentea_temple](https://github.com/hiiragi17/greentea_temple) を
+「Rails API（バックエンド）+ Next.js（フロントエンド）」構成へ移行するプロジェクトの、フロント側リポジトリです。
+
+## アーキテクチャ（2 リポジトリ構成）
+
+| 役割 | リポジトリ | 内容 | デプロイ先 |
+|------|-----------|------|-----------|
+| フロントエンド | **matcha-to-jinja**（このリポジトリ） | Next.js | Vercel |
+| バックエンド API | [greentea_temple](https://github.com/hiiragi17/greentea_temple) | Rails API（`api/v1` 名前空間） | GCP Cloud Run |
+
+- フロントは Rails API の `GET/POST /api/v1/*` を叩いてデータを取得・更新します。
+- 認証は Rails が JWT を発行し、フロントは NextAuth.js（Auth.js v5）経由で OAuth（Google / LINE）フローを管理します。
+- **このリポジトリに Rails コードは含まれません。** バックエンドの変更は greentea_temple 側で行います。
+
+## 技術スタック
+
+- Next.js 15（App Router）+ React 19 + TypeScript 5
+- Tailwind CSS v4 + daisyUI
+- SWR（データフェッチ / キャッシュ）
+- NextAuth.js（Auth.js v5、Google / LINE OAuth）
+- react-icons / `@vis.gl/react-google-maps`
+- Vitest + React Testing Library + MSW（ユニット / 統合テスト）
+- Playwright（E2E ゴールデンパス）
+
+## クイックスタート（モックモード）
+
+Rails API を起動しなくても、インメモリのモック実装でフロント単独で動かせます。
 
 ```bash
+npm install
+
+# 環境変数を用意（既定で NEXT_PUBLIC_USE_MOCK=true）
+cp .env.example .env.local
+
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+[http://localhost:3000](http://localhost:3000) を開くと、`src/lib/api/mock` が応答する状態で UI を確認できます。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+実 Rails API（`greentea_temple`、:3001）と結合して動かす手順は
+[`docs/local-setup.md`](docs/local-setup.md) を参照してください。
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## モック / 実 API の切替
 
-## Learn More
+`NEXT_PUBLIC_USE_MOCK` 環境変数で切り替えます。
 
-To learn more about Next.js, take a look at the following resources:
+- **`true`** … `src/lib/api/mock` のインメモリ実装が応答する（Rails 未起動で開発可）
+- **`false`** … `NEXT_PUBLIC_API_URL` に対して実 fetch を行う
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+`NEXT_PUBLIC_*` はビルド時に埋め込まれるため、切り替えたら `npm run dev` を再起動してください。
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## 環境変数
 
-## Deploy on Vercel
+`.env.example` をコピーして `.env.local` を作成します。主な変数:
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+| 変数 | 用途 |
+|------|------|
+| `NEXT_PUBLIC_API_URL` | Rails API のベース URL（開発: `http://localhost:3001`） |
+| `NEXT_PUBLIC_USE_MOCK` | モック / 実 API の切替（`true` / `false`） |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` / `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` | 現在地検索の地図表示 |
+| `AUTH_SECRET` / `AUTH_URL` | NextAuth.js（Auth.js v5） |
+| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` / `AUTH_LINE_ID` / `AUTH_LINE_SECRET` | OAuth プロバイダー（未設定時は開発用モックログインを表示） |
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+各変数の詳細はコメント付きで `.env.example` に記載しています。
+
+## スクリプト
+
+| コマンド | 内容 |
+|----------|------|
+| `npm run dev` | 開発サーバ起動（:3000） |
+| `npm run build` | 本番ビルド |
+| `npm run start` | ビルド済みアプリの起動 |
+| `npm run lint` | ESLint |
+| `npm test` | Vitest（ユニット / 統合） |
+| `npm run test:watch` | Vitest ウォッチモード |
+| `npm run test:coverage` | カバレッジ付きで実行（`coverage/` に出力） |
+| `npm run test:e2e` | Playwright E2E（モックモードで起動） |
+
+## ディレクトリ構成（抜粋）
+
+```
+src/
+  app/            # ルーティング（greenteas / temples / nearby / mypage / auth ...）
+  components/     # layout / greentea / temple / map / common / auth / brand
+  lib/
+    api/          # client.ts + 各リソースの API 関数 + mock 実装
+    auth.ts       # NextAuth 設定
+    utils/        # distance.ts ほか
+  types/          # API レスポンスに対応する型定義
+tests/
+  msw/            # MSW ハンドラ
+  e2e/            # Playwright シナリオ
+```
+
+エイリアス: `@/*` → `./src/*`、`@tests/*` → `./tests/*`。
+
+## ドキュメント
+
+- [`docs/local-setup.md`](docs/local-setup.md) — Rails API とのローカル結合手順
+- [`docs/migration-plan.md`](docs/migration-plan.md) — 移行計画（API レスポンス契約 / 構成 / レンダリング戦略 / デプロイ）
+- [`docs/test-plan.md`](docs/test-plan.md) — テスト方針
+- [`docs/github-issues.md`](docs/github-issues.md) — issue 定義
+- [`CLAUDE.md`](CLAUDE.md) — コーディング規約・アーキテクチャ方針
+
+## 著作権・免責
+
+- 画像は外部 URL 参照のみ（Rails 側 CarrierWave の URL をそのまま表示）。
+- 本アプリは非公式です。出典の注意書きをフッターに表示しています。


### PR DESCRIPTION
## 概要

`create-next-app` のデフォルトボイラープレートのままだった `README.md` を、本プロジェクト（「抹茶と神社。」フロントエンド）の内容へ全面的に書き換えました。

issue を棚卸ししたところ、現状 open な 10 件はすべてバックエンド（`greentea_temple`）/ インフラ待ちで、フロント単独で進められるのはドキュメント整備のみでした。`docs/` 配下は充実している一方、入口の README だけが未整備（Geist フォントや `app/page.tsx` 編集の話など本プロジェクトと無関係な記述）だったため、これを解消します。

## 変更内容

- 2 リポジトリ構成（Next.js / Rails API）・技術スタックを記載
- クイックスタート（モックモード）と実 API 結合手順（`docs/local-setup.md`）への導線
- モック / 実 API 切替（`NEXT_PUBLIC_USE_MOCK`）の説明
- 主要な環境変数の一覧表
- npm スクリプト一覧（dev / build / lint / test / test:e2e ほか）
- ディレクトリ構成とエイリアス（`@/*`, `@tests/*`）
- `docs/` 各ドキュメントと `CLAUDE.md` への導線、著作権・免責表示

## 確認

- 記載内容（daisyUI / エイリアス / スクリプト等）は実コードと突き合わせ済み
- `npm run lint` 警告・エラーなし
- `npm test` 141 件 green

ドキュメントのみの変更で、アプリの挙動には影響しません。

https://claude.ai/code/session_01PRwEjyRWgmhyBTsDAC6Cqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRwEjyRWgmhyBTsDAC6Cqk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with comprehensive project documentation including architecture overview, tech stack details, setup instructions with quick-start guide, environment variables, npm scripts, directory structure, and supporting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->