### PR TITLE
docs: Vercel Preview 環境の前提を追記 + .env を最新化 (#52)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=
 # NextAuth.js / Auth.js v5（#23 認証で使用）
 # 旧 NEXTAUTH_* 名でも互換動作するが、v5 では AUTH_* を推奨。
 AUTH_SECRET=
+# ローカルは固定値。Vercel では Production にのみ確定ドメインを設定し、
+# Preview はデプロイごとに URL が変わるため AUTH_URL を設定せず、Auth.js が
+# VERCEL_URL からホストを自動解決するのに任せる（Vercel 上は trustHost が自動有効）。
+# 詳細は docs/migration-plan.md「Vercel Preview 環境」を参照。
 AUTH_URL=http://localhost:3000
 
 # OAuth プロバイダー（未設定の場合は開発用モックログインが表示される）

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -493,6 +493,50 @@ export async function apiClient<T>(
 - **Rails API**: `localhost:3001`（ポート変更）
 - **Next.js**: `localhost:3000`
 
+### Vercel Preview 環境（本番切替の前段 / #52）
+
+ローカル疎通（#49 / #50 / #51）が取れた後、本番ドメイン切替（#27）の前に
+**Vercel Preview（プレビュー URL）→ Cloud Run dev（Rails API）** で結合確認を行う。
+CORS / Cookie / 環境変数の組み合わせをここで潰しておく。
+
+| 項目 | フロント（Vercel Preview） | バックエンド（Cloud Run dev） |
+|------|---------------------------|------------------------------|
+| URL | `https://<deploy>-<scope>.vercel.app`（毎回変わる） | Cloud Run dev の URL |
+| データ | 実 API（`NEXT_PUBLIC_USE_MOCK=false`） | Neon dev |
+
+#### 前提とハマりどころ
+
+- **`AUTH_URL` は Preview に設定しない**。Preview の URL はデプロイごとに変わるため、
+  固定値を入れると OAuth コールバックがずれる。Vercel 上では Auth.js が `VERCEL_URL`
+  からホストを自動解決し、`trustHost` も自動で有効になる。固定ドメインを持つ
+  Production にのみ `AUTH_URL` を設定する。
+- **CORS**: Rails 側 `rack-cors` の origins に Preview ドメインを許可する。
+  `*.vercel.app` をワイルドカード許可するか明示列挙するかは方針決定が必要
+  （ワイルドカードは第三者の `*.vercel.app` も通るリスクがあるため、
+  プロジェクトのデプロイ URL を正規表現で絞るのが無難）。
+- **Cookie / セッション**: フロントとオリジンが異なる cross-site 構成のため、
+  NextAuth の Cookie は `SameSite=None; Secure` で発行される必要がある（HTTPS 必須）。
+- **認証情報の送信**: `apiClient` は `credentials: "include"` で送るため、
+  Rails 側は `credentials: true` を許可する（origin にワイルドカード `*` は使えない）。
+
+#### Vercel 環境変数（Preview に設定するもの）
+
+| 変数 | 値 |
+|------|-----|
+| `NEXT_PUBLIC_API_URL` | Cloud Run dev の URL |
+| `NEXT_PUBLIC_USE_MOCK` | `false` |
+| `AUTH_SECRET` | Preview 用シークレット |
+| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | 開発用 OAuth クライアント |
+| `AUTH_LINE_ID` / `AUTH_LINE_SECRET` | 開発用 OAuth クライアント |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Maps キー |
+| `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` | Map ID |
+
+> `AUTH_URL` は Preview には入れない（上記の通り自動解決）。
+> OAuth クライアントのリダイレクト URI には `/api/auth/callback/{google,line}` を追加しておく。
+> Cloud Run dev には `FRONTEND_URL` / `JWT_SECRET_KEY` を設定する。
+
+本番ドメイン（`matcha-to-jinja.com` / `api.matcha-to-jinja.com`）への切替は #27 のスコープ。
+
 ### 本番環境構成: Vercel + GCP
 
 コスト削減のため、バックエンドを Heroku から GCP に移行する。
@@ -739,13 +783,25 @@ jobs:
 ### 環境変数
 
 #### Next.js 側 (.env.local)
+
+最新の一覧と各変数の説明は `.env.example` が正。要点のみ:
+
 ```
 NEXT_PUBLIC_API_URL=http://localhost:3001                    # 開発時
 # NEXT_PUBLIC_API_URL=https://api.matcha-to-jinja.com       # 本番時
+NEXT_PUBLIC_USE_MOCK=true                                    # 実 API 連携時は false
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=xxxxx
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=xxxxx
+NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID=xxxxx                         # Advanced Markers 用
+AUTH_SECRET=xxxxx                                            # 旧 NEXTAUTH_SECRET
+AUTH_URL=http://localhost:3000                               # 旧 NEXTAUTH_URL（Vercel Preview では未設定で自動解決）
+AUTH_GOOGLE_ID=xxxxx
+AUTH_GOOGLE_SECRET=xxxxx
+AUTH_LINE_ID=xxxxx
+AUTH_LINE_SECRET=xxxxx
 ```
+
+> Auth.js v5 では `AUTH_*` 名を推奨（旧 `NEXTAUTH_*` 名でも互換動作）。
+> OAuth クライアント未設定の場合は開発用モックログインが表示される。
 
 #### Rails 側（Cloud Run 環境変数 or .env）
 ```

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -510,6 +510,15 @@ CORS / Cookie / 環境変数の組み合わせをここで潰しておく。
   固定値を入れると OAuth コールバックがずれる。Vercel 上では Auth.js が `VERCEL_URL`
   からホストを自動解決し、`trustHost` も自動で有効になる。固定ドメインを持つ
   Production にのみ `AUTH_URL` を設定する。
+- **OAuth redirect proxy（Preview の肝）**: OAuth プロバイダ（Google / LINE）は
+  事前登録した**絶対 redirect URI** のみを許可し、毎回変わる `*.vercel.app` の
+  プレビュー host はそのままでは登録できない。`AUTH_GOOGLE_*` / `AUTH_LINE_*` を
+  設定すると `src/lib/auth.ts` が実プロバイダを有効化するため、対策しないと
+  Preview デプロイのたびに OAuth コールバックが失敗する。Auth.js v5 の
+  **redirect proxy**（`AUTH_REDIRECT_PROXY_URL` に安定 URL を設定し、全環境で
+  同じ `AUTH_SECRET` を共有）を使い、プロバイダには安定 URL の
+  `/api/auth/callback/{google,line}` だけを登録する。proxy が各 Preview デプロイへ
+  コールバックを転送する。安定したプレビュー URL を別途用意する手もある。
 - **CORS**: Rails 側 `rack-cors` の origins に Preview ドメインを許可する。
   `*.vercel.app` をワイルドカード許可するか明示列挙するかは方針決定が必要
   （ワイルドカードは第三者の `*.vercel.app` も通るリスクがあるため、
@@ -525,14 +534,16 @@ CORS / Cookie / 環境変数の組み合わせをここで潰しておく。
 |------|-----|
 | `NEXT_PUBLIC_API_URL` | Cloud Run dev の URL |
 | `NEXT_PUBLIC_USE_MOCK` | `false` |
-| `AUTH_SECRET` | Preview 用シークレット |
+| `AUTH_SECRET` | Preview 用シークレット（redirect proxy を使うなら proxy 元と同一値） |
+| `AUTH_REDIRECT_PROXY_URL` | 安定 URL の `/api/auth`（例: `https://<本番 or 安定>/api/auth`）。OAuth callback を Preview へ転送する |
 | `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | 開発用 OAuth クライアント |
 | `AUTH_LINE_ID` / `AUTH_LINE_SECRET` | 開発用 OAuth クライアント |
 | `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Maps キー |
 | `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` | Map ID |
 
 > `AUTH_URL` は Preview には入れない（上記の通り自動解決）。
-> OAuth クライアントのリダイレクト URI には `/api/auth/callback/{google,line}` を追加しておく。
+> OAuth クライアントに登録するリダイレクト URI は、redirect proxy を使う場合は
+> **安定 URL の** `/api/auth/callback/{google,line}` のみで足りる（毎回変わる Preview host は登録しない）。
 > Cloud Run dev には `FRONTEND_URL` / `JWT_SECRET_KEY` を設定する。
 
 本番ドメイン（`matcha-to-jinja.com` / `api.matcha-to-jinja.com`）への切替は #27 のスコープ。


### PR DESCRIPTION
## 概要

#52（CORS / 環境変数 / Vercel Preview からの結合確認）のうち、**バックエンドやインフラの実設定を待たずにこのリポジトリ内で先行できるドキュメント整備**を行いました。実際の Vercel / Cloud Run dev への設定や CORS 追加（Rails 側）、Preview からの実結合テストは外部作業のため #52 に残します。

## 変更内容

### `docs/migration-plan.md`「環境構成」
- 新節「**Vercel Preview 環境（本番切替の前段 / #52）**」を追加
  - `AUTH_URL` は Preview に設定せず `VERCEL_URL` からホストを自動解決する方針を明記（Preview の URL はデプロイごとに変わるため固定値は禁物。Vercel 上では `trustHost` が自動有効）
  - CORS（`*.vercel.app` のワイルドカード許可 vs 明示列挙のトレードオフ）/ Cookie（`SameSite=None; Secure`）/ `credentials: "include"` の前提を整理
  - Preview に設定する Vercel 環境変数の一覧表を追加
- 既存の「環境変数」ブロックが旧 `NEXTAUTH_*` 名のままだったため `.env.example` と整合（`AUTH_*`・`NEXT_PUBLIC_USE_MOCK`・`NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID`・OAuth 変数を反映）

### `.env.example`
- `AUTH_URL` のコメントに Preview 自動解決の注記を追加

## スコープ外（#52 に残す・外部作業）

- Vercel / Cloud Run dev の環境変数の実設定
- Rails 側 `rack-cors` の origins 追加（greentea_temple#13 依存）
- OAuth コンソールのリダイレクト URI 登録
- Preview → Cloud Run dev の実結合テスト（#26 の dev 環境立ち上げ依存）

## 補足

- ドキュメントと `.env.example` のみの変更で、アプリのコードは変更していません。

Closes #52

https://claude.ai/code/session_013pZABWmWg5vTrqx8vAaVfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013pZABWmWg5vTrqx8vAaVfZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vercel environment configuration guidance and authentication setup strategies
  * Added Vercel Preview deployment verification procedures with prerequisite requirements
  * Clarified environment variables and authentication configuration best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->