### PR TITLE
feat: OGP画像を動的生成（ImageResponse）に切り替え

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,13 +52,13 @@ export const metadata: Metadata = {
     siteName: "抹茶と神社。",
     title: "抹茶と神社。",
     description: SITE_DESCRIPTION,
-    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "抹茶と神社。" }],
+    // 画像は src/app/opengraph-image.tsx（ファイル規約）で自動付与される
   },
   twitter: {
     card: "summary_large_image",
     title: "抹茶と神社。",
     description: SITE_DESCRIPTION,
-    images: ["/og-image.png"],
+    // 画像は src/app/twitter-image.tsx（ファイル規約）で自動付与される
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -2,6 +2,9 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ImageResponse } from "next/og";
 
+// node:fs/promises を使うため Node.js ランタイムを明示する（Edge では動作しない）。
+export const runtime = "nodejs";
+
 export const alt = "抹茶と神社。";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
@@ -9,8 +12,14 @@ export const contentType = "image/png";
 // ロゴ（抹茶と神社。のタイトル文字を含む）を使うことで、
 // Satori に日本語フォントを埋め込まずに OGP 画像を生成する。
 export default async function OpengraphImage() {
-  const logo = await readFile(join(process.cwd(), "public/brand/logo.png"));
-  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+  // ロゴが読めない場合でも 500 にせず、タイトル文字のフォールバックで描画する。
+  let logoSrc = "";
+  try {
+    const logo = await readFile(join(process.cwd(), "public/brand/logo.png"));
+    logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+  } catch {
+    logoSrc = "";
+  }
 
   return new ImageResponse(
     (
@@ -39,7 +48,19 @@ export default async function OpengraphImage() {
             background: "#fbf6e5",
           }}
         >
-          <img src={logoSrc} alt="" width={360} height={360} />
+          {logoSrc ? (
+            <img
+              src={logoSrc}
+              alt=""
+              width={360}
+              height={360}
+              style={{ objectFit: "contain" }}
+            />
+          ) : (
+            <div style={{ fontSize: 64, letterSpacing: 8, color: "#3d3322" }}>
+              MATCHA TO JINJA
+            </div>
+          )}
           <div
             style={{
               fontSize: 30,

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ImageResponse } from "next/og";
+
+export const alt = "抹茶と神社。";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// ロゴ（抹茶と神社。のタイトル文字を含む）を使うことで、
+// Satori に日本語フォントを埋め込まずに OGP 画像を生成する。
+export default async function OpengraphImage() {
+  const logo = await readFile(join(process.cwd(), "public/brand/logo.png"));
+  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 48,
+          background: "linear-gradient(135deg, #e4d8b5 0%, #f1e9cf 100%)",
+        }}
+      >
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 28,
+            borderRadius: 28,
+            border: "2px solid #d5c9a4",
+            background: "#fbf6e5",
+          }}
+        >
+          <img src={logoSrc} alt="" width={360} height={360} />
+          <div
+            style={{
+              fontSize: 30,
+              letterSpacing: 6,
+              color: "#8a7a4e",
+            }}
+          >
+            KYOTO MATCHA SWEETS &#215; SHRINES
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              letterSpacing: 4,
+              color: "#9c8b45",
+            }}
+          >
+            unofficial guide
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";


### PR DESCRIPTION
## 概要

OGP / Twitter Card の画像を、App Router のファイル規約 + `next/og` の `ImageResponse` による**動的生成**に切り替えました。

## 背景・課題

- これまで `layout.tsx` の metadata が `/og-image.png` を参照していましたが、**実体の `public/og-image.png` が存在せず 404**。SNS シェア時に OGP 画像が表示されない状態でした。

## 変更内容

| ファイル | 内容 |
|---|---|
| `src/app/opengraph-image.tsx`（新規） | `ImageResponse` で 1200×630 の OGP 画像を生成 |
| `src/app/twitter-image.tsx`（新規） | 上記を再エクスポート（Twitter Card 用） |
| `src/app/layout.tsx`（修正） | 手動の `/og-image.png` 参照を削除し、ファイル規約に一本化 |

## 設計のポイント

- **ブランドロゴ（`public/brand/logo.png`）を埋め込み**。ロゴ自体に「抹茶と神社。」のタイトル文字が含まれるため、**Satori への日本語フォント同梱を回避**しています（フォント未指定だと CJK が豆腐 □ になる問題をクリア）。
- 背景・枠線をブランドカラー（`washi #f1e9cf` → `paper #fbf6e5`、ライン `#d5c9a4`）で統一。
- ラテン文字のタグライン `KYOTO MATCHA SWEETS × SHRINES` / `unofficial guide` を添えています。

## 生成イメージ

ロゴを中央に据えた和紙トーンのデザイン（1200×630）。`抹茶と神社。` のタイトルはロゴ内の文字で表現されます。

## 確認したこと

- 実際にレンダリングして見た目を確認（ロゴ中央・ブランドトーン）
- `next build` 成功 → `/opengraph-image` `/twitter-image` の両ルートが静的生成される
- ESLint / `tsc --noEmit` クリーン

## 補足

今回はロゴ中心のミニマルなデザインです。画像内に日本語のキャッチコピーを入れたい場合は、Noto Serif JP 等のフォント読み込みを追加して対応可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDp2FvxNzbWcW6z5KVuYJc)_