### PR TITLE
[Next.js] 管理画面 Phase 1: 管理基盤の実装

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import AdminNav from "@/components/admin/AdminNav";
+
+export const metadata = { title: "管理画面" };
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const session = await auth();
+
+  if (!session) {
+    redirect("/auth/login?callbackUrl=/admin");
+  }
+
+  if (session.user.role !== "admin") {
+    redirect("/");
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)]">
+      <AdminNav />
+      <main className="flex-1 overflow-auto p-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getGreenteas } from "@/lib/api/greenteas";
+import { getTemples } from "@/lib/api/temples";
+
+export default async function AdminDashboardPage() {
+  const [greenteaData, templeData] = await Promise.all([
+    getGreenteas().catch(() => null),
+    getTemples().catch(() => null),
+  ]);
+
+  const stats = [
+    {
+      label: "抹茶店",
+      count: greenteaData?.meta.total_count ?? "—",
+      href: "/admin/greenteas",
+    },
+    {
+      label: "神社・仏閣",
+      count: templeData?.meta.total_count ?? "—",
+      href: "/admin/temples",
+    },
+    {
+      label: "コメント",
+      count: "—",
+      href: "/admin/comments",
+    },
+  ];
+
+  return (
+    <div>
+      <h1 className="mb-6 font-mincho text-xl tracking-[0.1em] text-ink">
+        ダッシュボード
+      </h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {stats.map(({ label, count, href }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex flex-col gap-2 border border-line bg-paper p-5 transition-shadow hover:shadow-sm"
+          >
+            <span className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+              {label}
+            </span>
+            <span className="font-mincho text-3xl text-ink">{count}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navItems = [
+  { href: "/admin", label: "ダッシュボード" },
+  { href: "/admin/greenteas", label: "抹茶店" },
+  { href: "/admin/temples", label: "神社・仏閣" },
+  { href: "/admin/comments", label: "コメント" },
+] as const;
+
+export default function AdminNav() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-52 shrink-0 border-r border-line bg-paper">
+      <div className="border-b border-line px-4 py-4">
+        <span className="font-mincho text-xs tracking-[0.15em] text-muted">
+          管理画面
+        </span>
+      </div>
+      <nav className="flex flex-col py-2">
+        {navItems.map(({ href, label }) => {
+          const isActive =
+            href === "/admin"
+              ? pathname === "/admin"
+              : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`px-4 py-2.5 font-serif-jp text-sm transition-colors hover:bg-stone-100 ${
+                isActive ? "bg-stone-100 text-olive" : "text-ink"
+              }`}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -25,7 +25,7 @@ export default function AdminNav() {
           const isActive =
             href === "/admin"
               ? pathname === "/admin"
-              : pathname.startsWith(href);
+              : pathname === href || pathname.startsWith(`${href}/`);
           return (
             <Link
               key={href}

--- a/src/lib/api/admin/comments.ts
+++ b/src/lib/api/admin/comments.ts
@@ -1,0 +1,38 @@
+import type { Comment } from "@/types";
+import { apiClient } from "@/lib/api/client";
+
+export type AdminComment = Comment & {
+  resource_type: "greentea" | "temple";
+  resource_id: number;
+  resource_name: string;
+};
+
+export type AdminCommentListResponse = {
+  comments: AdminComment[];
+};
+
+export function listAdminComments(
+  authToken: string,
+): Promise<AdminCommentListResponse> {
+  return apiClient<AdminCommentListResponse>("/admin/comments", { authToken });
+}
+
+export function adminDeleteGreenteaComment(
+  id: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/admin/greenteacomments/${id}`, {
+    method: "DELETE",
+    authToken,
+  });
+}
+
+export function adminDeleteTempleComment(
+  id: number,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/admin/templecomments/${id}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/api/admin/comments.ts
+++ b/src/lib/api/admin/comments.ts
@@ -1,15 +1,7 @@
-import type { Comment } from "@/types";
-import { apiClient } from "@/lib/api/client";
+import type { AdminComment, AdminCommentListResponse } from "@/types";
+import { apiClient } from "../client";
 
-export type AdminComment = Comment & {
-  resource_type: "greentea" | "temple";
-  resource_id: number;
-  resource_name: string;
-};
-
-export type AdminCommentListResponse = {
-  comments: AdminComment[];
-};
+export type { AdminComment, AdminCommentListResponse };
 
 export function listAdminComments(
   authToken: string,

--- a/src/lib/api/admin/greenteas.ts
+++ b/src/lib/api/admin/greenteas.ts
@@ -1,21 +1,5 @@
-import type { Greentea } from "@/types";
-import { apiClient } from "@/lib/api/client";
-
-export type GreenteaInput = {
-  name: string;
-  description: string;
-  address: string;
-  access: string;
-  phone_number: string;
-  business_hours: string;
-  holiday: string;
-  homepage: string;
-  closed: boolean;
-  img: string;
-  latitude: number;
-  longitude: number;
-  genre_ids: number[];
-};
+import type { Greentea, GreenteaInput } from "@/types";
+import { apiClient } from "../client";
 
 type GreenteaResponse = { greentea: Greentea };
 

--- a/src/lib/api/admin/greenteas.ts
+++ b/src/lib/api/admin/greenteas.ts
@@ -1,0 +1,50 @@
+import type { Greentea } from "@/types";
+import { apiClient } from "@/lib/api/client";
+
+export type GreenteaInput = {
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  closed: boolean;
+  img: string;
+  latitude: number;
+  longitude: number;
+  genre_ids: number[];
+};
+
+type GreenteaResponse = { greentea: Greentea };
+
+export function createGreentea(
+  input: GreenteaInput,
+  authToken: string,
+): Promise<GreenteaResponse> {
+  return apiClient<GreenteaResponse>("/admin/greenteas", {
+    method: "POST",
+    body: JSON.stringify(input),
+    authToken,
+  });
+}
+
+export function updateGreentea(
+  id: number,
+  input: Partial<GreenteaInput>,
+  authToken: string,
+): Promise<GreenteaResponse> {
+  return apiClient<GreenteaResponse>(`/admin/greenteas/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+    authToken,
+  });
+}
+
+export function deleteGreentea(id: number, authToken: string): Promise<void> {
+  return apiClient<void>(`/admin/greenteas/${id}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/api/admin/temples.ts
+++ b/src/lib/api/admin/temples.ts
@@ -1,0 +1,49 @@
+import type { Temple } from "@/types";
+import { apiClient } from "@/lib/api/client";
+
+export type TempleInput = {
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  img: string;
+  latitude: number;
+  longitude: number;
+  area_ids: number[];
+};
+
+type TempleResponse = { temple: Temple };
+
+export function createTemple(
+  input: TempleInput,
+  authToken: string,
+): Promise<TempleResponse> {
+  return apiClient<TempleResponse>("/admin/temples", {
+    method: "POST",
+    body: JSON.stringify(input),
+    authToken,
+  });
+}
+
+export function updateTemple(
+  id: number,
+  input: Partial<TempleInput>,
+  authToken: string,
+): Promise<TempleResponse> {
+  return apiClient<TempleResponse>(`/admin/temples/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+    authToken,
+  });
+}
+
+export function deleteTemple(id: number, authToken: string): Promise<void> {
+  return apiClient<void>(`/admin/temples/${id}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/api/admin/temples.ts
+++ b/src/lib/api/admin/temples.ts
@@ -1,20 +1,5 @@
-import type { Temple } from "@/types";
-import { apiClient } from "@/lib/api/client";
-
-export type TempleInput = {
-  name: string;
-  description: string;
-  address: string;
-  access: string;
-  phone_number: string;
-  business_hours: string;
-  holiday: string;
-  homepage: string;
-  img: string;
-  latitude: number;
-  longitude: number;
-  area_ids: number[];
-};
+import type { Temple, TempleInput } from "@/types";
+import { apiClient } from "../client";
 
 type TempleResponse = { temple: Temple };
 

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -20,6 +20,7 @@ import type {
   TempleListResponse,
 } from "@/types";
 import { distanceMeters } from "@/lib/utils/distance";
+import type { AdminCommentListResponse } from "../admin/comments";
 import type { CurrentUserResponse } from "../auth";
 import { ApiError } from "../error";
 import {
@@ -36,17 +37,26 @@ import {
   addGreenteaLike,
   addTempleComment,
   addTempleLike,
+  adminDeleteGreenteaComment,
+  adminDeleteTempleComment,
+  createMockGreentea,
+  createMockTemple,
   deleteGreenteaComment,
+  deleteMockGreentea,
+  deleteMockTemple,
   deleteTempleComment,
   extractMockUserId,
   getGreenteaLikeDelta,
   getGreenteaLikedIds,
   getTempleLikeDelta,
   getTempleLikedIds,
+  listAllComments,
   listGreenteaComments,
   listTempleComments,
   removeGreenteaLike,
   removeTempleLike,
+  updateMockGreentea,
+  updateMockTemple,
 } from "./state";
 
 const PER_PAGE = 12;
@@ -118,6 +128,14 @@ function mergedTempleComments(
 function requireMockUser(headers: Headers): string {
   const userId = extractMockUserId(headers);
   if (!userId) unauthorized();
+  return userId;
+}
+
+function requireMockAdmin(headers: Headers): string {
+  const userId = requireMockUser(headers);
+  if (!userId.toLowerCase().includes("admin")) {
+    throw new ApiError(403, { error: "Admin role required" });
+  }
   return userId;
 }
 
@@ -464,6 +482,118 @@ export async function mockClient<T>(
     if (path === "/auth/logout") {
       requireMockUser(headers);
       return undefined as T;
+    }
+
+    // Admin: greentea 削除
+    const adminGreenteaDeleteMatch = path.match(/^\/admin\/greenteas\/(\d+)$/);
+    if (adminGreenteaDeleteMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminGreenteaDeleteMatch[1]);
+      if (!deleteMockGreentea(id)) notFound(endpoint);
+      return undefined as T;
+    }
+
+    // Admin: temple 削除
+    const adminTempleDeleteMatch = path.match(/^\/admin\/temples\/(\d+)$/);
+    if (adminTempleDeleteMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminTempleDeleteMatch[1]);
+      if (!deleteMockTemple(id)) notFound(endpoint);
+      return undefined as T;
+    }
+
+    // Admin: greentea コメント削除（owner チェックなし）
+    const adminGreenteaCommentMatch = path.match(
+      /^\/admin\/greenteacomments\/(\d+)$/,
+    );
+    if (adminGreenteaCommentMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminGreenteaCommentMatch[1]);
+      const result = adminDeleteGreenteaComment(id);
+      if (result === "not_found") notFound(endpoint);
+      return undefined as T;
+    }
+
+    // Admin: temple コメント削除（owner チェックなし）
+    const adminTempleCommentMatch = path.match(
+      /^\/admin\/templecomments\/(\d+)$/,
+    );
+    if (adminTempleCommentMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminTempleCommentMatch[1]);
+      const result = adminDeleteTempleComment(id);
+      if (result === "not_found") notFound(endpoint);
+      return undefined as T;
+    }
+  }
+
+  if (method === "GET") {
+    // Admin: コメント一覧（横断）
+    if (path === "/admin/comments") {
+      requireMockAdmin(headers);
+      const all = listAllComments();
+      const greenteasMap = new Map(mockGreenteas.map((g) => [g.id, g.name]));
+      const templesMap = new Map(mockTemples.map((t) => [t.id, t.name]));
+      const comments = all.map(({ comment, resourceType, resourceId }) => ({
+        ...comment,
+        resource_type: resourceType,
+        resource_id: resourceId,
+        resource_name:
+          resourceType === "greentea"
+            ? (greenteasMap.get(resourceId) ?? "")
+            : (templesMap.get(resourceId) ?? ""),
+      }));
+      return { comments } satisfies AdminCommentListResponse as T;
+    }
+  }
+
+  if (method === "POST") {
+    // Admin: greentea 作成
+    if (path === "/admin/greenteas") {
+      requireMockAdmin(headers);
+      const input = parseJsonBody<Parameters<typeof createMockGreentea>[0]>(
+        options?.body,
+      );
+      const greentea = createMockGreentea(input, { genres: mockGenres });
+      return { greentea } as T;
+    }
+
+    // Admin: temple 作成
+    if (path === "/admin/temples") {
+      requireMockAdmin(headers);
+      const input = parseJsonBody<Parameters<typeof createMockTemple>[0]>(
+        options?.body,
+      );
+      const temple = createMockTemple(input, { areas: mockAreas });
+      return { temple } as T;
+    }
+  }
+
+  if (method === "PATCH") {
+    // Admin: greentea 更新
+    const adminGreenteasPatchMatch = path.match(/^\/admin\/greenteas\/(\d+)$/);
+    if (adminGreenteasPatchMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminGreenteasPatchMatch[1]);
+      const input = parseJsonBody<Parameters<typeof updateMockGreentea>[1]>(
+        options?.body,
+      );
+      const greentea = updateMockGreentea(id, input, { genres: mockGenres });
+      if (!greentea) notFound(endpoint);
+      return { greentea } as T;
+    }
+
+    // Admin: temple 更新
+    const adminTemplesPatchMatch = path.match(/^\/admin\/temples\/(\d+)$/);
+    if (adminTemplesPatchMatch) {
+      requireMockAdmin(headers);
+      const id = Number(adminTemplesPatchMatch[1]);
+      const input = parseJsonBody<Parameters<typeof updateMockTemple>[1]>(
+        options?.body,
+      );
+      const temple = updateMockTemple(id, input, { areas: mockAreas });
+      if (!temple) notFound(endpoint);
+      return { temple } as T;
     }
   }
 

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -20,7 +20,7 @@ import type {
   TempleListResponse,
 } from "@/types";
 import { distanceMeters } from "@/lib/utils/distance";
-import type { AdminCommentListResponse } from "../admin/comments";
+import type { AdminCommentListResponse } from "@/types";
 import type { CurrentUserResponse } from "../auth";
 import { ApiError } from "../error";
 import {
@@ -489,7 +489,8 @@ export async function mockClient<T>(
     if (adminGreenteaDeleteMatch) {
       requireMockAdmin(headers);
       const id = Number(adminGreenteaDeleteMatch[1]);
-      if (!deleteMockGreentea(id)) notFound(endpoint);
+      if (!deleteMockGreentea(id, { greenteas: mockGreenteas }))
+        notFound(endpoint);
       return undefined as T;
     }
 
@@ -498,7 +499,7 @@ export async function mockClient<T>(
     if (adminTempleDeleteMatch) {
       requireMockAdmin(headers);
       const id = Number(adminTempleDeleteMatch[1]);
-      if (!deleteMockTemple(id)) notFound(endpoint);
+      if (!deleteMockTemple(id, { temples: mockTemples })) notFound(endpoint);
       return undefined as T;
     }
 
@@ -554,7 +555,13 @@ export async function mockClient<T>(
       const input = parseJsonBody<Parameters<typeof createMockGreentea>[0]>(
         options?.body,
       );
-      const greentea = createMockGreentea(input, { genres: mockGenres });
+      if (!Array.isArray(input.genre_ids)) {
+        throw new ApiError(400, { error: "genre_ids is required" });
+      }
+      const greentea = createMockGreentea(input, {
+        genres: mockGenres,
+        greenteas: mockGreenteas,
+      });
       return { greentea } as T;
     }
 
@@ -564,7 +571,13 @@ export async function mockClient<T>(
       const input = parseJsonBody<Parameters<typeof createMockTemple>[0]>(
         options?.body,
       );
-      const temple = createMockTemple(input, { areas: mockAreas });
+      if (!Array.isArray(input.area_ids)) {
+        throw new ApiError(400, { error: "area_ids is required" });
+      }
+      const temple = createMockTemple(input, {
+        areas: mockAreas,
+        temples: mockTemples,
+      });
       return { temple } as T;
     }
   }
@@ -578,7 +591,10 @@ export async function mockClient<T>(
       const input = parseJsonBody<Parameters<typeof updateMockGreentea>[1]>(
         options?.body,
       );
-      const greentea = updateMockGreentea(id, input, { genres: mockGenres });
+      const greentea = updateMockGreentea(id, input, {
+        genres: mockGenres,
+        greenteas: mockGreenteas,
+      });
       if (!greentea) notFound(endpoint);
       return { greentea } as T;
     }
@@ -591,7 +607,10 @@ export async function mockClient<T>(
       const input = parseJsonBody<Parameters<typeof updateMockTemple>[1]>(
         options?.body,
       );
-      const temple = updateMockTemple(id, input, { areas: mockAreas });
+      const temple = updateMockTemple(id, input, {
+        areas: mockAreas,
+        temples: mockTemples,
+      });
       if (!temple) notFound(endpoint);
       return { temple } as T;
     }

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -7,7 +7,9 @@
 // Next.js dev サーバーは HMR で module-level の変数がリセットされてしまい、
 // 開発中にいいね・コメントが突然消えて混乱するため、globalThis にぶら下げる。
 
-import type { Comment } from "@/types";
+import type { Comment, Greentea, Temple } from "@/types";
+import type { GreenteaInput } from "../admin/greenteas";
+import type { TempleInput } from "../admin/temples";
 
 type UserId = string;
 type CommentRecord = { comment: Comment; ownerId: UserId };
@@ -22,6 +24,9 @@ type MockStore = {
   greenteaLikeCountDelta: Map<number, number>;
   templeLikeCountDelta: Map<number, number>;
   nextCommentId: { value: number };
+  nextResourceId: { value: number };
+  greenteas: Greentea[] | null;
+  temples: Temple[] | null;
 };
 
 const globalKey = Symbol.for("matcha-to-jinja.mock-store");
@@ -38,6 +43,9 @@ const store: MockStore = ((): MockStore => {
       greenteaLikeCountDelta: new Map(),
       templeLikeCountDelta: new Map(),
       nextCommentId: { value: 1000 },
+      nextResourceId: { value: 9000 },
+      greenteas: null,
+      temples: null,
     };
   }
   return g[globalKey]!;
@@ -53,6 +61,9 @@ export function resetMockStore(): void {
   store.greenteaLikeCountDelta.clear();
   store.templeLikeCountDelta.clear();
   store.nextCommentId.value = 1000;
+  store.nextResourceId.value = 9000;
+  store.greenteas = null;
+  store.temples = null;
 }
 
 function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
@@ -230,4 +241,164 @@ export function extractMockUserId(headers: Headers): string | null {
   if (!token.startsWith("mock:")) return null;
   const id = token.slice("mock:".length);
   return id.length > 0 ? id : null;
+}
+
+export function isMockAdmin(userId: UserId): boolean {
+  return userId.toLowerCase().includes("admin");
+}
+
+// --- Admin: Greentea CRUD ---
+
+// データ.ts の mockGreenteas を遅延初期化して返す（循環 import を避けるため動的 import）。
+// Phase 2 でルーターを store.greenteas に切り替える際に使う。
+export function getMockGreenteas(seed: Greentea[]): Greentea[] {
+  if (store.greenteas === null) {
+    store.greenteas = [...seed];
+  }
+  return store.greenteas;
+}
+
+export function getMockTemples(seed: Temple[]): Temple[] {
+  if (store.temples === null) {
+    store.temples = [...seed];
+  }
+  return store.temples;
+}
+
+export function createMockGreentea(
+  input: GreenteaInput,
+  seed: { genres: import("@/types").Genre[] },
+): Greentea {
+  const greentea: Greentea = {
+    ...input,
+    id: store.nextResourceId.value++,
+    genres: seed.genres.filter((g) => input.genre_ids.includes(g.id)),
+    likes_count: 0,
+    liked_by_current_user: false,
+  };
+  getMockGreenteas([]).push(greentea);
+  return greentea;
+}
+
+export function updateMockGreentea(
+  id: number,
+  input: Partial<GreenteaInput>,
+  seed: { genres: import("@/types").Genre[] },
+): Greentea | null {
+  const list = store.greenteas;
+  if (!list) return null;
+  const idx = list.findIndex((g) => g.id === id);
+  if (idx < 0) return null;
+  const updated: Greentea = {
+    ...list[idx],
+    ...input,
+    genres: input.genre_ids
+      ? seed.genres.filter((g) => input.genre_ids!.includes(g.id))
+      : list[idx].genres,
+  };
+  list[idx] = updated;
+  return updated;
+}
+
+export function deleteMockGreentea(id: number): boolean {
+  const list = store.greenteas;
+  if (!list) return false;
+  const idx = list.findIndex((g) => g.id === id);
+  if (idx < 0) return false;
+  list.splice(idx, 1);
+  return true;
+}
+
+// --- Admin: Temple CRUD ---
+
+export function createMockTemple(
+  input: TempleInput,
+  seed: { areas: import("@/types").Area[] },
+): Temple {
+  const temple: Temple = {
+    ...input,
+    id: store.nextResourceId.value++,
+    areas: seed.areas.filter((a) => input.area_ids.includes(a.id)),
+    likes_count: 0,
+    liked_by_current_user: false,
+  };
+  getMockTemples([]).push(temple);
+  return temple;
+}
+
+export function updateMockTemple(
+  id: number,
+  input: Partial<TempleInput>,
+  seed: { areas: import("@/types").Area[] },
+): Temple | null {
+  const list = store.temples;
+  if (!list) return null;
+  const idx = list.findIndex((t) => t.id === id);
+  if (idx < 0) return null;
+  const updated: Temple = {
+    ...list[idx],
+    ...input,
+    areas: input.area_ids
+      ? seed.areas.filter((a) => input.area_ids!.includes(a.id))
+      : list[idx].areas,
+  };
+  list[idx] = updated;
+  return updated;
+}
+
+export function deleteMockTemple(id: number): boolean {
+  const list = store.temples;
+  if (!list) return false;
+  const idx = list.findIndex((t) => t.id === id);
+  if (idx < 0) return false;
+  list.splice(idx, 1);
+  return true;
+}
+
+// --- Admin: Comment moderation (admin bypass owner check) ---
+
+export function adminDeleteGreenteaComment(commentId: number): DeleteResult {
+  for (const list of store.greenteaComments.values()) {
+    const idx = list.findIndex((r) => r.comment.id === commentId);
+    if (idx >= 0) {
+      list.splice(idx, 1);
+      return "deleted";
+    }
+  }
+  return "not_found";
+}
+
+export function adminDeleteTempleComment(commentId: number): DeleteResult {
+  for (const list of store.templeComments.values()) {
+    const idx = list.findIndex((r) => r.comment.id === commentId);
+    if (idx >= 0) {
+      list.splice(idx, 1);
+      return "deleted";
+    }
+  }
+  return "not_found";
+}
+
+export function listAllComments(): Array<{
+  comment: Comment;
+  resourceType: "greentea" | "temple";
+  resourceId: number;
+}> {
+  const result: Array<{
+    comment: Comment;
+    resourceType: "greentea" | "temple";
+    resourceId: number;
+  }> = [];
+
+  for (const [resourceId, records] of store.greenteaComments.entries()) {
+    for (const r of records) {
+      result.push({ comment: r.comment, resourceType: "greentea", resourceId });
+    }
+  }
+  for (const [resourceId, records] of store.templeComments.entries()) {
+    for (const r of records) {
+      result.push({ comment: r.comment, resourceType: "temple", resourceId });
+    }
+  }
+  return result;
 }

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -7,9 +7,7 @@
 // Next.js dev サーバーは HMR で module-level の変数がリセットされてしまい、
 // 開発中にいいね・コメントが突然消えて混乱するため、globalThis にぶら下げる。
 
-import type { Comment, Greentea, Temple } from "@/types";
-import type { GreenteaInput } from "../admin/greenteas";
-import type { TempleInput } from "../admin/temples";
+import type { Comment, Greentea, GreenteaInput, Temple, TempleInput } from "@/types";
 
 type UserId = string;
 type CommentRecord = { comment: Comment; ownerId: UserId };
@@ -232,15 +230,21 @@ export function deleteTempleComment(
   return "not_found";
 }
 
-// Authorization: Bearer "mock:<id>" からユーザー ID を取り出す。
+// Authorization: Bearer "mock:<encoded-id>" からユーザー ID を取り出す。
+// auth.ts で encodeURIComponent されているため、ここで decodeURIComponent する。
 // 形式が異なるトークン（実 JWT 等）が来た場合は null。
 export function extractMockUserId(headers: Headers): string | null {
   const auth = headers.get("Authorization");
   if (!auth?.startsWith("Bearer ")) return null;
   const token = auth.slice("Bearer ".length);
   if (!token.startsWith("mock:")) return null;
-  const id = token.slice("mock:".length);
-  return id.length > 0 ? id : null;
+  const encoded = token.slice("mock:".length);
+  if (encoded.length === 0) return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
 }
 
 export function isMockAdmin(userId: UserId): boolean {
@@ -267,42 +271,45 @@ export function getMockTemples(seed: Temple[]): Temple[] {
 
 export function createMockGreentea(
   input: GreenteaInput,
-  seed: { genres: import("@/types").Genre[] },
+  seed: { genres: import("@/types").Genre[]; greenteas: Greentea[] },
 ): Greentea {
+  const { genre_ids, ...attrs } = input;
   const greentea: Greentea = {
-    ...input,
+    ...attrs,
     id: store.nextResourceId.value++,
-    genres: seed.genres.filter((g) => input.genre_ids.includes(g.id)),
+    genres: seed.genres.filter((g) => genre_ids.includes(g.id)),
     likes_count: 0,
     liked_by_current_user: false,
   };
-  getMockGreenteas([]).push(greentea);
+  getMockGreenteas(seed.greenteas).push(greentea);
   return greentea;
 }
 
 export function updateMockGreentea(
   id: number,
   input: Partial<GreenteaInput>,
-  seed: { genres: import("@/types").Genre[] },
+  seed: { genres: import("@/types").Genre[]; greenteas: Greentea[] },
 ): Greentea | null {
-  const list = store.greenteas;
-  if (!list) return null;
+  const list = getMockGreenteas(seed.greenteas);
   const idx = list.findIndex((g) => g.id === id);
   if (idx < 0) return null;
+  const { genre_ids, ...attrs } = input;
   const updated: Greentea = {
     ...list[idx],
-    ...input,
-    genres: input.genre_ids
-      ? seed.genres.filter((g) => input.genre_ids!.includes(g.id))
+    ...attrs,
+    genres: genre_ids
+      ? seed.genres.filter((g) => genre_ids.includes(g.id))
       : list[idx].genres,
   };
   list[idx] = updated;
   return updated;
 }
 
-export function deleteMockGreentea(id: number): boolean {
-  const list = store.greenteas;
-  if (!list) return false;
+export function deleteMockGreentea(
+  id: number,
+  seed: { greenteas: Greentea[] },
+): boolean {
+  const list = getMockGreenteas(seed.greenteas);
   const idx = list.findIndex((g) => g.id === id);
   if (idx < 0) return false;
   list.splice(idx, 1);
@@ -313,42 +320,45 @@ export function deleteMockGreentea(id: number): boolean {
 
 export function createMockTemple(
   input: TempleInput,
-  seed: { areas: import("@/types").Area[] },
+  seed: { areas: import("@/types").Area[]; temples: Temple[] },
 ): Temple {
+  const { area_ids, ...attrs } = input;
   const temple: Temple = {
-    ...input,
+    ...attrs,
     id: store.nextResourceId.value++,
-    areas: seed.areas.filter((a) => input.area_ids.includes(a.id)),
+    areas: seed.areas.filter((a) => area_ids.includes(a.id)),
     likes_count: 0,
     liked_by_current_user: false,
   };
-  getMockTemples([]).push(temple);
+  getMockTemples(seed.temples).push(temple);
   return temple;
 }
 
 export function updateMockTemple(
   id: number,
   input: Partial<TempleInput>,
-  seed: { areas: import("@/types").Area[] },
+  seed: { areas: import("@/types").Area[]; temples: Temple[] },
 ): Temple | null {
-  const list = store.temples;
-  if (!list) return null;
+  const list = getMockTemples(seed.temples);
   const idx = list.findIndex((t) => t.id === id);
   if (idx < 0) return null;
+  const { area_ids, ...attrs } = input;
   const updated: Temple = {
     ...list[idx],
-    ...input,
-    areas: input.area_ids
-      ? seed.areas.filter((a) => input.area_ids!.includes(a.id))
+    ...attrs,
+    areas: area_ids
+      ? seed.areas.filter((a) => area_ids.includes(a.id))
       : list[idx].areas,
   };
   list[idx] = updated;
   return updated;
 }
 
-export function deleteMockTemple(id: number): boolean {
-  const list = store.temples;
-  if (!list) return false;
+export function deleteMockTemple(
+  id: number,
+  seed: { temples: Temple[] },
+): boolean {
+  const list = getMockTemples(seed.temples);
   const idx = list.findIndex((t) => t.id === id);
   if (idx < 0) return false;
   list.splice(idx, 1);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -80,7 +80,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // モック provider は Rails が無いので、ここで擬似 JWT を発行して
         // apiClient のヘッダ付与経路を本番と統一する（mock/index.ts が Bearer "mock:<id>" を識別）。
         if (account.provider === "mock" && user?.id) {
-          token.railsJwt = `mock:${user.id}`;
+          // user.id は "mock-<name>" 形式。名前に非 ASCII 文字が含まれる場合
+          // Authorization ヘッダが TypeError になるため encodeURIComponent でエスケープする。
+          token.railsJwt = `mock:${encodeURIComponent(String(user.id))}`;
           // mock では名前に "admin" を含む場合に admin ロールを付与する（開発・テスト用）。
           token.role = String(user.id).toLowerCase().includes("admin")
             ? "admin"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -81,6 +81,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // apiClient のヘッダ付与経路を本番と統一する（mock/index.ts が Bearer "mock:<id>" を識別）。
         if (account.provider === "mock" && user?.id) {
           token.railsJwt = `mock:${user.id}`;
+          // mock では名前に "admin" を含む場合に admin ロールを付与する（開発・テスト用）。
+          token.role = String(user.id).toLowerCase().includes("admin")
+            ? "admin"
+            : "general";
         } else if (
           isRailsAuthProvider(account.provider) &&
           account.access_token
@@ -89,7 +93,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           // Rails 発行の JWT を受け取り、以後の API 呼び出し用に保持する。
           // 失敗時は token.railsJwt を残さずに throw → NextAuth がセッション確立を
           // 中断し、ユーザーは未ログイン状態のまま /auth/login に戻る。
-          const { token: railsJwt } = await exchangeOAuthForJwt(
+          const authResult = await exchangeOAuthForJwt(
             account.provider,
             {
               access_token: account.access_token,
@@ -103,7 +107,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
                 : undefined,
             },
           );
-          token.railsJwt = railsJwt;
+          token.railsJwt = authResult.token;
+          token.role = authResult.user.role;
         }
       }
       return token;
@@ -113,6 +118,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user = {
           ...session.user,
           provider: token.provider,
+        };
+      }
+      if (token.role) {
+        session.user = {
+          ...session.user,
+          role: token.role,
         };
       }
       if (token.railsJwt) {

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -15,3 +15,13 @@ export interface CommentListResponse {
 export interface CommentResponse {
   comment: Comment;
 }
+
+export interface AdminComment extends Comment {
+  resource_type: "greentea" | "temple";
+  resource_id: number;
+  resource_name: string;
+}
+
+export interface AdminCommentListResponse {
+  comments: AdminComment[];
+}

--- a/src/types/greentea.ts
+++ b/src/types/greentea.ts
@@ -1,5 +1,21 @@
 import type { Genre } from "./genre";
 
+export interface GreenteaInput {
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  closed: boolean;
+  img: string;
+  latitude: number;
+  longitude: number;
+  genre_ids: number[];
+}
+
 export interface Greentea {
   id: number;
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,15 @@
 export type { Genre } from "./genre";
 export type { Area } from "./area";
 export type { User, AuthUser } from "./user";
-export type { Comment, CommentListResponse, CommentResponse } from "./comment";
-export type { Greentea } from "./greentea";
-export type { Temple } from "./temple";
+export type {
+  Comment,
+  CommentListResponse,
+  CommentResponse,
+  AdminComment,
+  AdminCommentListResponse,
+} from "./comment";
+export type { Greentea, GreenteaInput } from "./greentea";
+export type { Temple, TempleInput } from "./temple";
 export type {
   GreenteaLike,
   TempleLike,

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,6 +4,7 @@ declare module "next-auth" {
   interface Session {
     user: DefaultSession["user"] & {
       provider?: string;
+      role?: string;
     };
     railsJwt?: string;
   }
@@ -13,5 +14,6 @@ declare module "@auth/core/jwt" {
   interface JWT {
     provider?: string;
     railsJwt?: string;
+    role?: string;
   }
 }

--- a/src/types/temple.ts
+++ b/src/types/temple.ts
@@ -1,5 +1,20 @@
 import type { Area } from "./area";
 
+export interface TempleInput {
+  name: string;
+  description: string;
+  address: string;
+  access: string;
+  phone_number: string;
+  business_hours: string;
+  holiday: string;
+  homepage: string;
+  img: string;
+  latitude: number;
+  longitude: number;
+  area_ids: number[];
+}
+
 export interface Temple {
   id: number;
   name: string;


### PR DESCRIPTION
## 概要

#71 の Phase 1（#73）。管理画面の土台を実装する。

## 変更内容

- **NextAuth に `role` を流す**
  - OAuth ログイン時: `exchangeOAuthForJwt` のレスポンス（`user.role`）を `token.role` に保持し `session.user.role` に展開
  - mock ログイン時: 名前に `admin` を含む場合に `role: "admin"` を付与（開発・テスト用）
  - `src/types/next-auth.d.ts` に `Session["user"].role` / `JWT.role` を追加

- **AdminGuard + レイアウト**（`src/app/admin/layout.tsx`）
  - 未ログイン → `/auth/login?callbackUrl=/admin` にリダイレクト
  - `role !== "admin"` → `/` にリダイレクト
  - サイドバー（AdminNav）+ メインコンテンツのレイアウト

- **ダッシュボード**（`src/app/admin/page.tsx`）
  - 抹茶店・神社・コメントの件数カードと各管理ページへのリンク

- **AdminNav**（`src/components/admin/AdminNav.tsx`）
  - ダッシュボード / 抹茶店 / 神社・仏閣 / コメント のサイドバーナビ

- **管理用 API 関数雛形**（`src/lib/api/admin/`）
  - `greenteas.ts`: `createGreentea / updateGreentea / deleteGreentea`
  - `temples.ts`: `createTemple / updateTemple / deleteTemple`
  - `comments.ts`: `listAdminComments / adminDeleteGreenteaComment / adminDeleteTempleComment`
  - すべて Bearer トークン必須

- **mock 対応**
  - `state.ts`: admin CRUD 関数・`isMockAdmin` ヘルパー・greenteas/temples のミュータブルストアを追加
  - `mock/index.ts`: admin ルート（POST/PATCH /admin/greenteas・temples、DELETE /admin/*、GET /admin/comments）を追加
  - `requireMockAdmin` ヘルパーで admin でないユーザーに 403 を返す

## 動作確認方法（mock モード）

1. `NEXT_PUBLIC_USE_MOCK=true` で起動
2. 表示名に `admin` を含む名前でモックログイン
3. `/admin` にアクセス → ダッシュボードが表示される
4. 非 admin ユーザーでログイン → `/admin` にアクセスすると `/` にリダイレクト

## 関連 Issue

Closes #73
- 親 issue: #71
- 次の Phase: #74（抹茶店 CRUD）、#75（神社 CRUD）、#76（コメントモデレーション）


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYVp9TGhhcRHjYL96QjDgN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin area with its own navigation, dashboard, and page title.
  * Enabled admin management for greenteas, temples, and comments, including create, edit, delete, and list actions.

* **Bug Fixes**
  * Restricted admin pages to signed-in users with the correct access level.
  * Improved comment handling so admin moderation works across all listed items.

* **Chores**
  * Session data now includes user role information for authorization-aware navigation and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->