### PR TITLE
feat: 管理画面 Phase 2 — 抹茶店（greenteas）CRUD の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,16 @@
       "name": "matcha-jinja-app",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "@vis.gl/react-google-maps": "^1.8.3",
         "next": "15.5.19",
         "next-auth": "^5.0.0-beta.31",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.80.0",
         "react-icons": "^5.6.0",
-        "swr": "^2.4.1"
+        "swr": "^2.4.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -603,6 +606,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/google.maps": "^3.53.1"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1893,6 +1908,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -7066,6 +7087,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.80.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.80.0.tgz",
+      "integrity": "sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
@@ -9041,6 +9078,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@vis.gl/react-google-maps": "^1.8.3",
     "next": "15.5.19",
     "next-auth": "^5.0.0-beta.31",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.80.0",
     "react-icons": "^5.6.0",
-    "swr": "^2.4.1"
+    "swr": "^2.4.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/admin/greenteas/[id]/edit/page.tsx
+++ b/src/app/admin/greenteas/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import GreenteaForm from "@/components/admin/GreenteaForm";
+import { getGenres, getGreentea } from "@/lib/api";
+import { getErrorStatus } from "@/lib/api";
+
+export default async function EditGreenteaPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const [greenteaResult, { genres }] = await Promise.all([
+    getGreentea(id).catch((e: unknown) => {
+      if (getErrorStatus(e) === 404) return null;
+      throw e;
+    }),
+    getGenres(),
+  ]);
+
+  if (!greenteaResult) notFound();
+  const { greentea } = greenteaResult;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/admin/greenteas"
+          className="font-sans-jp text-xs tracking-[0.1em] text-muted hover:text-olive"
+        >
+          ← 抹茶店の管理へ戻る
+        </Link>
+        <h1 className="mt-2 font-mincho text-xl tracking-[0.1em] text-ink">
+          抹茶店を編集
+        </h1>
+      </div>
+      <GreenteaForm genres={genres} mode="edit" initial={greentea} />
+    </div>
+  );
+}

--- a/src/app/admin/greenteas/new/page.tsx
+++ b/src/app/admin/greenteas/new/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import GreenteaForm from "@/components/admin/GreenteaForm";
+import { getGenres } from "@/lib/api";
+
+export default async function NewGreenteaPage() {
+  const { genres } = await getGenres();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/admin/greenteas"
+          className="font-sans-jp text-xs tracking-[0.1em] text-muted hover:text-olive"
+        >
+          ← 抹茶店の管理へ戻る
+        </Link>
+        <h1 className="mt-2 font-mincho text-xl tracking-[0.1em] text-ink">
+          抹茶店を新規作成
+        </h1>
+      </div>
+      <GreenteaForm genres={genres} mode="create" />
+    </div>
+  );
+}

--- a/src/app/admin/greenteas/page.tsx
+++ b/src/app/admin/greenteas/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { HiPlus } from "react-icons/hi2";
+import Pagination from "@/components/common/Pagination";
+import GreenteaAdminTable from "@/components/admin/GreenteaAdminTable";
+import { getGreenteas } from "@/lib/api";
+
+type SearchParams = { page?: string };
+
+export default async function AdminGreenteasPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page) || 1);
+
+  const { greenteas, meta } = await getGreenteas({ page });
+
+  // 範囲外の page= は最終ページへ寄せる（公開一覧と同じガード）。
+  if (meta.total_pages > 0 && page > meta.total_pages) {
+    redirect(
+      meta.total_pages > 1
+        ? `/admin/greenteas?page=${meta.total_pages}`
+        : "/admin/greenteas",
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-mincho text-xl tracking-[0.1em] text-ink">
+            抹茶店の管理
+          </h1>
+          <p className="mt-1 font-sans-jp text-xs tracking-[0.1em] text-muted">
+            全 {meta.total_count} 件
+            {meta.total_pages > 1 &&
+              ` ( ${meta.current_page} / ${meta.total_pages} ページ )`}
+          </p>
+        </div>
+        <Link
+          href="/admin/greenteas/new"
+          className="inline-flex items-center gap-1.5 border border-olive bg-olive px-4 py-2 font-mincho text-[13px] tracking-[0.12em] text-paper transition-colors hover:bg-olive-dark"
+        >
+          <HiPlus className="h-4 w-4" aria-hidden="true" />
+          新規作成
+        </Link>
+      </div>
+
+      <GreenteaAdminTable greenteas={greenteas} />
+
+      <div className="mt-8">
+        <Pagination
+          basePath="/admin/greenteas"
+          currentPage={meta.current_page}
+          totalPages={meta.total_pages}
+          preservedQuery=""
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -9,6 +9,7 @@ import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getGreentea } from "@/lib/api";
 import { auth } from "@/lib/auth";
+import { imageSrcOrPlaceholder } from "@/lib/utils/image";
 import type { GreenteaDetail, NearbySpot } from "@/types";
 
 type RouteParams = { id: string };
@@ -153,7 +154,7 @@ export default async function GreenteaDetailPage({
         <div className="aspect-[16/9] w-full">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={greentea.img}
+            src={imageSrcOrPlaceholder(greentea.img)}
             alt={greentea.name}
             className="h-full w-full object-cover"
           />

--- a/src/components/admin/DeleteConfirmDialog.tsx
+++ b/src/components/admin/DeleteConfirmDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type DeleteConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  loading?: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+// 削除確認モーダル。抹茶店 / 神社 / コメントの破壊的操作で共有する。
+export default function DeleteConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "削除する",
+  loading = false,
+  error,
+  onConfirm,
+  onCancel,
+}: DeleteConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // 開いたらキャンセルにフォーカスを移し、Esc で閉じられるようにする。
+  useEffect(() => {
+    if (!open) return;
+    cancelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !loading) onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, loading, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 px-4"
+    >
+      <div className="w-full max-w-sm border border-line bg-paper p-6">
+        <h2 className="font-mincho text-lg tracking-[0.08em] text-ink">
+          {title}
+        </h2>
+        <p className="mt-3 font-serif-jp text-sm leading-[1.9] text-muted">
+          {message}
+        </p>
+        {error && (
+          <p role="alert" className="mt-3 font-sans-jp text-xs text-bengara">
+            {error}
+          </p>
+        )}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="border border-line bg-paper px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-washi disabled:opacity-60"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className="border border-bengara bg-bengara px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-paper transition-colors hover:opacity-90 disabled:opacity-60"
+          >
+            {loading ? "削除中…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/GreenteaAdminTable.tsx
+++ b/src/components/admin/GreenteaAdminTable.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { HiPencilSquare, HiTrash } from "react-icons/hi2";
+import { deleteGreentea } from "@/lib/api/admin/greenteas";
+import { isUnauthorized } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import type { Greentea } from "@/types";
+import DeleteConfirmDialog from "./DeleteConfirmDialog";
+
+type GreenteaAdminTableProps = {
+  greenteas: Greentea[];
+};
+
+export default function GreenteaAdminTable({
+  greenteas,
+}: GreenteaAdminTableProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler("/admin/greenteas");
+  const [target, setTarget] = useState<Greentea | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, startDelete] = useTransition();
+
+  const handleConfirm = () => {
+    if (!target) return;
+    const id = target.id;
+    setDeleteError(null);
+    startDelete(async () => {
+      if (!authToken) {
+        await handleSessionExpired();
+        return;
+      }
+      try {
+        await deleteGreentea(id, authToken);
+        setTarget(null);
+        router.refresh();
+      } catch (e) {
+        if (isUnauthorized(e)) {
+          await handleSessionExpired();
+          return;
+        }
+        setDeleteError("削除に失敗しました。時間を置いてお試しください。");
+      }
+    });
+  };
+
+  if (greenteas.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-8 text-center font-serif-jp text-sm text-muted">
+        登録された抹茶店がありません。
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto border border-line">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-line bg-washi text-left">
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                店名
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                住所
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                ジャンル
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                状態
+              </th>
+              <th className="px-4 py-2.5 text-right font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {greenteas.map((g) => (
+              <tr key={g.id} className="border-b border-line-soft last:border-0">
+                <td className="px-4 py-3 font-mincho text-sm text-ink">
+                  {g.name}
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-xs text-muted">
+                  {g.address}
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-xs text-muted">
+                  {g.genres.map((genre) => genre.name).join(" / ") || "—"}
+                </td>
+                <td className="px-4 py-3">
+                  {g.closed ? (
+                    <span className="border border-bengara px-2 py-0.5 font-sans-jp text-[10px] tracking-[0.1em] text-bengara">
+                      閉店
+                    </span>
+                  ) : (
+                    <span className="border border-line px-2 py-0.5 font-sans-jp text-[10px] tracking-[0.1em] text-muted">
+                      営業中
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex justify-end gap-2">
+                    <Link
+                      href={`/admin/greenteas/${g.id}/edit`}
+                      className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-ink transition-colors hover:border-olive hover:text-olive"
+                    >
+                      <HiPencilSquare className="h-3.5 w-3.5" aria-hidden="true" />
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteError(null);
+                        setTarget(g);
+                      }}
+                      className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-muted transition-colors hover:border-bengara hover:text-bengara"
+                    >
+                      <HiTrash className="h-3.5 w-3.5" aria-hidden="true" />
+                      削除
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <DeleteConfirmDialog
+        open={target !== null}
+        title="抹茶店を削除"
+        message={
+          target
+            ? `「${target.name}」を削除します。この操作は取り消せません。`
+            : ""
+        }
+        loading={deleting}
+        error={deleteError}
+        onConfirm={handleConfirm}
+        onCancel={() => {
+          if (!deleting) {
+            setTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/admin/GreenteaForm.tsx
+++ b/src/components/admin/GreenteaForm.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  createGreentea,
+  updateGreentea,
+} from "@/lib/api/admin/greenteas";
+import { getApiErrorMessage, isUnauthorized, isValidationError } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import {
+  greenteaFormSchema,
+  type GreenteaFormValues,
+} from "@/lib/validation/greentea";
+import type { Genre, Greentea } from "@/types";
+import ImageUrlField from "./ImageUrlField";
+
+type GreenteaFormProps = {
+  genres: Genre[];
+  mode: "create" | "edit";
+  initial?: Greentea;
+};
+
+function toDefaults(initial?: Greentea): Partial<GreenteaFormValues> {
+  return {
+    name: initial?.name ?? "",
+    description: initial?.description ?? "",
+    address: initial?.address ?? "",
+    access: initial?.access ?? "",
+    phone_number: initial?.phone_number ?? "",
+    business_hours: initial?.business_hours ?? "",
+    holiday: initial?.holiday ?? "",
+    homepage: initial?.homepage ?? "",
+    closed: initial?.closed ?? false,
+    img: initial?.img ?? "",
+    // 未入力（新規）は number 入力で NaN になり、スキーマ側で必須エラーになる。
+    latitude: initial?.latitude,
+    longitude: initial?.longitude,
+    genre_ids: initial?.genres.map((g) => g.id) ?? [],
+  };
+}
+
+export default function GreenteaForm({
+  genres,
+  mode,
+  initial,
+}: GreenteaFormProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler("/admin/greenteas");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<GreenteaFormValues>({
+    resolver: zodResolver(greenteaFormSchema),
+    defaultValues: toDefaults(initial),
+  });
+
+  const imgValue = watch("img") ?? "";
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (!authToken) {
+      await handleSessionExpired();
+      return;
+    }
+    setSubmitError(null);
+    try {
+      if (mode === "create") {
+        await createGreentea(values, authToken);
+      } else if (initial) {
+        await updateGreentea(initial.id, values, authToken);
+      }
+      router.push("/admin/greenteas");
+      router.refresh();
+    } catch (e) {
+      if (isUnauthorized(e)) {
+        await handleSessionExpired();
+        return;
+      }
+      if (isValidationError(e)) {
+        setSubmitError(getApiErrorMessage(e, "入力内容を確認してください。"));
+        return;
+      }
+      setSubmitError("保存に失敗しました。時間を置いてお試しください。");
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="flex max-w-2xl flex-col gap-5">
+      <TextField
+        id="name"
+        label="店名 / NAME *"
+        error={errors.name?.message}
+        registration={register("name")}
+      />
+      <TextArea
+        id="description"
+        label="説明 / DESCRIPTION"
+        error={errors.description?.message}
+        registration={register("description")}
+      />
+      <TextField
+        id="address"
+        label="住所 / ADDRESS *"
+        error={errors.address?.message}
+        registration={register("address")}
+      />
+      <TextField
+        id="access"
+        label="アクセス / ACCESS"
+        error={errors.access?.message}
+        registration={register("access")}
+      />
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <TextField
+          id="phone_number"
+          label="電話番号 / PHONE"
+          error={errors.phone_number?.message}
+          registration={register("phone_number")}
+        />
+        <TextField
+          id="business_hours"
+          label="営業時間 / HOURS"
+          error={errors.business_hours?.message}
+          registration={register("business_hours")}
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <TextField
+          id="holiday"
+          label="定休日 / HOLIDAY"
+          error={errors.holiday?.message}
+          registration={register("holiday")}
+        />
+        <TextField
+          id="homepage"
+          label="ホームページ / HOMEPAGE"
+          error={errors.homepage?.message}
+          registration={register("homepage")}
+        />
+      </div>
+
+      <ImageUrlField
+        id="img"
+        label="画像 URL / IMAGE"
+        value={imgValue}
+        error={errors.img?.message}
+        registration={register("img")}
+      />
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <NumberField
+          id="latitude"
+          label="緯度 / LATITUDE *"
+          error={errors.latitude?.message}
+          registration={register("latitude", { valueAsNumber: true })}
+        />
+        <NumberField
+          id="longitude"
+          label="経度 / LONGITUDE *"
+          error={errors.longitude?.message}
+          registration={register("longitude", { valueAsNumber: true })}
+        />
+      </div>
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          {...register("closed")}
+          className="h-4 w-4 accent-olive"
+        />
+        <span className="font-serif-jp text-sm text-ink">閉店している</span>
+      </label>
+
+      <fieldset className="flex flex-col gap-2">
+        <legend className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          ジャンル / GENRES
+        </legend>
+        <Controller
+          control={control}
+          name="genre_ids"
+          render={({ field }) => (
+            <div className="flex flex-wrap gap-3">
+              {genres.map((genre) => {
+                const checked = field.value?.includes(genre.id) ?? false;
+                return (
+                  <label
+                    key={genre.id}
+                    className="flex items-center gap-1.5 border border-line bg-paper px-3 py-1.5"
+                  >
+                    <input
+                      type="checkbox"
+                      value={genre.id}
+                      checked={checked}
+                      onChange={(e) => {
+                        const next = new Set(field.value ?? []);
+                        if (e.target.checked) next.add(genre.id);
+                        else next.delete(genre.id);
+                        field.onChange([...next]);
+                      }}
+                      className="h-4 w-4 accent-olive"
+                    />
+                    <span className="font-serif-jp text-sm text-ink">
+                      {genre.name}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        />
+      </fieldset>
+
+      {submitError && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {submitError}
+        </p>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="border border-olive bg-olive px-6 py-2 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          {isSubmitting ? "保存中…" : mode === "create" ? "作成する" : "更新する"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push("/admin/greenteas")}
+          disabled={isSubmitting}
+          className="border border-line bg-paper px-5 py-2 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-washi disabled:opacity-60"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type FieldProps = {
+  id: string;
+  label: string;
+  error?: string;
+  registration: React.ComponentProps<"input">;
+};
+
+function TextField({ id, label, error, registration }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="text"
+        className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NumberField({ id, label, error, registration }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        step="any"
+        className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function TextArea({
+  id,
+  label,
+  error,
+  registration,
+}: {
+  id: string;
+  label: string;
+  error?: string;
+  registration: React.ComponentProps<"textarea">;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <textarea
+        id={id}
+        rows={3}
+        className="resize-y border border-line bg-washi px-3 py-2 font-serif-jp text-sm leading-[1.9] text-ink focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/ImageUrlField.tsx
+++ b/src/components/admin/ImageUrlField.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+
+type ImageUrlFieldProps = {
+  id: string;
+  label: string;
+  value: string;
+  error?: string;
+  registration: React.ComponentProps<"input">;
+};
+
+// 画像は MVP として URL 入力のみ（issue #71 方針）。入力された URL の
+// プレビューを表示し、壊れた URL のときは控えめに案内する。
+export default function ImageUrlField({
+  id,
+  label,
+  value,
+  error,
+  registration,
+}: ImageUrlFieldProps) {
+  const [broken, setBroken] = useState(false);
+  const trimmed = value.trim();
+  const showPreview = trimmed !== "" && /^https?:\/\//i.test(trimmed);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="url"
+        inputMode="url"
+        placeholder="https://..."
+        className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+        {...registration}
+        onChange={(e) => {
+          setBroken(false);
+          registration.onChange?.(e);
+        }}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+      {showPreview && (
+        <div className="mt-1">
+          {broken ? (
+            <p className="font-sans-jp text-[11px] text-muted">
+              画像を読み込めませんでした。URL をご確認ください。
+            </p>
+          ) : (
+            // 外部 URL のプレビュー。next/image は許可ドメイン設定が要るため、
+            // 管理プレビューでは素の img を使う。
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={trimmed}
+              alt="プレビュー"
+              className="h-32 w-auto border border-line object-cover"
+              onError={() => setBroken(true)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/__tests__/GreenteaForm.test.tsx
+++ b/src/components/admin/__tests__/GreenteaForm.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GreenteaForm from "@/components/admin/GreenteaForm";
+import type { Genre, Greentea } from "@/types";
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const createGreenteaMock = vi.fn();
+const updateGreenteaMock = vi.fn();
+const useSessionMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/api/admin/greenteas", () => ({
+  createGreentea: (...args: unknown[]) => createGreenteaMock(...args),
+  updateGreentea: (...args: unknown[]) => updateGreenteaMock(...args),
+}));
+
+const genres: Genre[] = [
+  { id: 1, name: "パフェ" },
+  { id: 2, name: "ドリンク" },
+];
+
+beforeEach(() => {
+  pushMock.mockReset();
+  refreshMock.mockReset();
+  createGreenteaMock.mockReset().mockResolvedValue({ greentea: { id: 1 } });
+  updateGreenteaMock.mockReset().mockResolvedValue({ greentea: { id: 1 } });
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+});
+
+async function fillRequired(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/店名/), "新店");
+  await user.type(screen.getByLabelText(/住所/), "京都市中京区");
+  await user.type(screen.getByLabelText(/緯度/), "35.01");
+  await user.type(screen.getByLabelText(/経度/), "135.77");
+}
+
+describe("GreenteaForm (create)", () => {
+  it("必須を満たして送信すると createGreentea が呼ばれ一覧へ遷移する", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaForm genres={genres} mode="create" />);
+
+    await fillRequired(user);
+    await user.click(screen.getByLabelText("パフェ"));
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    await waitFor(() => expect(createGreenteaMock).toHaveBeenCalledTimes(1));
+    const [payload, token] = createGreenteaMock.mock.calls[0];
+    expect(token).toBe("jwt-token");
+    expect(payload).toMatchObject({
+      name: "新店",
+      address: "京都市中京区",
+      latitude: 35.01,
+      longitude: 135.77,
+      genre_ids: [1],
+    });
+    expect(pushMock).toHaveBeenCalledWith("/admin/greenteas");
+  });
+
+  it("店名が空だとバリデーションエラーになり API を呼ばない", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaForm genres={genres} mode="create" />);
+
+    // 住所・緯度・経度だけ埋めて店名は空のまま
+    await user.type(screen.getByLabelText(/住所/), "京都市中京区");
+    await user.type(screen.getByLabelText(/緯度/), "35.01");
+    await user.type(screen.getByLabelText(/経度/), "135.77");
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    expect(await screen.findByText("店名は必須です")).toBeInTheDocument();
+    expect(createGreenteaMock).not.toHaveBeenCalled();
+  });
+
+  it("緯度未入力だと必須エラーになる", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaForm genres={genres} mode="create" />);
+
+    await user.type(screen.getByLabelText(/店名/), "新店");
+    await user.type(screen.getByLabelText(/住所/), "京都市中京区");
+    await user.type(screen.getByLabelText(/経度/), "135.77");
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    expect(await screen.findByText("緯度を入力してください")).toBeInTheDocument();
+    expect(createGreenteaMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GreenteaForm (edit)", () => {
+  const initial: Greentea = {
+    id: 5,
+    name: "既存店",
+    description: "説明",
+    address: "京都市東山区",
+    access: "徒歩5分",
+    phone_number: "075-000-0005",
+    business_hours: "10:00-21:00",
+    holiday: "不定休",
+    homepage: "https://example.com",
+    closed: false,
+    img: "https://example.com/x.png",
+    latitude: 35.0,
+    longitude: 135.77,
+    genres: [genres[0]],
+    likes_count: 3,
+  };
+
+  it("初期値が反映され、更新で updateGreentea が id 付きで呼ばれる", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaForm genres={genres} mode="edit" initial={initial} />);
+
+    expect(screen.getByLabelText(/店名/)).toHaveValue("既存店");
+
+    await user.clear(screen.getByLabelText(/店名/));
+    await user.type(screen.getByLabelText(/店名/), "改名後");
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(() => expect(updateGreenteaMock).toHaveBeenCalledTimes(1));
+    const [id, payload, token] = updateGreenteaMock.mock.calls[0];
+    expect(id).toBe(5);
+    expect(token).toBe("jwt-token");
+    expect(payload).toMatchObject({ name: "改名後", genre_ids: [1] });
+  });
+});

--- a/src/components/greentea/GreenteaCard.tsx
+++ b/src/components/greentea/GreenteaCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
+import { imageSrcOrPlaceholder } from "@/lib/utils/image";
 import type { Greentea } from "@/types";
 
 type GreenteaCardProps = {
@@ -16,7 +17,7 @@ export default function GreenteaCard({ greentea }: GreenteaCardProps) {
         {/* 画像は Rails(CarrierWave)/外部 URL をそのまま表示するため next/image を使わない */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={greentea.img}
+          src={imageSrcOrPlaceholder(greentea.img)}
           alt={greentea.name}
           loading="lazy"
           className="h-full w-full object-cover"

--- a/src/lib/api/admin/__tests__/greenteas.test.ts
+++ b/src/lib/api/admin/__tests__/greenteas.test.ts
@@ -1,0 +1,90 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import {
+  createGreentea,
+  deleteGreentea,
+  updateGreentea,
+} from "@/lib/api/admin/greenteas";
+import type { GreenteaInput } from "@/types";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const input: GreenteaInput = {
+  name: "新店",
+  description: "説明",
+  address: "京都市中京区",
+  access: "駅から徒歩1分",
+  phone_number: "075-000-0000",
+  business_hours: "10:00-18:00",
+  holiday: "水曜",
+  homepage: "https://example.com",
+  closed: false,
+  img: "https://example.com/x.png",
+  latitude: 35.01,
+  longitude: 135.77,
+  genre_ids: [1, 2],
+};
+
+const greenteaFixture = {
+  id: 9001,
+  ...input,
+  genres: [{ id: 1, name: "パフェ" }],
+  likes_count: 0,
+  liked_by_current_user: false,
+};
+
+describe("admin/greenteas API", () => {
+  it("createGreentea は POST /admin/greenteas に body と Bearer を送る", async () => {
+    let captured: { auth: string | null; body: unknown } | null = null;
+    server.use(
+      http.post(endpoint("/admin/greenteas"), async ({ request }) => {
+        captured = {
+          auth: request.headers.get("Authorization"),
+          body: await request.json(),
+        };
+        return HttpResponse.json({ greentea: greenteaFixture });
+      }),
+    );
+
+    const res = await createGreentea(input, "jwt-token");
+
+    expect(captured).not.toBeNull();
+    expect(captured!.auth).toBe("Bearer jwt-token");
+    expect(captured!.body).toEqual(input);
+    expect(res.greentea.id).toBe(9001);
+  });
+
+  it("updateGreentea は PATCH /admin/greenteas/:id に部分 body を送る", async () => {
+    let captured: { method: string; body: unknown } | null = null;
+    server.use(
+      http.patch(endpoint("/admin/greenteas/9001"), async ({ request }) => {
+        captured = { method: request.method, body: await request.json() };
+        return HttpResponse.json({
+          greentea: { ...greenteaFixture, name: "更新後" },
+        });
+      }),
+    );
+
+    const res = await updateGreentea(9001, { name: "更新後" }, "jwt-token");
+
+    expect(captured!.method).toBe("PATCH");
+    expect(captured!.body).toEqual({ name: "更新後" });
+    expect(res.greentea.name).toBe("更新後");
+  });
+
+  it("deleteGreentea は DELETE /admin/greenteas/:id を呼ぶ（204）", async () => {
+    let called = false;
+    server.use(
+      http.delete(endpoint("/admin/greenteas/9001"), () => {
+        called = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    await expect(deleteGreentea(9001, "jwt-token")).resolves.toBeUndefined();
+    expect(called).toBe(true);
+  });
+});

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -337,6 +337,65 @@ describe("mockClient comments", () => {
   });
 });
 
+describe("mockClient admin greentea CRUD は公開一覧に反映される", () => {
+  const adminAuth = auth("mock-admin");
+
+  it("create した抹茶店が GET /greenteas に現れる", async () => {
+    const before = await mockClient<GreenteaListResponse>("/greenteas");
+
+    const { greentea } = await mockClient<{ greentea: { id: number } }>(
+      "/admin/greenteas",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "新店",
+          description: "",
+          address: "京都市中京区",
+          access: "",
+          phone_number: "",
+          business_hours: "",
+          holiday: "",
+          homepage: "",
+          closed: false,
+          img: "",
+          latitude: 35.01,
+          longitude: 135.77,
+          genre_ids: [1],
+        }),
+        ...adminAuth,
+      },
+    );
+
+    const after = await mockClient<GreenteaListResponse>("/greenteas");
+    expect(after.meta.total_count).toBe(before.meta.total_count + 1);
+    expect(after.greenteas.some((g) => g.id === greentea.id)).toBe(true);
+  });
+
+  it("delete した抹茶店は GET /greenteas から消える", async () => {
+    await mockClient("/admin/greenteas/1", {
+      method: "DELETE",
+      ...adminAuth,
+    });
+
+    const after = await mockClient<GreenteaListResponse>("/greenteas");
+    expect(after.greenteas.some((g) => g.id === 1)).toBe(false);
+    await expect(mockClient("/greenteas/1")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("update した内容が GET /greenteas/:id に反映される", async () => {
+    await mockClient("/admin/greenteas/2", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "改名後" }),
+      ...adminAuth,
+    });
+
+    const res = await mockClient<GreenteaDetailResponse>("/greenteas/2");
+    expect(res.greentea.name).toBe("改名後");
+  });
+});
+
 describe("mockClient routing", () => {
   it("未定義パスは ApiError(404)", async () => {
     await expect(mockClient("/unknown")).rejects.toMatchObject({

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -26,8 +26,8 @@ import { ApiError } from "../error";
 import {
   mockAreas,
   mockGenres,
-  mockGreenteas,
-  mockTemples,
+  mockGreenteas as seedGreenteas,
+  mockTemples as seedTemples,
   mockUserName,
   seedGreenteaComments,
   seedTempleComments,
@@ -46,6 +46,8 @@ import {
   deleteMockTemple,
   deleteTempleComment,
   extractMockUserId,
+  getMockGreenteas,
+  getMockTemples,
   getGreenteaLikeDelta,
   getGreenteaLikedIds,
   getTempleLikeDelta,
@@ -149,6 +151,12 @@ export async function mockClient<T>(
   const params = url.searchParams;
   const headers = new Headers(options?.headers);
   const userId = extractMockUserId(headers);
+
+  // mock モードの単一の真実: 公開取得（list/detail/likes/nearby）も管理 CRUD も、
+  // 同じ可変ストアを参照する。seed から遅延初期化されるため、admin の
+  // create/update/delete が一覧・詳細に即座に反映される（Phase 1 で予告した切替）。
+  const mockGreenteas = getMockGreenteas(seedGreenteas);
+  const mockTemples = getMockTemples(seedTemples);
 
   if (method === "GET") {
     if (path === "/greenteas") {

--- a/src/lib/utils/__tests__/image.test.ts
+++ b/src/lib/utils/__tests__/image.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  NO_IMAGE_PLACEHOLDER,
+  imageSrcOrPlaceholder,
+} from "@/lib/utils/image";
+
+describe("imageSrcOrPlaceholder", () => {
+  it("URL があればそのまま返す", () => {
+    expect(imageSrcOrPlaceholder("https://example.com/x.png")).toBe(
+      "https://example.com/x.png",
+    );
+  });
+
+  it("空文字はプレースホルダにフォールバックする", () => {
+    expect(imageSrcOrPlaceholder("")).toBe(NO_IMAGE_PLACEHOLDER);
+  });
+
+  it("空白のみもプレースホルダにフォールバックする", () => {
+    expect(imageSrcOrPlaceholder("   ")).toBe(NO_IMAGE_PLACEHOLDER);
+  });
+
+  it("null / undefined もプレースホルダにフォールバックする", () => {
+    expect(imageSrcOrPlaceholder(null)).toBe(NO_IMAGE_PLACEHOLDER);
+    expect(imageSrcOrPlaceholder(undefined)).toBe(NO_IMAGE_PLACEHOLDER);
+  });
+
+  it("プレースホルダは data:image/svg+xml の URI", () => {
+    expect(NO_IMAGE_PLACEHOLDER.startsWith("data:image/svg+xml,")).toBe(true);
+  });
+});

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -1,0 +1,13 @@
+// 画像 URL が未設定（管理画面で img を空登録した場合や、実 API が空を返した場合）に
+// 使う「画像なし」プレースホルダ。外部依存を避けるため inline SVG の data URI にする。
+// img の src を空のままにするとブラウザが現在ページURLを再取得し、壊れた画像表示や
+// 余計なリクエストが発生するため、必ずこの関数で空をプレースホルダへ寄せる。
+const NO_IMAGE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect width="100%" height="100%" fill="#ece9e1"/><text x="50%" y="50%" fill="#9a958a" font-family="serif" font-size="20" text-anchor="middle" dominant-baseline="middle">No Image</text></svg>`;
+
+export const NO_IMAGE_PLACEHOLDER = `data:image/svg+xml,${encodeURIComponent(
+  NO_IMAGE_SVG,
+)}`;
+
+export function imageSrcOrPlaceholder(url: string | null | undefined): string {
+  return url && url.trim() !== "" ? url : NO_IMAGE_PLACEHOLDER;
+}

--- a/src/lib/validation/__tests__/greentea.test.ts
+++ b/src/lib/validation/__tests__/greentea.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { greenteaFormSchema } from "@/lib/validation/greentea";
+
+const validInput = {
+  name: "茶寮都路里",
+  description: "宇治抹茶のパフェ",
+  address: "京都市東山区祇園町南側",
+  access: "祇園四条駅から徒歩5分",
+  phone_number: "075-000-0001",
+  business_hours: "10:00-21:00",
+  holiday: "不定休",
+  homepage: "https://example.com/tsujiri",
+  closed: false,
+  img: "https://example.com/img.png",
+  latitude: 35.0036,
+  longitude: 135.7714,
+  genre_ids: [1, 2],
+};
+
+describe("greenteaFormSchema", () => {
+  it("妥当な入力を通す", () => {
+    const result = greenteaFormSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("name が空だとエラー", () => {
+    const result = greenteaFormSchema.safeParse({ ...validInput, name: "  " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "name")).toBe(true);
+    }
+  });
+
+  it("address が空だとエラー", () => {
+    const result = greenteaFormSchema.safeParse({ ...validInput, address: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("img / homepage は空文字を許容する", () => {
+    const result = greenteaFormSchema.safeParse({
+      ...validInput,
+      img: "",
+      homepage: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("img が http(s) 以外だとエラー", () => {
+    const result = greenteaFormSchema.safeParse({
+      ...validInput,
+      img: "ftp://example.com/x.png",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("緯度が範囲外だとエラー", () => {
+    const result = greenteaFormSchema.safeParse({ ...validInput, latitude: 120 });
+    expect(result.success).toBe(false);
+  });
+
+  it("緯度が未入力(NaN)だとエラー", () => {
+    const result = greenteaFormSchema.safeParse({
+      ...validInput,
+      latitude: NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("文字列フィールドは trim される", () => {
+    const result = greenteaFormSchema.safeParse({
+      ...validInput,
+      name: "  茶寮都路里  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("茶寮都路里");
+    }
+  });
+});

--- a/src/lib/validation/greentea.ts
+++ b/src/lib/validation/greentea.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// 任意入力の URL フィールド（img / homepage）。空文字は許容し、値があるときだけ
+// http(s):// 始まりを要求する。Rails 側のバリデーションと表記を揃える。
+const optionalHttpUrl = z
+  .string()
+  .trim()
+  .refine((v) => v === "" || /^https?:\/\/\S+$/i.test(v), {
+    message: "http(s):// から始まる URL を入力してください",
+  });
+
+// 緯度・経度は number 入力（valueAsNumber）から渡る。未入力は undefined / NaN に
+// なるが、zod v4 の z.number() はどちらも invalid_type として弾くため、その型エラー
+// メッセージを日本語の必須メッセージに差し替える。妥当な数値のときだけ範囲を見る。
+const latitude = z
+  .number({ error: "緯度を入力してください" })
+  .min(-90, { error: "緯度は -90〜90 の範囲で入力してください" })
+  .max(90, { error: "緯度は -90〜90 の範囲で入力してください" });
+
+const longitude = z
+  .number({ error: "経度を入力してください" })
+  .min(-180, { error: "経度は -180〜180 の範囲で入力してください" })
+  .max(180, { error: "経度は -180〜180 の範囲で入力してください" });
+
+// GreenteaInput（作成・更新 body）に一致するフォームスキーマ。
+// 必須は name / address のみ（issue #74 の方針）。その他は空文字を許容する。
+export const greenteaFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "店名は必須です" }),
+  description: z.string(),
+  address: z.string().trim().min(1, { message: "住所は必須です" }),
+  access: z.string(),
+  phone_number: z.string(),
+  business_hours: z.string(),
+  holiday: z.string(),
+  homepage: optionalHttpUrl,
+  closed: z.boolean(),
+  img: optionalHttpUrl,
+  latitude,
+  longitude,
+  genre_ids: z.array(z.number()),
+});
+
+export type GreenteaFormValues = z.infer<typeof greenteaFormSchema>;


### PR DESCRIPTION
## 概要

#71 の Phase 2。抹茶店（greenteas）の作成・編集・削除を管理画面に実装しました。Phase 1（#73 管理基盤・AdminGuard・mock CRUD バックエンド・admin API 関数雛形）の上に、UI とバリデーション・テストを追加しています。

Closes #74

## 追加したもの

### ページ（`src/app/admin/greenteas/`）
- `page.tsx` — 一覧（各行に編集/削除アクション・件数表示・ページネーション・「新規作成」導線）
- `new/page.tsx` — 新規作成フォーム
- `[id]/edit/page.tsx` — 編集フォーム（404 は `notFound()`）

一覧・新規・編集ページは Server Component で `getGreenteas()` / `getGenres()` / `getGreentea()` を取得し、書き込み・削除を担う Client Component に渡す構成です（CSR・認証必須の方針は親 issue 準拠。認可は Rails 側で別途 enforce 前提）。

### コンポーネント（`src/components/admin/`）
- `GreenteaForm.tsx` — **react-hook-form + zod**。`name, description, address, access, phone_number, business_hours, holiday, homepage, closed, img(URL), latitude, longitude, genres[]` を入力。genres は `getGenres()` から複数選択。作成/編集を `mode` で共用
- `ImageUrlField.tsx` — 画像 URL 入力＋プレビュー（MVP は URL のみ）
- `DeleteConfirmDialog.tsx` — 削除確認モーダル（Esc/フォーカス対応）
- `GreenteaAdminTable.tsx` — 一覧テーブル＋削除（確認ダイアログ経由）

### バリデーション（`src/lib/validation/greentea.ts`）
- `greenteaFormSchema`（zod）。必須は `name` / `address`。`img` / `homepage` は空許容で http(s) URL のみ。`latitude` / `longitude` は数値かつ妥当な範囲

## エラーハンドリング

#51 / #64 のパターンを流用：
- 401 → `useSessionExpiredHandler`（`signOut` ＋ ログイン誘導）
- 422 → `getApiErrorMessage` でメッセージ表示
- それ以外 → 汎用エラー表示

## モック対応

Phase 1 で整備済みの mock CRUD（`src/lib/api/mock/`）に乗るため、`NEXT_PUBLIC_USE_MOCK=true` で作成/編集/削除が一通り動作します。

## 依存追加

- `react-hook-form` / `zod` / `@hookform/resolvers`（CLAUDE.md「導入予定」のフォーム関連）

## テスト

- zod スキーマ単体（必須・URL・範囲・trim）
- `GreenteaForm` のバリデーション・送信（create/edit、未入力エラー）
- admin API クライアントの MSW 契約テスト（create=POST / update=PATCH / delete=DELETE のリクエスト形・Bearer 付与）

## 確認

- `npx tsc --noEmit` ✅
- `npx next lint` ✅（warning/error なし）
- `npx vitest run` ✅（21 files / 156 tests）
- `npx next build` ✅（`/admin/greenteas` 系ルート生成を確認）

## スコープ外（後続）

- Phase 3（神社 CRUD・#75）/ Phase 4（コメントモデレーション・#76）
- 実 Rails の admin CRUD API 結合（greentea_temple 側で別途 issue 化が必要）
- 画像ファイルアップロード（CarrierWave / Cloud Storage）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMjkSiBKYPw2vNm5Tyfbmw)_