### PR TITLE
feat: 管理画面 Phase 3 — 神社（temples）CRUD の実装 (#75)

### DIFF
--- a/src/app/admin/temples/[id]/edit/page.tsx
+++ b/src/app/admin/temples/[id]/edit/page.tsx
@@ -10,9 +10,13 @@ export default async function EditTemplePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const templeId = Number(id);
+  if (!Number.isInteger(templeId) || templeId <= 0) {
+    notFound();
+  }
 
   const [templeResult, { areas }] = await Promise.all([
-    getTemple(id).catch((e: unknown) => {
+    getTemple(templeId).catch((e: unknown) => {
       if (getErrorStatus(e) === 404) return null;
       throw e;
     }),

--- a/src/app/admin/temples/[id]/edit/page.tsx
+++ b/src/app/admin/temples/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import TempleForm from "@/components/admin/TempleForm";
+import { getAreas, getTemple } from "@/lib/api";
+import { getErrorStatus } from "@/lib/api";
+
+export default async function EditTemplePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const [templeResult, { areas }] = await Promise.all([
+    getTemple(id).catch((e: unknown) => {
+      if (getErrorStatus(e) === 404) return null;
+      throw e;
+    }),
+    getAreas(),
+  ]);
+
+  if (!templeResult) notFound();
+  const { temple } = templeResult;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/admin/temples"
+          className="font-sans-jp text-xs tracking-[0.1em] text-muted hover:text-olive"
+        >
+          ← 神社・仏閣の管理へ戻る
+        </Link>
+        <h1 className="mt-2 font-mincho text-xl tracking-[0.1em] text-ink">
+          神社・仏閣を編集
+        </h1>
+      </div>
+      <TempleForm areas={areas} mode="edit" initial={temple} />
+    </div>
+  );
+}

--- a/src/app/admin/temples/new/page.tsx
+++ b/src/app/admin/temples/new/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import TempleForm from "@/components/admin/TempleForm";
+import { getAreas } from "@/lib/api";
+
+export default async function NewTemplePage() {
+  const { areas } = await getAreas();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/admin/temples"
+          className="font-sans-jp text-xs tracking-[0.1em] text-muted hover:text-olive"
+        >
+          ← 神社・仏閣の管理へ戻る
+        </Link>
+        <h1 className="mt-2 font-mincho text-xl tracking-[0.1em] text-ink">
+          神社・仏閣を新規作成
+        </h1>
+      </div>
+      <TempleForm areas={areas} mode="create" />
+    </div>
+  );
+}

--- a/src/app/admin/temples/page.tsx
+++ b/src/app/admin/temples/page.tsx
@@ -13,7 +13,8 @@ export default async function AdminTemplesPage({
   searchParams: Promise<SearchParams>;
 }) {
   const sp = await searchParams;
-  const page = Math.max(1, Number(sp.page) || 1);
+  const parsedPage = Number.parseInt(sp.page ?? "", 10);
+  const page = Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;
 
   const { temples, meta } = await getTemples({ page });
 

--- a/src/app/admin/temples/page.tsx
+++ b/src/app/admin/temples/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { HiPlus } from "react-icons/hi2";
+import Pagination from "@/components/common/Pagination";
+import TempleAdminTable from "@/components/admin/TempleAdminTable";
+import { getTemples } from "@/lib/api";
+
+type SearchParams = { page?: string };
+
+export default async function AdminTemplesPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page) || 1);
+
+  const { temples, meta } = await getTemples({ page });
+
+  // 範囲外の page= は最終ページへ寄せる（公開一覧と同じガード）。
+  if (meta.total_pages > 0 && page > meta.total_pages) {
+    redirect(
+      meta.total_pages > 1
+        ? `/admin/temples?page=${meta.total_pages}`
+        : "/admin/temples",
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-mincho text-xl tracking-[0.1em] text-ink">
+            神社・仏閣の管理
+          </h1>
+          <p className="mt-1 font-sans-jp text-xs tracking-[0.1em] text-muted">
+            全 {meta.total_count} 件
+            {meta.total_pages > 1 &&
+              ` ( ${meta.current_page} / ${meta.total_pages} ページ )`}
+          </p>
+        </div>
+        <Link
+          href="/admin/temples/new"
+          className="inline-flex items-center gap-1.5 border border-olive bg-olive px-4 py-2 font-mincho text-[13px] tracking-[0.12em] text-paper transition-colors hover:bg-olive-dark"
+        >
+          <HiPlus className="h-4 w-4" aria-hidden="true" />
+          新規作成
+        </Link>
+      </div>
+
+      <TempleAdminTable temples={temples} />
+
+      <div className="mt-8">
+        <Pagination
+          basePath="/admin/temples"
+          currentPage={meta.current_page}
+          totalPages={meta.total_pages}
+          preservedQuery=""
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -9,6 +9,7 @@ import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import { ApiError, getTemple } from "@/lib/api";
 import { auth } from "@/lib/auth";
+import { imageSrcOrPlaceholder } from "@/lib/utils/image";
 import type { NearbySpot, TempleDetail } from "@/types";
 
 type RouteParams = { id: string };
@@ -158,7 +159,7 @@ export default async function TempleDetailPage({
         <div className="aspect-[16/9] w-full">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={temple.img}
+            src={imageSrcOrPlaceholder(temple.img)}
             alt={temple.name}
             className="h-full w-full object-cover"
           />

--- a/src/components/admin/TempleAdminTable.tsx
+++ b/src/components/admin/TempleAdminTable.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { HiPencilSquare, HiTrash } from "react-icons/hi2";
+import { deleteTemple } from "@/lib/api/admin/temples";
+import { isUnauthorized } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import type { Temple } from "@/types";
+import DeleteConfirmDialog from "./DeleteConfirmDialog";
+
+type TempleAdminTableProps = {
+  temples: Temple[];
+};
+
+export default function TempleAdminTable({ temples }: TempleAdminTableProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler("/admin/temples");
+  const [target, setTarget] = useState<Temple | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, startDelete] = useTransition();
+
+  const handleConfirm = () => {
+    if (!target) return;
+    const id = target.id;
+    setDeleteError(null);
+    startDelete(async () => {
+      if (!authToken) {
+        await handleSessionExpired();
+        return;
+      }
+      try {
+        await deleteTemple(id, authToken);
+        setTarget(null);
+        router.refresh();
+      } catch (e) {
+        if (isUnauthorized(e)) {
+          await handleSessionExpired();
+          return;
+        }
+        setDeleteError("削除に失敗しました。時間を置いてお試しください。");
+      }
+    });
+  };
+
+  if (temples.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-8 text-center font-serif-jp text-sm text-muted">
+        登録された神社・仏閣がありません。
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto border border-line">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-line bg-washi text-left">
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                神社名
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                住所
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                エリア
+              </th>
+              <th className="px-4 py-2.5 text-right font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {temples.map((t) => (
+              <tr key={t.id} className="border-b border-line-soft last:border-0">
+                <td className="px-4 py-3 font-mincho text-sm text-ink">
+                  {t.name}
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-xs text-muted">
+                  {t.address}
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-xs text-muted">
+                  {t.areas.map((area) => area.name).join(" / ") || "—"}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex justify-end gap-2">
+                    <Link
+                      href={`/admin/temples/${t.id}/edit`}
+                      className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-ink transition-colors hover:border-olive hover:text-olive"
+                    >
+                      <HiPencilSquare className="h-3.5 w-3.5" aria-hidden="true" />
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteError(null);
+                        setTarget(t);
+                      }}
+                      className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-muted transition-colors hover:border-bengara hover:text-bengara"
+                    >
+                      <HiTrash className="h-3.5 w-3.5" aria-hidden="true" />
+                      削除
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <DeleteConfirmDialog
+        open={target !== null}
+        title="神社・仏閣を削除"
+        message={
+          target
+            ? `「${target.name}」を削除します。この操作は取り消せません。`
+            : ""
+        }
+        loading={deleting}
+        error={deleteError}
+        onConfirm={handleConfirm}
+        onCancel={() => {
+          if (!deleting) {
+            setTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/admin/TempleForm.tsx
+++ b/src/components/admin/TempleForm.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createTemple, updateTemple } from "@/lib/api/admin/temples";
+import { getApiErrorMessage, isUnauthorized, isValidationError } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import {
+  templeFormSchema,
+  type TempleFormValues,
+} from "@/lib/validation/temple";
+import type { Area, Temple } from "@/types";
+import ImageUrlField from "./ImageUrlField";
+
+type TempleFormProps = {
+  areas: Area[];
+  mode: "create" | "edit";
+  initial?: Temple;
+};
+
+function toDefaults(initial?: Temple): Partial<TempleFormValues> {
+  return {
+    name: initial?.name ?? "",
+    description: initial?.description ?? "",
+    address: initial?.address ?? "",
+    access: initial?.access ?? "",
+    phone_number: initial?.phone_number ?? "",
+    business_hours: initial?.business_hours ?? "",
+    holiday: initial?.holiday ?? "",
+    homepage: initial?.homepage ?? "",
+    img: initial?.img ?? "",
+    // 未入力（新規）は number 入力で NaN になり、スキーマ側で必須エラーになる。
+    latitude: initial?.latitude,
+    longitude: initial?.longitude,
+    area_ids: initial?.areas.map((a) => a.id) ?? [],
+  };
+}
+
+export default function TempleForm({ areas, mode, initial }: TempleFormProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler("/admin/temples");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<TempleFormValues>({
+    resolver: zodResolver(templeFormSchema),
+    defaultValues: toDefaults(initial),
+  });
+
+  const imgValue = watch("img") ?? "";
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (!authToken) {
+      await handleSessionExpired();
+      return;
+    }
+    setSubmitError(null);
+    try {
+      if (mode === "create") {
+        await createTemple(values, authToken);
+      } else if (initial) {
+        await updateTemple(initial.id, values, authToken);
+      }
+      router.push("/admin/temples");
+      router.refresh();
+    } catch (e) {
+      if (isUnauthorized(e)) {
+        await handleSessionExpired();
+        return;
+      }
+      if (isValidationError(e)) {
+        setSubmitError(getApiErrorMessage(e, "入力内容を確認してください。"));
+        return;
+      }
+      setSubmitError("保存に失敗しました。時間を置いてお試しください。");
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="flex max-w-2xl flex-col gap-5">
+      <TextField
+        id="name"
+        label="神社名 / NAME *"
+        error={errors.name?.message}
+        registration={register("name")}
+      />
+      <TextArea
+        id="description"
+        label="説明 / DESCRIPTION"
+        error={errors.description?.message}
+        registration={register("description")}
+      />
+      <TextField
+        id="address"
+        label="住所 / ADDRESS *"
+        error={errors.address?.message}
+        registration={register("address")}
+      />
+      <TextField
+        id="access"
+        label="アクセス / ACCESS"
+        error={errors.access?.message}
+        registration={register("access")}
+      />
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <TextField
+          id="phone_number"
+          label="電話番号 / PHONE"
+          error={errors.phone_number?.message}
+          registration={register("phone_number")}
+        />
+        <TextField
+          id="business_hours"
+          label="参拝時間 / HOURS"
+          error={errors.business_hours?.message}
+          registration={register("business_hours")}
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <TextField
+          id="holiday"
+          label="定休日 / HOLIDAY"
+          error={errors.holiday?.message}
+          registration={register("holiday")}
+        />
+        <TextField
+          id="homepage"
+          label="ホームページ / HOMEPAGE"
+          error={errors.homepage?.message}
+          registration={register("homepage")}
+        />
+      </div>
+
+      <ImageUrlField
+        id="img"
+        label="画像 URL / IMAGE"
+        value={imgValue}
+        error={errors.img?.message}
+        registration={register("img")}
+      />
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <NumberField
+          id="latitude"
+          label="緯度 / LATITUDE *"
+          error={errors.latitude?.message}
+          registration={register("latitude", { valueAsNumber: true })}
+        />
+        <NumberField
+          id="longitude"
+          label="経度 / LONGITUDE *"
+          error={errors.longitude?.message}
+          registration={register("longitude", { valueAsNumber: true })}
+        />
+      </div>
+
+      <fieldset className="flex flex-col gap-2">
+        <legend className="font-sans-jp text-[11px] tracking-[0.2em] text-olive">
+          エリア / AREAS
+        </legend>
+        <Controller
+          control={control}
+          name="area_ids"
+          render={({ field }) => (
+            <div className="flex flex-wrap gap-3">
+              {areas.map((area) => {
+                const checked = field.value?.includes(area.id) ?? false;
+                return (
+                  <label
+                    key={area.id}
+                    className="flex items-center gap-1.5 border border-line bg-paper px-3 py-1.5"
+                  >
+                    <input
+                      type="checkbox"
+                      value={area.id}
+                      checked={checked}
+                      onChange={(e) => {
+                        const next = new Set(field.value ?? []);
+                        if (e.target.checked) next.add(area.id);
+                        else next.delete(area.id);
+                        field.onChange([...next]);
+                      }}
+                      className="h-4 w-4 accent-olive"
+                    />
+                    <span className="font-serif-jp text-sm text-ink">
+                      {area.name}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        />
+      </fieldset>
+
+      {submitError && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {submitError}
+        </p>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="border border-olive bg-olive px-6 py-2 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          {isSubmitting ? "保存中…" : mode === "create" ? "作成する" : "更新する"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push("/admin/temples")}
+          disabled={isSubmitting}
+          className="border border-line bg-paper px-5 py-2 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-washi disabled:opacity-60"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type FieldProps = {
+  id: string;
+  label: string;
+  error?: string;
+  registration: React.ComponentProps<"input">;
+};
+
+function TextField({ id, label, error, registration }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="text"
+        className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NumberField({ id, label, error, registration }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        step="any"
+        className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function TextArea({
+  id,
+  label,
+  error,
+  registration,
+}: {
+  id: string;
+  label: string;
+  error?: string;
+  registration: React.ComponentProps<"textarea">;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+      >
+        {label}
+      </label>
+      <textarea
+        id={id}
+        rows={3}
+        className="resize-y border border-line bg-washi px-3 py-2 font-serif-jp text-sm leading-[1.9] text-ink focus:border-olive focus:outline-none"
+        {...registration}
+      />
+      {error && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/TempleForm.tsx
+++ b/src/components/admin/TempleForm.tsx
@@ -15,11 +15,12 @@ import {
 import type { Area, Temple } from "@/types";
 import ImageUrlField from "./ImageUrlField";
 
-type TempleFormProps = {
-  areas: Area[];
-  mode: "create" | "edit";
-  initial?: Temple;
-};
+// edit モードでは initial を必須にして、initial 無しの edit という不正状態を
+// 型レベルで排除する（initial 無し edit だと書き込みをスキップしたまま一覧へ
+// リダイレクトし、偽の成功になってしまうため）。
+type TempleFormProps =
+  | { areas: Area[]; mode: "create"; initial?: never }
+  | { areas: Area[]; mode: "edit"; initial: Temple };
 
 function toDefaults(initial?: Temple): Partial<TempleFormValues> {
   return {
@@ -39,7 +40,8 @@ function toDefaults(initial?: Temple): Partial<TempleFormValues> {
   };
 }
 
-export default function TempleForm({ areas, mode, initial }: TempleFormProps) {
+export default function TempleForm(props: TempleFormProps) {
+  const { areas, mode, initial } = props;
   const router = useRouter();
   const authToken = useAuthToken();
   const handleSessionExpired = useSessionExpiredHandler("/admin/temples");
@@ -65,10 +67,12 @@ export default function TempleForm({ areas, mode, initial }: TempleFormProps) {
     }
     setSubmitError(null);
     try {
-      if (mode === "create") {
+      // props 経由で参照して discriminated union のナローイングを効かせる
+      // （edit 分岐では props.initial が Temple として確定する）。
+      if (props.mode === "create") {
         await createTemple(values, authToken);
-      } else if (initial) {
-        await updateTemple(initial.id, values, authToken);
+      } else {
+        await updateTemple(props.initial.id, values, authToken);
       }
       router.push("/admin/temples");
       router.refresh();

--- a/src/components/admin/__tests__/TempleForm.test.tsx
+++ b/src/components/admin/__tests__/TempleForm.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TempleForm from "@/components/admin/TempleForm";
+import type { Area, Temple } from "@/types";
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const createTempleMock = vi.fn();
+const updateTempleMock = vi.fn();
+const useSessionMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/api/admin/temples", () => ({
+  createTemple: (...args: unknown[]) => createTempleMock(...args),
+  updateTemple: (...args: unknown[]) => updateTempleMock(...args),
+}));
+
+const areas: Area[] = [
+  { id: 1, name: "東山区" },
+  { id: 2, name: "左京区" },
+];
+
+beforeEach(() => {
+  pushMock.mockReset();
+  refreshMock.mockReset();
+  createTempleMock.mockReset().mockResolvedValue({ temple: { id: 1 } });
+  updateTempleMock.mockReset().mockResolvedValue({ temple: { id: 1 } });
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+});
+
+async function fillRequired(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/神社名/), "新神社");
+  await user.type(screen.getByLabelText(/住所/), "京都市左京区");
+  await user.type(screen.getByLabelText(/緯度/), "35.01");
+  await user.type(screen.getByLabelText(/経度/), "135.77");
+}
+
+describe("TempleForm (create)", () => {
+  it("必須を満たして送信すると createTemple が呼ばれ一覧へ遷移する", async () => {
+    const user = userEvent.setup();
+    render(<TempleForm areas={areas} mode="create" />);
+
+    await fillRequired(user);
+    await user.click(screen.getByLabelText("東山区"));
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    await waitFor(() => expect(createTempleMock).toHaveBeenCalledTimes(1));
+    const [payload, token] = createTempleMock.mock.calls[0];
+    expect(token).toBe("jwt-token");
+    expect(payload).toMatchObject({
+      name: "新神社",
+      address: "京都市左京区",
+      latitude: 35.01,
+      longitude: 135.77,
+      area_ids: [1],
+    });
+    expect(pushMock).toHaveBeenCalledWith("/admin/temples");
+  });
+
+  it("神社名が空だとバリデーションエラーになり API を呼ばない", async () => {
+    const user = userEvent.setup();
+    render(<TempleForm areas={areas} mode="create" />);
+
+    // 住所・緯度・経度だけ埋めて神社名は空のまま
+    await user.type(screen.getByLabelText(/住所/), "京都市左京区");
+    await user.type(screen.getByLabelText(/緯度/), "35.01");
+    await user.type(screen.getByLabelText(/経度/), "135.77");
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    expect(await screen.findByText("神社名は必須です")).toBeInTheDocument();
+    expect(createTempleMock).not.toHaveBeenCalled();
+  });
+
+  it("緯度未入力だと必須エラーになる", async () => {
+    const user = userEvent.setup();
+    render(<TempleForm areas={areas} mode="create" />);
+
+    await user.type(screen.getByLabelText(/神社名/), "新神社");
+    await user.type(screen.getByLabelText(/住所/), "京都市左京区");
+    await user.type(screen.getByLabelText(/経度/), "135.77");
+    await user.click(screen.getByRole("button", { name: "作成する" }));
+
+    expect(await screen.findByText("緯度を入力してください")).toBeInTheDocument();
+    expect(createTempleMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("TempleForm (edit)", () => {
+  const initial: Temple = {
+    id: 5,
+    name: "既存神社",
+    description: "説明",
+    address: "京都市東山区",
+    access: "徒歩5分",
+    phone_number: "075-000-0005",
+    business_hours: "終日参拝可",
+    holiday: "なし",
+    homepage: "https://example.com",
+    img: "https://example.com/x.png",
+    latitude: 35.0,
+    longitude: 135.77,
+    areas: [areas[0]],
+    likes_count: 3,
+  };
+
+  it("初期値が反映され、更新で updateTemple が id 付きで呼ばれる", async () => {
+    const user = userEvent.setup();
+    render(<TempleForm areas={areas} mode="edit" initial={initial} />);
+
+    expect(screen.getByLabelText(/神社名/)).toHaveValue("既存神社");
+
+    await user.clear(screen.getByLabelText(/神社名/));
+    await user.type(screen.getByLabelText(/神社名/), "改名後");
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(() => expect(updateTempleMock).toHaveBeenCalledTimes(1));
+    const [id, payload, token] = updateTempleMock.mock.calls[0];
+    expect(id).toBe(5);
+    expect(token).toBe("jwt-token");
+    expect(payload).toMatchObject({ name: "改名後", area_ids: [1] });
+  });
+});

--- a/src/components/temple/TempleCard.tsx
+++ b/src/components/temple/TempleCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
+import { imageSrcOrPlaceholder } from "@/lib/utils/image";
 import type { Temple } from "@/types";
 
 type TempleCardProps = {
@@ -16,7 +17,7 @@ export default function TempleCard({ temple }: TempleCardProps) {
         {/* 画像は Rails(CarrierWave)/外部 URL をそのまま表示するため next/image を使わない */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={temple.img}
+          src={imageSrcOrPlaceholder(temple.img)}
           alt={temple.name}
           loading="lazy"
           className="h-full w-full object-cover"

--- a/src/lib/api/admin/__tests__/temples.test.ts
+++ b/src/lib/api/admin/__tests__/temples.test.ts
@@ -1,0 +1,89 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import {
+  createTemple,
+  deleteTemple,
+  updateTemple,
+} from "@/lib/api/admin/temples";
+import type { TempleInput } from "@/types";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const input: TempleInput = {
+  name: "新神社",
+  description: "説明",
+  address: "京都市左京区",
+  access: "駅から徒歩1分",
+  phone_number: "075-000-0000",
+  business_hours: "終日参拝可",
+  holiday: "なし",
+  homepage: "https://example.com",
+  img: "https://example.com/x.png",
+  latitude: 35.01,
+  longitude: 135.77,
+  area_ids: [1, 2],
+};
+
+const templeFixture = {
+  id: 9001,
+  ...input,
+  areas: [{ id: 1, name: "東山区" }],
+  likes_count: 0,
+  liked_by_current_user: false,
+};
+
+describe("admin/temples API", () => {
+  it("createTemple は POST /admin/temples に body と Bearer を送る", async () => {
+    let captured: { auth: string | null; body: unknown } | null = null;
+    server.use(
+      http.post(endpoint("/admin/temples"), async ({ request }) => {
+        captured = {
+          auth: request.headers.get("Authorization"),
+          body: await request.json(),
+        };
+        return HttpResponse.json({ temple: templeFixture });
+      }),
+    );
+
+    const res = await createTemple(input, "jwt-token");
+
+    expect(captured).not.toBeNull();
+    expect(captured!.auth).toBe("Bearer jwt-token");
+    expect(captured!.body).toEqual(input);
+    expect(res.temple.id).toBe(9001);
+  });
+
+  it("updateTemple は PATCH /admin/temples/:id に部分 body を送る", async () => {
+    let captured: { method: string; body: unknown } | null = null;
+    server.use(
+      http.patch(endpoint("/admin/temples/9001"), async ({ request }) => {
+        captured = { method: request.method, body: await request.json() };
+        return HttpResponse.json({
+          temple: { ...templeFixture, name: "更新後" },
+        });
+      }),
+    );
+
+    const res = await updateTemple(9001, { name: "更新後" }, "jwt-token");
+
+    expect(captured!.method).toBe("PATCH");
+    expect(captured!.body).toEqual({ name: "更新後" });
+    expect(res.temple.name).toBe("更新後");
+  });
+
+  it("deleteTemple は DELETE /admin/temples/:id を呼ぶ（204）", async () => {
+    let called = false;
+    server.use(
+      http.delete(endpoint("/admin/temples/9001"), () => {
+        called = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    await expect(deleteTemple(9001, "jwt-token")).resolves.toBeUndefined();
+    expect(called).toBe(true);
+  });
+});

--- a/src/lib/validation/__tests__/temple.test.ts
+++ b/src/lib/validation/__tests__/temple.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { templeFormSchema } from "@/lib/validation/temple";
+
+const validInput = {
+  name: "八坂神社",
+  description: "祇園さん",
+  address: "京都市東山区祇園町北側625",
+  access: "祇園四条駅から徒歩5分",
+  phone_number: "075-000-0002",
+  business_hours: "終日参拝可",
+  holiday: "なし",
+  homepage: "https://example.com/yasaka",
+  img: "https://example.com/img.png",
+  latitude: 35.0036,
+  longitude: 135.7785,
+  area_ids: [1, 2],
+};
+
+describe("templeFormSchema", () => {
+  it("妥当な入力を通す", () => {
+    const result = templeFormSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("name が空だとエラー", () => {
+    const result = templeFormSchema.safeParse({ ...validInput, name: "  " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "name")).toBe(true);
+    }
+  });
+
+  it("address が空だとエラー", () => {
+    const result = templeFormSchema.safeParse({ ...validInput, address: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("img / homepage は空文字を許容する", () => {
+    const result = templeFormSchema.safeParse({
+      ...validInput,
+      img: "",
+      homepage: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("img が http(s) 以外だとエラー", () => {
+    const result = templeFormSchema.safeParse({
+      ...validInput,
+      img: "ftp://example.com/x.png",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("緯度が範囲外だとエラー", () => {
+    const result = templeFormSchema.safeParse({ ...validInput, latitude: 120 });
+    expect(result.success).toBe(false);
+  });
+
+  it("緯度が未入力(NaN)だとエラー", () => {
+    const result = templeFormSchema.safeParse({
+      ...validInput,
+      latitude: NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("文字列フィールドは trim される", () => {
+    const result = templeFormSchema.safeParse({
+      ...validInput,
+      name: "  八坂神社  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("八坂神社");
+    }
+  });
+});

--- a/src/lib/validation/temple.ts
+++ b/src/lib/validation/temple.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// 任意入力の URL フィールド（img / homepage）。空文字は許容し、値があるときだけ
+// http(s):// 始まりを要求する。Rails 側のバリデーションと表記を揃える。
+const optionalHttpUrl = z
+  .string()
+  .trim()
+  .refine((v) => v === "" || /^https?:\/\/\S+$/i.test(v), {
+    message: "http(s):// から始まる URL を入力してください",
+  });
+
+// 緯度・経度は number 入力（valueAsNumber）から渡る。未入力は undefined / NaN に
+// なるが、zod v4 の z.number() はどちらも invalid_type として弾くため、その型エラー
+// メッセージを日本語の必須メッセージに差し替える。妥当な数値のときだけ範囲を見る。
+const latitude = z
+  .number({ error: "緯度を入力してください" })
+  .min(-90, { error: "緯度は -90〜90 の範囲で入力してください" })
+  .max(90, { error: "緯度は -90〜90 の範囲で入力してください" });
+
+const longitude = z
+  .number({ error: "経度を入力してください" })
+  .min(-180, { error: "経度は -180〜180 の範囲で入力してください" })
+  .max(180, { error: "経度は -180〜180 の範囲で入力してください" });
+
+// TempleInput（作成・更新 body）に一致するフォームスキーマ。
+// 必須は name / address のみ（issue #75 の方針）。その他は空文字を許容する。
+// greentea と違い closed フィールドはなく、genre_ids ではなく area_ids を持つ。
+export const templeFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "神社名は必須です" }),
+  description: z.string(),
+  address: z.string().trim().min(1, { message: "住所は必須です" }),
+  access: z.string(),
+  phone_number: z.string(),
+  business_hours: z.string(),
+  holiday: z.string(),
+  homepage: optionalHttpUrl,
+  img: optionalHttpUrl,
+  latitude,
+  longitude,
+  area_ids: z.array(z.number()),
+});
+
+export type TempleFormValues = z.infer<typeof templeFormSchema>;


### PR DESCRIPTION
## 概要

#71（管理画面）の **Phase 3: 神社（temples）CRUD** を実装しました。Phase 2（抹茶店）と同構成で、神社・仏閣の作成・編集・削除を管理画面から行えるようにします。

`Closes #75`

## 変更内容

### ページ（CSR・認証必須・admin role）
- `src/app/admin/temples/page.tsx` — 一覧（編集 / 削除アクション・ページネーション）
- `src/app/admin/temples/new/page.tsx` — 新規作成
- `src/app/admin/temples/[id]/edit/page.tsx` — 編集（404 は `notFound()`）

### コンポーネント
- `src/components/admin/TempleForm.tsx` — react-hook-form + zod。フィールドは `name, description, address, access, phone_number, business_hours, holiday, homepage, img(URL), latitude, longitude, areas[]`（抹茶店と異なり `closed` なし、`genres` ではなく `areas` を `getAreas()` から複数選択）。401 は `signOut` + ログイン誘導、422 はメッセージ表示。
- `src/components/admin/TempleAdminTable.tsx` — 削除（確認ダイアログ・楽観更新後の `router.refresh()`）

### バリデーション
- `src/lib/validation/temple.ts` — `templeFormSchema`（必須は `name` / `address`、URL は空許容で http(s) のみ、緯度経度は範囲チェック）

### テスト
- `src/lib/validation/__tests__/temple.test.ts` — zod スキーマの単体テスト
- `src/components/admin/__tests__/TempleForm.test.tsx` — 作成 / 編集 / バリデーションの送信テスト
- `src/lib/api/admin/__tests__/temples.test.ts` — admin API クライアントの MSW 契約テスト（create / update / delete のリクエスト形・Bearer）

## 補足

- admin API 関数（`createTemple / updateTemple / deleteTemple`）・mock モードの Temple CRUD（`createMockTemple` 等）・型（`TempleInput`）は **Phase 2 で先行実装済み** のものを利用しています。本 PR は UI 層とテストの追加が中心です。
- `NEXT_PUBLIC_USE_MOCK=true` でも一覧 / 作成 / 編集 / 削除が一通り動作します（mock router に admin/temples ルート配線済み）。
- 実際の認可は Rails 側で Bearer + role により enforce する前提（フロントの role ガードは UX 用）。

## 確認

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run lint` 警告・エラーなし
- [x] `npx vitest run` 全 179 テスト通過
- [x] `npm run build` 成功（`/admin/temples`・`/admin/temples/new`・`/admin/temples/[id]/edit` 生成を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012miZwXD6SwNzKLCSVdgjNs

---
_Generated by [Claude Code](https://claude.ai/code/session_012miZwXD6SwNzKLCSVdgjNs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin temples list with pagination, total counts, and quick access to create, edit, and delete actions.
  * Added separate pages for creating and editing temple entries, with a shared form for both flows.
* **Bug Fixes**
  * Improved page handling so out-of-range admin list pages redirect to a valid page.
  * Added clearer validation and error messages for temple details, including links, coordinates, and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->