### PR TITLE
feat: 管理画面 Phase 4 — コメントモデレーションの実装 (#76)

### DIFF
--- a/src/app/admin/comments/page.tsx
+++ b/src/app/admin/comments/page.tsx
@@ -1,0 +1,18 @@
+import CommentModerationList from "@/components/admin/CommentModerationList";
+
+export default function AdminCommentsPage() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-mincho text-xl tracking-[0.1em] text-ink">
+          コメントの管理
+        </h1>
+        <p className="mt-1 font-sans-jp text-xs tracking-[0.1em] text-muted">
+          抹茶店・神社仏閣に投稿されたコメントを横断して確認・削除できます。
+        </p>
+      </div>
+
+      <CommentModerationList />
+    </div>
+  );
+}

--- a/src/components/admin/CommentModerationList.tsx
+++ b/src/components/admin/CommentModerationList.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, useTransition } from "react";
+import useSWR from "swr";
+import { HiTrash } from "react-icons/hi2";
+import { ApiError, isForbidden, isUnauthorized } from "@/lib/api";
+import {
+  adminDeleteGreenteaComment,
+  adminDeleteTempleComment,
+  listAdminComments,
+} from "@/lib/api/admin/comments";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import type { AdminComment, AdminCommentListResponse } from "@/types";
+import DeleteConfirmDialog from "./DeleteConfirmDialog";
+
+const CALLBACK_URL = "/admin/comments";
+type SwrKey = readonly [string, string];
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function resourceHref(comment: AdminComment): string {
+  return comment.resource_type === "greentea"
+    ? `/greenteas/${comment.resource_id}`
+    : `/temples/${comment.resource_id}`;
+}
+
+export default function CommentModerationList() {
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler(CALLBACK_URL);
+  const [target, setTarget] = useState<AdminComment | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, startDelete] = useTransition();
+
+  // フェッチャーは SWR キーからトークンを取り出す（クロージャ越しの authToken に
+  // 依存するとキャッシュ無効化のタイミングがずれるため）。
+  const fetcher = ([, token]: SwrKey): Promise<AdminCommentListResponse> =>
+    listAdminComments(token);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    AdminCommentListResponse,
+    ApiError,
+    SwrKey | null
+  >(authToken ? (["/admin/comments", authToken] as const) : null, fetcher);
+
+  // 一覧取得時の 401（セッション切れ）はレンダー中に処理できないため effect で。
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) {
+      void handleSessionExpired();
+    }
+  }, [sessionExpired, handleSessionExpired]);
+
+  const handleConfirm = () => {
+    if (!target) return;
+    const comment = target;
+    setDeleteError(null);
+    startDelete(async () => {
+      if (!authToken) {
+        await handleSessionExpired();
+        return;
+      }
+      try {
+        if (comment.resource_type === "greentea") {
+          await adminDeleteGreenteaComment(comment.id, authToken);
+        } else {
+          await adminDeleteTempleComment(comment.id, authToken);
+        }
+        setTarget(null);
+        // 楽観的更新はせず、削除後に再取得して一覧を確定させる。
+        await mutate();
+      } catch (e) {
+        if (isUnauthorized(e)) {
+          await handleSessionExpired();
+          return;
+        }
+        if (isForbidden(e)) {
+          setDeleteError("このコメントを削除する権限がありません。");
+          return;
+        }
+        setDeleteError("削除に失敗しました。時間を置いてお試しください。");
+      }
+    });
+  };
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          コメント管理の表示にはログインが必要です。
+        </p>
+        <Link
+          href={`/auth/login?callbackUrl=${encodeURIComponent(CALLBACK_URL)}`}
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (error) {
+    const msg = isUnauthorized(error)
+      ? "ログインの有効期限が切れました。再度ログインしてください。"
+      : "コメントの取得に失敗しました。時間を置いてお試しください。";
+    return (
+      <p role="alert" className="font-sans-jp text-xs text-bengara">
+        {msg}
+      </p>
+    );
+  }
+
+  const comments = data?.comments ?? [];
+
+  if (comments.length === 0) {
+    return (
+      <p className="border border-line-soft bg-paper px-5 py-8 text-center font-serif-jp text-sm text-muted">
+        コメントがありません。
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto border border-line">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-line bg-washi text-left">
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                対象
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                投稿者
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                本文
+              </th>
+              <th className="px-4 py-2.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                投稿日
+              </th>
+              <th className="px-4 py-2.5 text-right font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                操作
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {comments.map((comment) => (
+              <tr
+                key={`${comment.resource_type}-${comment.id}`}
+                className="border-b border-line-soft last:border-0 align-top"
+              >
+                <td className="px-4 py-3">
+                  <span className="mb-1 inline-block border border-line px-2 py-0.5 font-sans-jp text-[10px] tracking-[0.1em] text-muted">
+                    {comment.resource_type === "greentea" ? "抹茶店" : "神社・仏閣"}
+                  </span>
+                  <Link
+                    href={resourceHref(comment)}
+                    className="block font-mincho text-sm text-ink transition-colors hover:text-olive"
+                  >
+                    {comment.resource_name || `#${comment.resource_id}`}
+                  </Link>
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-xs text-muted">
+                  {comment.user.name}
+                </td>
+                <td className="px-4 py-3 font-serif-jp text-sm leading-[1.8] text-ink">
+                  <span className="block max-w-md whitespace-pre-wrap break-words">
+                    {comment.body}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 font-sans-jp text-xs text-muted">
+                  {formatDate(comment.created_at)}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteError(null);
+                        setTarget(comment);
+                      }}
+                      className="inline-flex items-center gap-1 border border-line px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-muted transition-colors hover:border-bengara hover:text-bengara"
+                    >
+                      <HiTrash className="h-3.5 w-3.5" aria-hidden="true" />
+                      削除
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <DeleteConfirmDialog
+        open={target !== null}
+        title="コメントを削除"
+        message={
+          target
+            ? `「${target.resource_name || `#${target.resource_id}`}」への ${target.user.name} さんのコメントを削除します。この操作は取り消せません。`
+            : ""
+        }
+        loading={deleting}
+        error={deleteError}
+        onConfirm={handleConfirm}
+        onCancel={() => {
+          if (!deleting) {
+            setTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/admin/CommentModerationList.tsx
+++ b/src/components/admin/CommentModerationList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { useEffect, useState, useTransition } from "react";
 import useSWR from "swr";
 import { HiTrash } from "react-icons/hi2";
@@ -37,6 +38,7 @@ function resourceHref(comment: AdminComment): string {
 }
 
 export default function CommentModerationList() {
+  const { status } = useSession();
   const authToken = useAuthToken();
   const handleSessionExpired = useSessionExpiredHandler(CALLBACK_URL);
   const [target, setTarget] = useState<AdminComment | null>(null);
@@ -94,6 +96,16 @@ export default function CommentModerationList() {
     });
   };
 
+  // NextAuth セッション解決中はログイン CTA を出さない。解決前は railsJwt が
+  // 一時的に undefined になり、ログイン済み admin に誤って CTA が見えてしまうため。
+  if (status === "loading") {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
   if (!authToken) {
     return (
       <div className="border border-line-soft bg-paper px-5 py-6">
@@ -121,7 +133,9 @@ export default function CommentModerationList() {
   if (error) {
     const msg = isUnauthorized(error)
       ? "ログインの有効期限が切れました。再度ログインしてください。"
-      : "コメントの取得に失敗しました。時間を置いてお試しください。";
+      : isForbidden(error)
+        ? "この画面を表示する権限がありません。"
+        : "コメントの取得に失敗しました。時間を置いてお試しください。";
     return (
       <p role="alert" className="font-sans-jp text-xs text-bengara">
         {msg}

--- a/src/components/admin/__tests__/CommentModerationList.test.tsx
+++ b/src/components/admin/__tests__/CommentModerationList.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CommentModerationList from "@/components/admin/CommentModerationList";
+import { server } from "@tests/msw/server";
+
+const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const comments = [
+  {
+    id: 101,
+    body: "抹茶パフェが最高でした",
+    user: { id: 1, name: "テスト太郎" },
+    created_at: "2026-06-01T00:00:00.000Z",
+    resource_type: "greentea",
+    resource_id: 1,
+    resource_name: "茶寮 翠",
+  },
+  {
+    id: 202,
+    body: "静かで落ち着く神社でした",
+    user: { id: 2, name: "テスト花子" },
+    created_at: "2026-06-02T00:00:00.000Z",
+    resource_type: "temple",
+    resource_id: 3,
+    resource_name: "下鴨神社",
+  },
+];
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+});
+
+function renderWithSwr(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("CommentModerationList — コメントモデレーション", () => {
+  it("未ログインではログイン案内とログインリンクを表示する", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<CommentModerationList />);
+
+    expect(
+      screen.getByText(/コメント管理の表示にはログインが必要/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /ログインへ/ })).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Fadmin%2Fcomments",
+    );
+  });
+
+  it("ログイン時は横断コメント一覧を対象リンク付きで表示する", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(endpoint("/admin/comments"), () =>
+        HttpResponse.json({ comments }),
+      ),
+    );
+
+    renderWithSwr(<CommentModerationList />);
+
+    expect(await screen.findByText("抹茶パフェが最高でした")).toBeInTheDocument();
+    expect(screen.getByText("静かで落ち着く神社でした")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "茶寮 翠" })).toHaveAttribute(
+      "href",
+      "/greenteas/1",
+    );
+    expect(screen.getByRole("link", { name: "下鴨神社" })).toHaveAttribute(
+      "href",
+      "/temples/3",
+    );
+  });
+
+  it("削除は確認後に対応するリソースの admin DELETE を呼び一覧を再取得する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    let deleteCalled = false;
+    let listCalls = 0;
+    server.use(
+      http.get(endpoint("/admin/comments"), () => {
+        listCalls += 1;
+        return HttpResponse.json({
+          comments: deleteCalled ? [comments[1]] : comments,
+        });
+      }),
+      http.delete(endpoint("/admin/greenteacomments/101"), () => {
+        deleteCalled = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    renderWithSwr(<CommentModerationList />);
+
+    await screen.findByText("抹茶パフェが最高でした");
+
+    const deleteButtons = screen.getAllByRole("button", { name: /削除/ });
+    await user.click(deleteButtons[0]);
+
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() => expect(deleteCalled).toBe(true));
+    await waitFor(() =>
+      expect(screen.queryByText("抹茶パフェが最高でした")).not.toBeInTheDocument(),
+    );
+    expect(listCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("一覧取得が 401 だと signOut してログインへ誘導する", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(endpoint("/admin/comments"), () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    renderWithSwr(<CommentModerationList />);
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fadmin%2Fcomments",
+    );
+  });
+});

--- a/src/components/admin/__tests__/CommentModerationList.test.tsx
+++ b/src/components/admin/__tests__/CommentModerationList.test.tsx
@@ -75,6 +75,35 @@ describe("CommentModerationList — コメントモデレーション", () => {
     );
   });
 
+  it("セッション解決中（loading）はログイン CTA を出さず読み込み中を表示する", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "loading" });
+
+    render(<CommentModerationList />);
+
+    expect(screen.getByText(/読み込み中/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/コメント管理の表示にはログインが必要/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("一覧取得が 403 のときは権限エラーを表示する", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(endpoint("/admin/comments"), () =>
+        HttpResponse.json({ error: "forbidden" }, { status: 403 }),
+      ),
+    );
+
+    renderWithSwr(<CommentModerationList />);
+
+    expect(
+      await screen.findByText(/この画面を表示する権限がありません/),
+    ).toBeInTheDocument();
+  });
+
   it("ログイン時は横断コメント一覧を対象リンク付きで表示する", async () => {
     useSessionMock.mockReturnValue({
       data: { railsJwt: "jwt-token" },

--- a/src/lib/api/admin/__tests__/comments.test.ts
+++ b/src/lib/api/admin/__tests__/comments.test.ts
@@ -1,0 +1,85 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import {
+  adminDeleteGreenteaComment,
+  adminDeleteTempleComment,
+  listAdminComments,
+} from "@/lib/api/admin/comments";
+import type { AdminComment } from "@/types";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const greenteaComment: AdminComment = {
+  id: 101,
+  body: "抹茶パフェが最高でした",
+  user: { id: 1, name: "テスト太郎" },
+  created_at: "2026-06-01T00:00:00.000Z",
+  resource_type: "greentea",
+  resource_id: 1,
+  resource_name: "茶寮 翠",
+};
+
+const templeComment: AdminComment = {
+  id: 202,
+  body: "静かで落ち着く神社でした",
+  user: { id: 2, name: "テスト花子" },
+  created_at: "2026-06-02T00:00:00.000Z",
+  resource_type: "temple",
+  resource_id: 3,
+  resource_name: "下鴨神社",
+};
+
+describe("admin/comments API", () => {
+  it("listAdminComments は GET /admin/comments に Bearer を送り横断一覧を返す", async () => {
+    let captured: { auth: string | null } | null = null;
+    server.use(
+      http.get(endpoint("/admin/comments"), ({ request }) => {
+        captured = { auth: request.headers.get("Authorization") };
+        return HttpResponse.json({
+          comments: [greenteaComment, templeComment],
+        });
+      }),
+    );
+
+    const res = await listAdminComments("jwt-token");
+
+    expect(captured).not.toBeNull();
+    expect(captured!.auth).toBe("Bearer jwt-token");
+    expect(res.comments).toHaveLength(2);
+    expect(res.comments[0].resource_type).toBe("greentea");
+    expect(res.comments[1].resource_type).toBe("temple");
+  });
+
+  it("adminDeleteGreenteaComment は DELETE /admin/greenteacomments/:id を呼ぶ（204）", async () => {
+    let captured: { auth: string | null } | null = null;
+    server.use(
+      http.delete(endpoint("/admin/greenteacomments/101"), ({ request }) => {
+        captured = { auth: request.headers.get("Authorization") };
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    await expect(
+      adminDeleteGreenteaComment(101, "jwt-token"),
+    ).resolves.toBeUndefined();
+    expect(captured!.auth).toBe("Bearer jwt-token");
+  });
+
+  it("adminDeleteTempleComment は DELETE /admin/templecomments/:id を呼ぶ（204）", async () => {
+    let called = false;
+    server.use(
+      http.delete(endpoint("/admin/templecomments/202"), () => {
+        called = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    await expect(
+      adminDeleteTempleComment(202, "jwt-token"),
+    ).resolves.toBeUndefined();
+    expect(called).toBe(true);
+  });
+});

--- a/src/lib/api/admin/__tests__/comments.test.ts
+++ b/src/lib/api/admin/__tests__/comments.test.ts
@@ -69,10 +69,10 @@ describe("admin/comments API", () => {
   });
 
   it("adminDeleteTempleComment は DELETE /admin/templecomments/:id を呼ぶ（204）", async () => {
-    let called = false;
+    let captured: { auth: string | null } | null = null;
     server.use(
-      http.delete(endpoint("/admin/templecomments/202"), () => {
-        called = true;
+      http.delete(endpoint("/admin/templecomments/202"), ({ request }) => {
+        captured = { auth: request.headers.get("Authorization") };
         return HttpResponse.text(null, { status: 204 });
       }),
     );
@@ -80,6 +80,6 @@ describe("admin/comments API", () => {
     await expect(
       adminDeleteTempleComment(202, "jwt-token"),
     ).resolves.toBeUndefined();
-    expect(called).toBe(true);
+    expect(captured!.auth).toBe("Bearer jwt-token");
   });
 });


### PR DESCRIPTION
## 概要

管理画面 Phase 4（#76 / 親 #71）。admin が抹茶店・神社のコメントを **横断一覧** し、任意のコメントを削除できるモデレーション画面を実装しました。

API クライアント（`src/lib/api/admin/comments.ts`）・型（`AdminComment` 等）・mock ルーター（`/admin/comments`、admin DELETE、所有者チェックのバイパス）は Phase 1 で雛形済みのものを利用し、本 PR では不足していた **UI とテスト** を追加しています。

## 変更内容

- **`/admin/comments` ページ**（`src/app/admin/comments/page.tsx`）
  - CSR・認証必須（`/admin` レイアウトの AdminGuard 配下）
- **`CommentModerationList` コンポーネント**（`src/components/admin/CommentModerationList.tsx`）
  - 抹茶店/神社のコメントを横断表示し、対象スポット（`/greenteas/[id]` `/temples/[id]`）へリンク
  - `resource_type` に応じて `adminDeleteGreenteaComment` / `adminDeleteTempleComment` を呼び分け（admin は他人のコメントも削除可）
  - 削除は `DeleteConfirmDialog` で確認 → 削除後に SWR `mutate` で一覧を再取得
  - 401（セッション切れ）→ `signOut` + ログイン誘導、403 / その他エラーで UI を出し分け（#51 / #64 のパターンを踏襲）

## テスト

- `src/lib/api/admin/__tests__/comments.test.ts` — admin API の MSW 契約テスト（一覧 / greentea・temple コメント削除、Bearer 付与）
- `src/components/admin/__tests__/CommentModerationList.test.tsx` — 未ログイン案内 / 横断一覧表示 / 確認後の削除と再取得 / 401 リダイレクト

## 確認

- [x] `npx tsc --noEmit`
- [x] `npx next lint`（警告・エラーなし）
- [x] `npx vitest run`（27 ファイル / 186 テスト パス）
- [x] `npx next build`（`/admin/comments` ルート生成を確認）

## 備考

- mock モード（`NEXT_PUBLIC_USE_MOCK=true`）では、`listAllComments` の仕様上ストア（ユーザー投稿）のコメントが対象です。seed コメントは詳細ページ専用のため一覧・削除の対象外としています。
- ダッシュボードのコメント件数は引き続き `—`（プレースホルダ）。件数表示には admin Bearer での集計が必要なため、本 PR のスコープ外としています。

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011FUWvR2SDuMiA1ucFb8kVa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin comments page with a moderation view for comments across shop and shrine/temple posts.
  * Added a moderation list with login handling, loading/empty states, comment details, and per-comment delete actions.
* **Tests**
  * Added coverage for admin comment listing, deletion flows, and session-expired behavior.
  * Added API tests to verify authenticated comment fetching and deletion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->