### PR TITLE
docs: Vercel デプロイ前チェックリスト（モック先行の最短手順）を追加

### DIFF
--- a/docs/deploy-checklist.md
+++ b/docs/deploy-checklist.md
@@ -43,13 +43,20 @@ Vercel のビルドは `next build` を実行する。事前にローカルで�
 
    - `AUTH_URL` は **設定しない**（Preview は毎回 URL が変わるため。Vercel 上では Auth.js が `VERCEL_URL` から自動解決）。
    - `NEXT_PUBLIC_API_URL` はモックモードでは参照されないので**未設定で OK**（Phase 3 以降で設定）。
-   - OAuth（`AUTH_GOOGLE_*` / `AUTH_LINE_*`）も**未設定で OK**。未設定なら開発用モックログインが表示される。
+   - OAuth（`AUTH_GOOGLE_*` / `AUTH_LINE_*`）も**未設定で OK**（この段階では設定不要）。
 3. 🧑 **Deploy** を押す。完了後、`https://<project>.vercel.app` でモックサイトが開く。
-4. ✅ 主要ページが表示されることを確認：
+4. ✅ **ログイン不要の公開ページ**が表示されることを確認（この段階で確認できるのはここまで）：
    - `/`（トップ）/ `/greenteas`（一覧・検索）/ `/temples` / `/greenteas/[id]`（詳細）
    - `/nearby`（現在地検索・要 Maps キーは Phase 2、未設定でも地図枠は出る）
-   - `/mypage`（モックログイン後）/ `/admin`（モックの admin ユーザーで）
+   - 表示されるデータは `NEXT_PUBLIC_USE_MOCK=true` による**モックデータ**。
 5. ✅ 以降、main への push / PR ごとに Preview デプロイが自動生成される。
+
+> ⚠️ **Vercel 上ではモックログインは使えない**（`/mypage` `/admin` などログイン必須ページはこの段階では確認不可）。
+> 開発用モックログイン（`src/lib/auth.ts` の Credentials provider）は **`NODE_ENV !== "production"` のときだけ**有効で、
+> Vercel は Preview / Production とも production ビルドで動くため無効化される。
+> - **ログイン必須ページの確認はローカル（`npm run dev`）で行う**（`docs/frontend-setup-runbook.md` Phase 0）。そこではモックログインが出る。
+> - Vercel 上でログインを通すには **OAuth 設定（Phase 2）＋ Rails JWT 連携（Phase 3 以降）** が必要。
+> - 補足: `NEXT_PUBLIC_USE_MOCK`（API の**データ**をモックにする）と、モック**ログイン**（認証を省略する）は別物。前者は Vercel でも効くが、後者は本番ビルドでは無効。
 
 ---
 

--- a/docs/deploy-checklist.md
+++ b/docs/deploy-checklist.md
@@ -1,0 +1,74 @@
+# Vercel デプロイ チェックリスト（最短手順）
+
+> まだ Vercel にデプロイしていない段階から、**バックエンド（Rails / Cloud Run）を待たずに**
+> モックモードで「共有できる URL」を作るまでのチェックリスト。
+> フェーズ全体（実 API 結合・本番ドメイン）の詳細は `docs/frontend-setup-runbook.md` が正。
+> 本書はその **Phase 0〜1 に絞った実行チェックリスト**。
+
+凡例: 🧑 = あなたの手作業 / 🤖 = Claude に依頼可 / ✅ = 完了確認
+
+---
+
+## 0. デプロイ前チェック（ローカルで緑を確認）
+
+Vercel のビルドは `next build` を実行する。事前にローカルで同じ緑を確認しておく。
+
+| コマンド | 内容 | 直近の状態 |
+|----------|------|-----------|
+| `npm ci` | 依存をクリーンインストール | ✅ |
+| `npm run lint` | ESLint | ✅ warning/error なし |
+| `npm run test` | 単体テスト（Vitest） | ✅ 188 passed |
+| `npm run build` | 本番ビルド（Vercel と同じ） | ✅ 22 ルート生成 |
+| `npm run test:e2e` | E2E（Playwright） | ⚠️ ブラウザバイナリ依存。CI/ローカルでブラウザが入っていれば通る（Vercel デプロイ自体は E2E を実行しない） |
+
+> 📌 E2E はローカル環境にブラウザが無いと `Executable doesn't exist` で落ちるが、
+> これは**テスト内容ではなく実行環境の問題**。Vercel のビルドには影響しない。
+
+🤖 これらのチェックは Claude 側でも随時回せる。差分が出たら知らせる。
+
+---
+
+## 1. Vercel プロジェクト作成（モックのまま Preview）
+
+実 API もシークレットもまだ不要。**今すぐ着手できる。**
+
+1. 🧑 Vercel にログイン → **Add New Project** → GitHub `hiiragi17/matcha-to-jinja` を import。
+   - Framework Preset は **Next.js**（自動検出）。Build Command / Output はデフォルトのまま。
+2. 🧑 環境変数を **Production / Preview / Development の3環境すべて**に設定：
+
+   | 変数 | 値 | 備考 |
+   |------|-----|------|
+   | `NEXT_PUBLIC_USE_MOCK` | `true` | この段階はモック。Rails 完成後に `false` へ |
+   | `AUTH_SECRET` | `npx auth secret` で生成した値 | **全環境・全フェーズで同一値を使い続ける（再生成しない）** |
+
+   - `AUTH_URL` は **設定しない**（Preview は毎回 URL が変わるため。Vercel 上では Auth.js が `VERCEL_URL` から自動解決）。
+   - `NEXT_PUBLIC_API_URL` はモックモードでは参照されないので**未設定で OK**（Phase 3 以降で設定）。
+   - OAuth（`AUTH_GOOGLE_*` / `AUTH_LINE_*`）も**未設定で OK**。未設定なら開発用モックログインが表示される。
+3. 🧑 **Deploy** を押す。完了後、`https://<project>.vercel.app` でモックサイトが開く。
+4. ✅ 主要ページが表示されることを確認：
+   - `/`（トップ）/ `/greenteas`（一覧・検索）/ `/temples` / `/greenteas/[id]`（詳細）
+   - `/nearby`（現在地検索・要 Maps キーは Phase 2、未設定でも地図枠は出る）
+   - `/mypage`（モックログイン後）/ `/admin`（モックの admin ユーザーで）
+5. ✅ 以降、main への push / PR ごとに Preview デプロイが自動生成される。
+
+---
+
+## 2. この後の流れ（バックエンド進捗に同期）
+
+| 次のフェーズ | やること | 依存 |
+|------------|---------|------|
+| Phase 2 | Google Maps / OAuth クライアント発行 | 外部サービス登録（並行可） |
+| Phase 3 | ローカルで実 Rails API 結合（`NEXT_PUBLIC_USE_MOCK=false`） | greentea_temple #13/#14/#17 |
+| Phase 4 | Vercel Preview → Cloud Run dev | Rails の Cloud Run（#26） |
+| Phase 5 | 本番ドメイン `matcha-to-jinja.com` 切替 | #27 |
+
+各フェーズの手順は `docs/frontend-setup-runbook.md` を参照。
+
+---
+
+## 参考
+
+- `docs/frontend-setup-runbook.md` — Phase 0〜5 の全手順（本書の親）
+- `docs/migration-plan.md`「環境構成」— Vercel Preview / redirect proxy / 本番構成の詳細
+- `.env.example` — 各環境変数のコメント
+- 関連 issue: #27（Vercel デプロイ & 本番連携）/ #26（Cloud Run）


### PR DESCRIPTION
## 概要

Vercel 未デプロイの現状から、**バックエンド（Rails / Cloud Run）の完成を待たずにモックモードで「共有できる URL」を作る**ための最短チェックリスト `docs/deploy-checklist.md` を追加します。

既存の `docs/frontend-setup-runbook.md`（Phase 0〜5 の全手順）とは**重複させず**、その Phase 0〜1 に絞った「今すぐ実行できるチェックリスト」として位置づけ、親ドキュメントへの導線を明記しています。

## 変更内容

- `docs/deploy-checklist.md` を新規追加
  - **デプロイ前チェック**の結果を記録（`npm ci` / `lint` / `test` / `build`）
  - バックエンド非依存で今すぐ出せる **Vercel モック Preview** の手順（プロジェクト import → 環境変数 `NEXT_PUBLIC_USE_MOCK=true` / `AUTH_SECRET` のみ → Deploy）
  - 以降のフェーズ（実 API 結合・本番ドメイン）は `frontend-setup-runbook.md` へリンク

## デプロイ前チェック結果（このブランチで実行）

| チェック | 結果 |
|----------|------|
| `npm run lint` | ✅ warning/error なし |
| `npm run test`（単体 / Vitest） | ✅ 188 passed（27 ファイル） |
| `npm run build`（Vercel と同じ本番ビルド） | ✅ 22 ルート生成 |
| `npm run test:e2e`（Playwright） | ⚠️ 実行環境のブラウザバイナリ依存。正しい Chromium 指定で通る（テスト内容・プロダクトコードは正常。Vercel デプロイは E2E を実行しない） |

## 補足: Issue 整理

本 PR とは別に、調査の結果として以下を整理しました（コード変更なし）。

- **#71（管理画面）**: フロント / モック実装（Phase 1〜4 / #73・#74・#75・#76）の完了を確認し close。
- **#81 を新規作成**: #71 のうち実 Rails API 結合に依存する部分（admin CRUD / コメントモデレーション）を分割（#51 → #64 と同じパターン）。

## レビュー観点

- ドキュメントのみの変更です（アプリのコード変更なし）。
- 既存 `frontend-setup-runbook.md` との記述の整合性・重複の有無をご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScyD4m4i3R61yzKBkc8GS4)_