### PR TITLE
feat: 現在地検索を京都圏外でも京都中心へ寄せる＋アイコン視認性を向上

### DIFF
--- a/src/components/brand/icons.tsx
+++ b/src/components/brand/icons.tsx
@@ -12,7 +12,7 @@ export function ToriiIcon({
   color = "#905050",
   className,
 }: IconProps) {
-  const sw = 1.6;
+  const sw = 2.4;
   return (
     <svg
       viewBox="0 0 32 32"
@@ -36,7 +36,7 @@ export function ChawanIcon({
   color = "#608060",
   className,
 }: IconProps) {
-  const sw = 1.6;
+  const sw = 2.4;
   return (
     <svg
       viewBox="0 0 32 32"
@@ -46,9 +46,10 @@ export function ChawanIcon({
       className={className}
       aria-hidden="true"
     >
+      <path d="M 5 13 Q 6 26, 16 28 Q 26 26, 27 13 Z" fill={color} fillOpacity="0.14" />
       <ellipse cx="16" cy="13" rx="11" ry="2.4" stroke={color} strokeWidth={sw} fill="none" />
       <path d="M 5 13 Q 6 26, 16 28 Q 26 26, 27 13" stroke={color} strokeWidth={sw} fill="none" strokeLinecap="round" />
-      <path d="M 11 13 Q 14 11.5, 17 12.5 T 21 12.7" stroke={color} strokeWidth={sw * 0.7} fill="none" strokeLinecap="round" opacity="0.6" />
+      <path d="M 11 13 Q 14 11.5, 17 12.5 T 21 12.7" stroke={color} strokeWidth={sw * 0.7} fill="none" strokeLinecap="round" opacity="0.7" />
     </svg>
   );
 }

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -189,7 +189,11 @@ export default function NearbyMap() {
                       }}
                       onCloseClick={() => setSelected(null)}
                     >
-                      <SpotInfo kind={selected.kind} spot={selected.spot} />
+                      <SpotInfo
+                        kind={selected.kind}
+                        spot={selected.spot}
+                        outsideKyoto={outsideKyoto}
+                      />
                     </InfoWindow>
                   </>
                 )}
@@ -215,6 +219,7 @@ export default function NearbyMap() {
       {fetchState.status === "success" && (
         <SpotLists
           data={fetchState.data}
+          outsideKyoto={outsideKyoto}
           onSelect={setSelected}
         />
       )}
@@ -337,12 +342,16 @@ function MarkerBadge({ kind }: { kind: "greentea" | "temple" }) {
 function SpotInfo({
   kind,
   spot,
+  outsideKyoto,
 }: {
   kind: "greentea" | "temple";
   spot: NearbySpot;
+  outsideKyoto: boolean;
 }) {
   const href = kind === "greentea" ? `/greenteas/${spot.id}` : `/temples/${spot.id}`;
   const label = kind === "greentea" ? "抹茶店" : "神社仏閣";
+  // 京都圏外では検索の基準が現在地ではなく京都市中心部になるため文言を切り替える。
+  const distancePrefix = outsideKyoto ? "京都市中心部から" : "現在地から";
   return (
     <div className="flex min-w-[180px] flex-col gap-2 font-serif-jp text-ink">
       <span className="font-sans-jp text-[10px] tracking-[0.2em] text-muted">
@@ -350,7 +359,7 @@ function SpotInfo({
       </span>
       <span className="font-mincho text-base leading-tight">{spot.name}</span>
       <span className="font-sans-jp text-xs text-muted">
-        現在地から {formatDistance(spot.distance_meters)}
+        {distancePrefix} {formatDistance(spot.distance_meters)}
       </span>
       <Link
         href={href}
@@ -376,13 +385,6 @@ function StatusPanel({
   if (geo.status === "requesting") {
     return <Notice tone="info">現在地を取得中…</Notice>;
   }
-  if (outsideKyoto) {
-    return (
-      <Notice tone="info">
-        現在地が京都府の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。
-      </Notice>
-    );
-  }
   if (geo.status === "denied") {
     return (
       <Notice tone="warn" action={{ label: "もう一度試す", onClick: onRetry }}>
@@ -397,24 +399,42 @@ function StatusPanel({
       </Notice>
     );
   }
+
+  // 京都圏外の案内は fetch の状態(検索中/失敗/0件)を隠さず併記する。
+  const notices: React.ReactNode[] = [];
+  if (outsideKyoto) {
+    notices.push(
+      <Notice key="outside" tone="info">
+        現在地が京都府の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。
+      </Notice>,
+    );
+  }
   if (fetchState.status === "loading") {
-    return <Notice tone="info">近隣スポットを検索中…</Notice>;
-  }
-  if (fetchState.status === "error") {
-    return <Notice tone="warn">{fetchState.message}</Notice>;
-  }
-  if (fetchState.status === "success") {
+    notices.push(
+      <Notice key="loading" tone="info">
+        近隣スポットを検索中…
+      </Notice>,
+    );
+  } else if (fetchState.status === "error") {
+    notices.push(
+      <Notice key="error" tone="warn">
+        {fetchState.message}
+      </Notice>,
+    );
+  } else if (fetchState.status === "success") {
     const total =
       fetchState.data.greenteas.length + fetchState.data.temples.length;
     if (total === 0) {
-      return (
-        <Notice tone="info">
+      notices.push(
+        <Notice key="empty" tone="info">
           指定した範囲には登録されたスポットがありません。半径を広げてお試しください。
-        </Notice>
+        </Notice>,
       );
     }
   }
-  return null;
+
+  if (notices.length === 0) return null;
+  return <div className="flex flex-col gap-3">{notices}</div>;
 }
 
 function Notice({
@@ -451,26 +471,36 @@ function Notice({
 
 function SpotLists({
   data,
+  outsideKyoto,
   onSelect,
 }: {
   data: NearbyResponse;
+  outsideKyoto: boolean;
   onSelect: (s: SelectedSpot) => void;
 }) {
   return (
-    <section className="grid gap-6 lg:grid-cols-2">
-      <SpotColumn
-        title="抹茶店"
-        kind="greentea"
-        spots={data.greenteas}
-        onSelect={onSelect}
-      />
-      <SpotColumn
-        title="神社仏閣"
-        kind="temple"
-        spots={data.temples}
-        onSelect={onSelect}
-      />
-    </section>
+    <div className="flex flex-col gap-3">
+      {/* 京都圏外では距離の基準が現在地ではなく京都市中心部であることを明示する。 */}
+      {outsideKyoto && (
+        <p className="font-serif-jp text-xs leading-relaxed text-muted">
+          ※ 距離は京都市中心部からの目安です（現在地が京都府外のため）。
+        </p>
+      )}
+      <section className="grid gap-6 lg:grid-cols-2">
+        <SpotColumn
+          title="抹茶店"
+          kind="greentea"
+          spots={data.greenteas}
+          onSelect={onSelect}
+        />
+        <SpotColumn
+          title="神社仏閣"
+          kind="temple"
+          spots={data.temples}
+          onSelect={onSelect}
+        />
+      </section>
+    </div>
   );
 }
 

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -23,12 +23,13 @@ type Radius = (typeof RADIUS_OPTIONS)[number];
 const KYOTO_CENTER = { lat: 35.0116, lng: 135.7681 };
 
 // 収録スポットは京都のみのため、現在地がこの範囲外なら京都中心へ寄せる。
-// 京都市〜周辺をゆるく覆う緯度経度ボックス（嵐山・伏見・鞍馬あたりまで含む）。
+// 京都府全体をゆるく覆う緯度経度ボックス（北は丹後半島〜日本海側、南は奈良府境、
+// 西は兵庫府境、東は滋賀・三重府境あたりまで含む）。
 const KYOTO_BOUNDS = {
-  minLat: 34.85,
-  maxLat: 35.25,
-  minLng: 135.6,
-  maxLng: 135.95,
+  minLat: 34.7,
+  maxLat: 35.8,
+  minLng: 134.85,
+  maxLng: 136.05,
 } as const;
 
 function isInKyoto(lat: number, lng: number): boolean {
@@ -378,7 +379,7 @@ function StatusPanel({
   if (outsideKyoto) {
     return (
       <Notice tone="info">
-        現在地が京都の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。
+        現在地が京都府の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。
       </Notice>
     );
   }

--- a/src/components/map/NearbyMap.tsx
+++ b/src/components/map/NearbyMap.tsx
@@ -19,8 +19,26 @@ import Hairline from "@/components/brand/Hairline";
 const RADIUS_OPTIONS = [0.5, 1.0, 1.5, 2.0] as const;
 type Radius = (typeof RADIUS_OPTIONS)[number];
 
-// 京都市中心部のフォールバック（位置情報拒否時の初期表示）
+// 京都市中心部のフォールバック（位置情報拒否時・京都圏外時の初期表示）
 const KYOTO_CENTER = { lat: 35.0116, lng: 135.7681 };
+
+// 収録スポットは京都のみのため、現在地がこの範囲外なら京都中心へ寄せる。
+// 京都市〜周辺をゆるく覆う緯度経度ボックス（嵐山・伏見・鞍馬あたりまで含む）。
+const KYOTO_BOUNDS = {
+  minLat: 34.85,
+  maxLat: 35.25,
+  minLng: 135.6,
+  maxLng: 135.95,
+} as const;
+
+function isInKyoto(lat: number, lng: number): boolean {
+  return (
+    lat >= KYOTO_BOUNDS.minLat &&
+    lat <= KYOTO_BOUNDS.maxLat &&
+    lng >= KYOTO_BOUNDS.minLng &&
+    lng <= KYOTO_BOUNDS.maxLng
+  );
+}
 
 type Origin = { lat: number; lng: number };
 type SelectedSpot = { kind: "greentea" | "temple"; spot: NearbySpot };
@@ -28,7 +46,7 @@ type SelectedSpot = { kind: "greentea" | "temple"; spot: NearbySpot };
 type GeoState =
   | { status: "idle" }
   | { status: "requesting" }
-  | { status: "granted"; origin: Origin }
+  | { status: "granted"; origin: Origin; outsideKyoto: boolean }
   | { status: "denied" }
   | { status: "error"; message: string };
 
@@ -62,9 +80,13 @@ export default function NearbyMap() {
     setGeo({ status: "requesting" });
     navigator.geolocation.getCurrentPosition(
       (pos) => {
+        const { latitude, longitude } = pos.coords;
+        // 京都圏内なら実際の現在地、圏外なら収録範囲の京都中心へ寄せる。
+        const inKyoto = isInKyoto(latitude, longitude);
         setGeo({
           status: "granted",
-          origin: { lat: pos.coords.latitude, lng: pos.coords.longitude },
+          origin: inKyoto ? { lat: latitude, lng: longitude } : KYOTO_CENTER,
+          outsideKyoto: !inKyoto,
         });
       },
       (err) => {
@@ -87,6 +109,7 @@ export default function NearbyMap() {
   }, [hasMapsConfig, requestLocation]);
 
   const origin = geo.status === "granted" ? geo.origin : null;
+  const outsideKyoto = geo.status === "granted" && geo.outsideKyoto;
 
   useEffect(() => {
     if (!hasMapsConfig || !origin) return;
@@ -141,7 +164,9 @@ export default function NearbyMap() {
                 disableDefaultUI={false}
                 clickableIcons={false}
               >
-                {origin && <OriginMarker origin={origin} />}
+                {origin && (
+                  <OriginMarker origin={origin} outsideKyoto={outsideKyoto} />
+                )}
                 {fetchState.status === "success" && (
                   <SpotMarkers
                     spots={fetchState.data}
@@ -182,6 +207,7 @@ export default function NearbyMap() {
       <StatusPanel
         geo={geo}
         fetchState={fetchState}
+        outsideKyoto={outsideKyoto}
         onRetry={requestLocation}
       />
 
@@ -239,9 +265,18 @@ function RadiusSelector({
   );
 }
 
-function OriginMarker({ origin }: { origin: Origin }) {
+function OriginMarker({
+  origin,
+  outsideKyoto,
+}: {
+  origin: Origin;
+  outsideKyoto: boolean;
+}) {
   return (
-    <AdvancedMarker position={origin} title="現在地">
+    <AdvancedMarker
+      position={origin}
+      title={outsideKyoto ? "京都市中心部" : "現在地"}
+    >
       <Pin background="#4a90a4" borderColor="#3d3322" glyphColor="#fbf6e5" />
     </AdvancedMarker>
   );
@@ -329,14 +364,23 @@ function SpotInfo({
 function StatusPanel({
   geo,
   fetchState,
+  outsideKyoto,
   onRetry,
 }: {
   geo: GeoState;
   fetchState: FetchState;
+  outsideKyoto: boolean;
   onRetry: () => void;
 }) {
   if (geo.status === "requesting") {
     return <Notice tone="info">現在地を取得中…</Notice>;
+  }
+  if (outsideKyoto) {
+    return (
+      <Notice tone="info">
+        現在地が京都の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。
+      </Notice>
+    );
   }
   if (geo.status === "denied") {
     return (


### PR DESCRIPTION
## 概要

現在地検索（`/nearby`）の2点を改善しました。

1. **現在地が京都府外でも京都へ寄せる** — 掲載スポットは京都のみのため、現在地が京都府の範囲外の場合は地図を京都市中心部へ寄せて近隣スポットを表示します。京都府内ならこれまで通り実際の現在地を使用します。
2. **地図アイコンの視認性向上** — 抹茶店（茶碗）・神社仏閣（鳥居）の SVG アイコンを、和風デザインを保ったまま見やすく調整しました。

## 変更内容

### 1. 現在地の京都圏判定（`src/components/map/NearbyMap.tsx`）
- 京都府全体をゆるく覆う緯度経度ボックス `KYOTO_BOUNDS` を追加（緯度 34.7〜35.8 / 経度 134.85〜136.05。北は丹後半島〜日本海側、南は奈良府境、西は兵庫府境、東は滋賀・三重府境あたりまで）。
- 位置情報取得後、`isInKyoto()` で判定：
  - **京都府内** → 実際の現在地を中心に表示。
  - **京都府外** → `KYOTO_CENTER`（京都市中心部）へ寄せて表示。
- 圏外時は「現在地が京都府の外のようです。掲載スポットは京都のみのため、京都市中心部のまわりを表示しています。」とステータス通知。
- 圏外時は現在地ピンの title を「現在地」→「京都市中心部」に切り替え（実在しない場所を「現在地」と誤表示しないため）。

### 2. アイコン視認性（`src/components/brand/icons.tsx`）
- `ChawanIcon` / `ToriiIcon` の線幅を `1.6 → 2.4` に。
- 茶碗に薄い塗り（`fillOpacity 0.14`）を追加し、小さい地図マーカー上でも形が読み取りやすく。
- 茶筅のかすれ線の不透明度を `0.6 → 0.7` に微調整。
- 配色・ブランドカラー指定はそのまま維持（絵文字化は不採用、SVG 統一感を優先）。

## 補足
- **Google Maps の追加 API キーは不要**です。京都圏判定は単純な座標計算、現在地取得はブラウザ標準の `navigator.geolocation`（無料・キー不要）で、地図描画キーは既存の `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` をそのまま使います。
- 位置情報を「拒否」した場合の挙動（京都中心を表示・スポット未取得）は既存のまま据え置いています。

## 動作確認
- `tsc --noEmit`：エラーなし
- `next lint`：警告・エラーなし
- `vitest run`：188 件すべて成功


---
_Generated by [Claude Code](https://claude.ai/code/session_011rc5yZNY9EqBZFrKHrSUJ1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Kyoto-area location handling in the map experience, including a fallback view when the detected location is outside Kyoto.
  * Displayed a new informational notice and distance note so users understand when results are measured from Kyoto city center.

* **UI Updates**
  * Refined icon styling for the Torii and Chawan brand icons, with updated stroke thickness and improved visual detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->