### PR TITLE
feat: モデルコース（抹茶店＋神社仏閣）作成機能を追加

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -81,6 +81,18 @@ export default function MyPage() {
             参拝・散策で気に入った社寺をいつでも見返せます。
           </p>
         </Link>
+        <Link
+          href="/routes"
+          className="border border-line-soft bg-paper px-6 py-7 transition-colors hover:bg-washi-bg sm:col-span-2"
+        >
+          <p className="font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            MODEL COURSE
+          </p>
+          <p className="mt-3 font-mincho text-xl text-ink">モデルコース</p>
+          <p className="mt-3 font-serif-jp text-xs leading-[1.9] text-muted">
+            抹茶スイーツ店と神社仏閣を組み合わせて、自分だけの巡りコースを作成・保存できます。
+          </p>
+        </Link>
       </div>
     </section>
   );

--- a/src/app/routes/[id]/edit/page.tsx
+++ b/src/app/routes/[id]/edit/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Hairline from "@/components/brand/Hairline";
+import RouteEditForm from "@/components/route/RouteEditForm";
+
+export const metadata: Metadata = {
+  title: "コースを編集",
+};
+
+type RouteParams = { id: string };
+
+export default async function EditRoutePage({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}) {
+  const { id } = await params;
+
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16">
+      <div className="mb-6">
+        <Link
+          href={`/routes/${id}`}
+          className="font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          ← コース詳細へ戻る
+        </Link>
+      </div>
+      <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+        MODEL COURSE / EDIT
+      </p>
+      <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+        コースを編集
+      </h1>
+      <Hairline width={40} className="mt-5" />
+
+      <div className="mt-10">
+        <RouteEditForm id={id} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/routes/[id]/page.tsx
+++ b/src/app/routes/[id]/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import RouteDetailView from "@/components/route/RouteDetailView";
+
+// コース名は認証必須（JWT）でクライアント取得のため、サーバー側では静的な
+// フォールバックタイトルを設定する（new / edit と同様にタブ・SEO 文脈を揃える）。
+export const metadata: Metadata = {
+  title: "コース詳細",
+};
 
 type RouteParams = { id: string };
 

--- a/src/app/routes/[id]/page.tsx
+++ b/src/app/routes/[id]/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import RouteDetailView from "@/components/route/RouteDetailView";
+
+type RouteParams = { id: string };
+
+export default async function RouteDetailPage({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}) {
+  const { id } = await params;
+
+  return (
+    <section className="mx-auto w-full max-w-4xl px-6 py-16">
+      <div className="mb-6">
+        <Link
+          href="/routes"
+          className="font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          ← モデルコース一覧へ
+        </Link>
+      </div>
+      <RouteDetailView id={id} />
+    </section>
+  );
+}

--- a/src/app/routes/layout.tsx
+++ b/src/app/routes/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "モデルコース",
+  description:
+    "お気に入りの抹茶スイーツ店と神社仏閣を組み合わせて、自分だけの京都モデルコースを作成できます。",
+};
+
+export default function RoutesLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/routes/new/page.tsx
+++ b/src/app/routes/new/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Hairline from "@/components/brand/Hairline";
+import RouteBuilder from "@/components/route/RouteBuilder";
+
+export const metadata: Metadata = {
+  title: "コースを作成",
+};
+
+export default function NewRoutePage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16">
+      <div className="mb-6">
+        <Link
+          href="/routes"
+          className="font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          ← モデルコース一覧へ
+        </Link>
+      </div>
+      <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+        MODEL COURSE / NEW
+      </p>
+      <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+        コースを作成
+      </h1>
+      <Hairline width={40} className="mt-5" />
+
+      <div className="mt-10">
+        <RouteBuilder mode="create" />
+      </div>
+    </section>
+  );
+}

--- a/src/app/routes/new/page.tsx
+++ b/src/app/routes/new/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Hairline from "@/components/brand/Hairline";
-import RouteBuilder from "@/components/route/RouteBuilder";
+import RouteCreateForm from "@/components/route/RouteCreateForm";
 
 export const metadata: Metadata = {
   title: "コースを作成",
@@ -27,7 +27,7 @@ export default function NewRoutePage() {
       <Hairline width={40} className="mt-5" />
 
       <div className="mt-10">
-        <RouteBuilder mode="create" />
+        <RouteCreateForm />
       </div>
     </section>
   );

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -9,7 +9,7 @@ export default async function RoutesPage({
   searchParams: Promise<SearchParams>;
 }) {
   const sp = await searchParams;
-  const page = Math.max(1, Number(sp.page) || 1);
+  const page = Math.max(1, Math.floor(Number(sp.page)) || 1);
 
   return (
     <section className="mx-auto w-full max-w-3xl px-6 py-16">

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -1,0 +1,23 @@
+import Hairline from "@/components/brand/Hairline";
+import RouteList from "@/components/route/RouteList";
+
+export default function RoutesPage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl px-6 py-16">
+      <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+        モデルコース / MODEL COURSE
+      </p>
+      <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+        わたしのモデルコース
+      </h1>
+      <Hairline width={40} className="mt-5" />
+      <p className="mt-5 font-serif-jp text-sm leading-[2] text-muted">
+        抹茶スイーツ店と神社仏閣を組み合わせた、自分だけの巡りコースを保存できます。
+      </p>
+
+      <div className="mt-10">
+        <RouteList />
+      </div>
+    </section>
+  );
+}

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -1,7 +1,16 @@
 import Hairline from "@/components/brand/Hairline";
 import RouteList from "@/components/route/RouteList";
 
-export default function RoutesPage() {
+type SearchParams = { page?: string };
+
+export default async function RoutesPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page) || 1);
+
   return (
     <section className="mx-auto w-full max-w-3xl px-6 py-16">
       <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
@@ -16,7 +25,7 @@ export default function RoutesPage() {
       </p>
 
       <div className="mt-10">
-        <RouteList />
+        <RouteList page={page} />
       </div>
     </section>
   );

--- a/src/components/route/RouteBuilder.tsx
+++ b/src/components/route/RouteBuilder.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import {
+  ApiError,
+  createRoute,
+  getApiErrorMessage,
+  getGreenteas,
+  getTemples,
+  isUnauthorized,
+  isValidationError,
+  updateRoute,
+} from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import { routeFormSchema, toRouteInput } from "@/lib/validation/route";
+import type {
+  GreenteaListResponse,
+  RouteDetail,
+  SpotType,
+  TempleListResponse,
+  Transport,
+} from "@/types";
+
+type RouteBuilderProps = {
+  mode: "create" | "edit";
+  initial?: RouteDetail;
+};
+
+type SelectedSpot = {
+  spot_type: SpotType;
+  spot_id: number;
+  name: string;
+  transport: Transport;
+};
+
+const TRANSPORT_OPTIONS: { value: Exclude<Transport, null>; label: string }[] = [
+  { value: "walk", label: "徒歩" },
+  { value: "train", label: "電車" },
+  { value: "bus", label: "バス" },
+  { value: "car", label: "車" },
+];
+
+function toSelected(initial?: RouteDetail): SelectedSpot[] {
+  return (
+    initial?.spots.map((s) => ({
+      spot_type: s.spot_type,
+      spot_id: s.id,
+      name: s.name,
+      transport: s.transport,
+    })) ?? []
+  );
+}
+
+// 並び順・スポット・移動手段が初期状態と同一かどうか。
+// 同一ならタイトル/説明のみ変更とみなし、PATCH で spots を省く（経路再計算を避ける）。
+function spotsUnchanged(a: SelectedSpot[], b: SelectedSpot[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((s, i) => {
+    const t = b[i];
+    // 末尾の transport はサーバ側で null になるため比較から除外する。
+    const isLast = i === a.length - 1;
+    return (
+      s.spot_type === t.spot_type &&
+      s.spot_id === t.spot_id &&
+      (isLast || s.transport === t.transport)
+    );
+  });
+}
+
+export default function RouteBuilder({ mode, initial }: RouteBuilderProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const callbackUrl =
+    mode === "edit" && initial
+      ? `/routes/${initial.id}/edit`
+      : "/routes/new";
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
+
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [selected, setSelected] = useState<SelectedSpot[]>(() =>
+    toSelected(initial),
+  );
+  const [tab, setTab] = useState<SpotType>("greentea");
+  const [search, setSearch] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const initialSelected = useMemo(() => toSelected(initial), [initial]);
+
+  const addSpot = (spot: SelectedSpot) =>
+    setSelected((prev) => [...prev, spot]);
+
+  const removeSpot = (index: number) =>
+    setSelected((prev) => prev.filter((_, i) => i !== index));
+
+  const moveSpot = (index: number, dir: -1 | 1) =>
+    setSelected((prev) => {
+      const next = [...prev];
+      const target = index + dir;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+
+  const setTransport = (index: number, transport: Transport) =>
+    setSelected((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, transport } : s)),
+    );
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+
+    const parsed = routeFormSchema.safeParse({
+      name,
+      description,
+      spots: selected.map((s) => ({
+        spot_type: s.spot_type,
+        spot_id: s.spot_id,
+        transport: s.transport,
+      })),
+    });
+    if (!parsed.success) {
+      setSubmitError(
+        parsed.error.issues[0]?.message ?? "入力内容を確認してください。",
+      );
+      return;
+    }
+
+    if (!authToken) {
+      await handleSessionExpired();
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (mode === "create") {
+        const res = await createRoute(toRouteInput(parsed.data, true), authToken);
+        router.push(`/routes/${res.data.id}`);
+        router.refresh();
+      } else if (initial) {
+        const includeSpots = !spotsUnchanged(initialSelected, selected);
+        const res = await updateRoute(
+          initial.id,
+          toRouteInput(parsed.data, includeSpots),
+          authToken,
+        );
+        router.push(`/routes/${res.data.id}`);
+        router.refresh();
+      }
+    } catch (err) {
+      if (isUnauthorized(err)) {
+        await handleSessionExpired();
+        return;
+      }
+      if (isValidationError(err)) {
+        setSubmitError(getApiErrorMessage(err, "入力内容を確認してください。"));
+      } else {
+        setSubmitError("保存に失敗しました。時間を置いてお試しください。");
+      }
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-8">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="route-name"
+            className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+          >
+            コース名 / NAME *
+          </label>
+          <input
+            id="route-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="祇園抹茶巡り"
+            className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="route-description"
+            className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+          >
+            説明 / DESCRIPTION
+          </label>
+          <textarea
+            id="route-description"
+            rows={2}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="神社とお茶屋さんを巡る半日コース"
+            className="resize-y border border-line bg-washi px-3 py-2 font-serif-jp text-sm leading-[1.9] text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <SelectedSpots
+        selected={selected}
+        onMove={moveSpot}
+        onRemove={removeSpot}
+        onTransport={setTransport}
+      />
+
+      <SpotPicker
+        tab={tab}
+        onTab={setTab}
+        search={search}
+        onSearch={setSearch}
+        onAdd={addSpot}
+      />
+
+      {submitError && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {submitError}
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="border border-olive bg-olive px-6 py-2 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          {submitting
+            ? "保存中…"
+            : mode === "create"
+              ? "コースを作成"
+              : "変更を保存"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          disabled={submitting}
+          className="border border-line bg-paper px-5 py-2 font-mincho text-[13px] tracking-[0.15em] text-ink transition-colors hover:bg-washi disabled:opacity-60"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function SelectedSpots({
+  selected,
+  onMove,
+  onRemove,
+  onTransport,
+}: {
+  selected: SelectedSpot[];
+  onMove: (index: number, dir: -1 | 1) => void;
+  onRemove: (index: number) => void;
+  onTransport: (index: number, transport: Transport) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="font-mincho text-base tracking-[0.15em] text-ink">
+        コースのスポット
+        <span className="ml-3 font-sans-jp text-xs tracking-[0.1em] text-muted">
+          {selected.length} 件
+        </span>
+      </h2>
+      {selected.length === 0 ? (
+        <p className="border border-dashed border-line bg-paper px-5 py-6 text-center font-serif-jp text-sm text-muted">
+          下の候補から抹茶店・神社仏閣を追加してください。追加した順にコースになります。
+        </p>
+      ) : (
+        <ol className="flex flex-col gap-3">
+          {selected.map((spot, index) => {
+            const isLast = index === selected.length - 1;
+            return (
+              <li
+                key={`${spot.spot_type}-${spot.spot_id}-${index}`}
+                className="flex flex-col gap-3 border border-line bg-paper px-4 py-3 sm:flex-row sm:items-center"
+              >
+                <div className="flex flex-1 items-center gap-3">
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-olive font-sans-jp text-sm text-olive">
+                    {index + 1}
+                  </span>
+                  {spot.spot_type === "greentea" ? (
+                    <ChawanIcon size={20} color="#608060" />
+                  ) : (
+                    <ToriiIcon size={20} color="#905050" />
+                  )}
+                  <span className="font-mincho text-base text-ink">
+                    {spot.name}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {!isLast && (
+                    <label className="flex items-center gap-1.5 font-sans-jp text-[11px] tracking-[0.1em] text-muted">
+                      次へ
+                      <select
+                        value={spot.transport ?? ""}
+                        onChange={(e) =>
+                          onTransport(
+                            index,
+                            e.target.value === ""
+                              ? null
+                              : (e.target.value as Transport),
+                          )
+                        }
+                        className="border border-line bg-washi px-2 py-1 font-serif-jp text-sm text-ink focus:border-olive focus:outline-none"
+                        aria-label={`${spot.name} から次のスポットへの移動手段`}
+                      >
+                        <option value="">未設定</option>
+                        {TRANSPORT_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  <IconButton
+                    label="上へ移動"
+                    disabled={index === 0}
+                    onClick={() => onMove(index, -1)}
+                  >
+                    ↑
+                  </IconButton>
+                  <IconButton
+                    label="下へ移動"
+                    disabled={isLast}
+                    onClick={() => onMove(index, 1)}
+                  >
+                    ↓
+                  </IconButton>
+                  <IconButton
+                    label="削除"
+                    onClick={() => onRemove(index)}
+                    tone="danger"
+                  >
+                    ×
+                  </IconButton>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function IconButton({
+  children,
+  label,
+  onClick,
+  disabled,
+  tone = "default",
+}: {
+  children: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  tone?: "default" | "danger";
+}) {
+  const toneClass =
+    tone === "danger"
+      ? "border-bengara text-bengara hover:bg-bengara hover:text-paper"
+      : "border-line text-ink hover:border-olive hover:text-olive";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={`flex h-8 w-8 items-center justify-center border font-sans-jp text-base transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${toneClass}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+type CandidateResponse = GreenteaListResponse | TempleListResponse;
+
+function SpotPicker({
+  tab,
+  onTab,
+  search,
+  onSearch,
+  onAdd,
+}: {
+  tab: SpotType;
+  onTab: (t: SpotType) => void;
+  search: string;
+  onSearch: (v: string) => void;
+  onAdd: (spot: SelectedSpot) => void;
+}) {
+  const fetcher = ([, kind, term]: readonly [
+    string,
+    SpotType,
+    string,
+  ]): Promise<CandidateResponse> =>
+    kind === "greentea"
+      ? getGreenteas({ q: { name_cont: term } })
+      : getTemples({ q: { name_cont: term } });
+
+  const { data, error, isLoading } = useSWR<
+    CandidateResponse,
+    ApiError,
+    readonly [string, SpotType, string]
+  >(["/route-candidates", tab, search] as const, fetcher, {
+    keepPreviousData: true,
+  });
+
+  const items =
+    data && "greenteas" in data
+      ? data.greenteas
+      : data && "temples" in data
+        ? data.temples
+        : [];
+
+  return (
+    <section className="flex flex-col gap-3 border border-line-soft bg-washi-bg px-4 py-4">
+      <h2 className="font-mincho text-base tracking-[0.15em] text-ink">
+        スポットを追加
+      </h2>
+      <div className="flex gap-2">
+        <TabButton active={tab === "greentea"} onClick={() => onTab("greentea")}>
+          抹茶スイーツ
+        </TabButton>
+        <TabButton active={tab === "temple"} onClick={() => onTab("temple")}>
+          神社仏閣
+        </TabButton>
+      </div>
+      <input
+        type="search"
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        placeholder="名前で絞り込み"
+        className="h-10 border border-line bg-paper px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+      />
+      {error ? (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          候補の取得に失敗しました。時間を置いてお試しください。
+        </p>
+      ) : isLoading ? (
+        <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+          読み込み中…
+        </p>
+      ) : items.length === 0 ? (
+        <p className="font-serif-jp text-sm text-muted">
+          該当するスポットがありません。
+        </p>
+      ) : (
+        <ul className="grid max-h-72 grid-cols-1 gap-2 overflow-y-auto sm:grid-cols-2">
+          {items.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  onAdd({
+                    spot_type: tab,
+                    spot_id: item.id,
+                    name: item.name,
+                    transport: null,
+                  })
+                }
+                className="flex w-full items-center gap-2 border border-line bg-paper px-3 py-2 text-left transition-colors hover:border-olive hover:bg-paper/80"
+              >
+                {tab === "greentea" ? (
+                  <ChawanIcon size={18} color="#608060" />
+                ) : (
+                  <ToriiIcon size={18} color="#905050" />
+                )}
+                <span className="flex-1 font-mincho text-sm text-ink">
+                  {item.name}
+                </span>
+                <span className="font-sans-jp text-lg text-olive">＋</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function TabButton({
+  children,
+  active,
+  onClick,
+}: {
+  children: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`border px-4 py-1.5 font-sans-jp text-sm tracking-[0.1em] transition-colors ${
+        active
+          ? "border-olive bg-olive text-paper"
+          : "border-line bg-paper text-ink hover:border-olive hover:text-olive"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/route/RouteBuilder.tsx
+++ b/src/components/route/RouteBuilder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
 import {
@@ -92,11 +92,25 @@ export default function RouteBuilder({ mode, initial }: RouteBuilderProps) {
 
   const initialSelected = useMemo(() => toSelected(initial), [initial]);
 
+  // transport は「そのスポットから次のスポットへの手段」。並び替え・削除で
+  // 「次のスポット」が変わると手段が別の区間に付いたままになるため、
+  // 隣接が変化したスポットの transport はクリアして状態の整合を保つ。
+  const clearTransportAt = (spots: SelectedSpot[], index: number) => {
+    if (index >= 0 && index < spots.length && spots[index].transport !== null) {
+      spots[index] = { ...spots[index], transport: null };
+    }
+  };
+
   const addSpot = (spot: SelectedSpot) =>
     setSelected((prev) => [...prev, spot]);
 
   const removeSpot = (index: number) =>
-    setSelected((prev) => prev.filter((_, i) => i !== index));
+    setSelected((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      // 削除位置の直前スポットの「次」が変わるため transport をクリア
+      clearTransportAt(next, index - 1);
+      return next;
+    });
 
   const moveSpot = (index: number, dir: -1 | 1) =>
     setSelected((prev) => {
@@ -104,6 +118,11 @@ export default function RouteBuilder({ mode, initial }: RouteBuilderProps) {
       const target = index + dir;
       if (target < 0 || target >= next.length) return prev;
       [next[index], next[target]] = [next[target], next[index]];
+      // 入れ替えに関与した2要素と、その直前要素の「次」が変わるためクリア
+      const lo = Math.min(index, target);
+      clearTransportAt(next, lo - 1);
+      clearTransportAt(next, lo);
+      clearTransportAt(next, lo + 1);
       return next;
     });
 
@@ -397,6 +416,14 @@ function SpotPicker({
   onSearch: (v: string) => void;
   onAdd: (spot: SelectedSpot) => void;
 }) {
+  // 実 API 連携時にキー入力ごとのリクエストを抑えるため、SWR キーに渡す
+  // 検索語をデバウンスする（入力自体は即時反映しつつ、フェッチだけ遅らせる）。
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 250);
+    return () => clearTimeout(timer);
+  }, [search]);
+
   const fetcher = ([, kind, term]: readonly [
     string,
     SpotType,
@@ -410,7 +437,7 @@ function SpotPicker({
     CandidateResponse,
     ApiError,
     readonly [string, SpotType, string]
-  >(["/route-candidates", tab, search] as const, fetcher, {
+  >(["/route-candidates", tab, debouncedSearch] as const, fetcher, {
     keepPreviousData: true,
   });
 
@@ -439,6 +466,7 @@ function SpotPicker({
         value={search}
         onChange={(e) => onSearch(e.target.value)}
         placeholder="名前で絞り込み"
+        aria-label="スポットを名前で絞り込み"
         className="h-10 border border-line bg-paper px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
       />
       {error ? (

--- a/src/components/route/RouteCreateForm.tsx
+++ b/src/components/route/RouteCreateForm.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import RouteBuilder from "@/components/route/RouteBuilder";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+
+// 作成フォームは list/detail/edit と同様に、未ログインでは
+// ビルダーを描画せずログイン導線を先に見せる（作成途中で入力を失わせない）。
+export default function RouteCreateForm() {
+  const authToken = useAuthToken();
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          モデルコースの作成にはログインが必要です。
+        </p>
+        <Link
+          href="/auth/login?callbackUrl=%2Froutes%2Fnew"
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  return <RouteBuilder mode="create" />;
+}

--- a/src/components/route/RouteCreateForm.tsx
+++ b/src/components/route/RouteCreateForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import RouteBuilder from "@/components/route/RouteBuilder";
+import RouteBuilder from "./RouteBuilder";
 import { useAuthToken } from "@/lib/api/useAuthToken";
 
 // 作成フォームは list/detail/edit と同様に、未ログインでは

--- a/src/components/route/RouteDetailView.tsx
+++ b/src/components/route/RouteDetailView.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import Hairline from "@/components/brand/Hairline";
+import RouteMap from "@/components/route/RouteMap";
+import {
+  ApiError,
+  deleteRoute,
+  getErrorStatus,
+  getRoute,
+  isUnauthorized,
+} from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import {
+  formatDistance,
+  formatDuration,
+  transportLabel,
+} from "@/lib/utils/format";
+import type { RouteDetailResponse, RouteSpot } from "@/types";
+
+type RouteDetailViewProps = {
+  id: string;
+};
+
+type SwrKey = readonly [string, string];
+
+export default function RouteDetailView({ id }: RouteDetailViewProps) {
+  const router = useRouter();
+  const authToken = useAuthToken();
+  const callbackUrl = `/routes/${id}`;
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetcher = ([, token]: SwrKey): Promise<RouteDetailResponse> =>
+    getRoute(id, token);
+
+  const { data, error, isLoading } = useSWR<
+    RouteDetailResponse,
+    ApiError,
+    SwrKey | null
+  >(authToken ? ([`/routes/${id}`, authToken] as const) : null, fetcher);
+
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) void handleSessionExpired();
+  }, [sessionExpired, handleSessionExpired]);
+
+  const onDelete = async () => {
+    if (!authToken) {
+      await handleSessionExpired();
+      return;
+    }
+    if (!window.confirm("このコースを削除しますか？")) return;
+    setDeleting(true);
+    try {
+      await deleteRoute(id, authToken);
+      router.push("/routes");
+      router.refresh();
+    } catch (err) {
+      if (isUnauthorized(err)) {
+        await handleSessionExpired();
+        return;
+      }
+      window.alert("削除に失敗しました。時間を置いてお試しください。");
+      setDeleting(false);
+    }
+  };
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          コースの表示にはログインが必要です。
+        </p>
+        <Link
+          href={`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (error) {
+    const notFound = getErrorStatus(error) === 404;
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-8 text-center">
+        <p role="alert" className="font-serif-jp text-sm text-muted">
+          {notFound
+            ? "コースが見つかりませんでした。削除された可能性があります。"
+            : "コースの取得に失敗しました。時間を置いてお試しください。"}
+        </p>
+        <Link
+          href="/routes"
+          className="mt-4 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          コース一覧へ
+        </Link>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+  const route = data.data;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+              MODEL COURSE
+            </p>
+            <h1 className="mt-2 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+              {route.name}
+            </h1>
+          </div>
+          <div className="flex gap-2">
+            <Link
+              href={`/routes/${route.id}/edit`}
+              className="border border-line px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:border-olive hover:text-olive"
+            >
+              編集
+            </Link>
+            <button
+              type="button"
+              onClick={onDelete}
+              disabled={deleting}
+              className="border border-bengara px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-bengara transition-colors hover:bg-bengara hover:text-paper disabled:opacity-50"
+            >
+              {deleting ? "削除中…" : "削除"}
+            </button>
+          </div>
+        </div>
+        {route.description && (
+          <p className="font-serif-jp text-sm leading-[2] text-muted">
+            {route.description}
+          </p>
+        )}
+        <Hairline width={40} />
+        <dl className="flex flex-wrap gap-x-10 gap-y-2">
+          <div>
+            <dt className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+              TOTAL DISTANCE
+            </dt>
+            <dd className="mt-1 font-mincho text-lg text-ink">
+              {formatDistance(route.total_distance_meters)}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+              TOTAL TIME
+            </dt>
+            <dd className="mt-1 font-mincho text-lg text-ink">
+              {formatDuration(route.total_duration_seconds)}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+              SPOTS
+            </dt>
+            <dd className="mt-1 font-mincho text-lg text-ink">
+              {route.spots.length} 件
+            </dd>
+          </div>
+        </dl>
+      </header>
+
+      <RouteMap spots={route.spots} />
+
+      <ol className="flex flex-col">
+        {route.spots.map((spot, index) => (
+          <SpotRow
+            key={`${spot.spot_type}-${spot.id}-${spot.position}`}
+            spot={spot}
+            isLast={index === route.spots.length - 1}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function SpotRow({ spot, isLast }: { spot: RouteSpot; isLast: boolean }) {
+  const href =
+    spot.spot_type === "greentea"
+      ? `/greenteas/${spot.id}`
+      : `/temples/${spot.id}`;
+  // 経路値優先・直線距離フォールバック（ハンドオフ doc の指針）。
+  const legMeters =
+    spot.route_distance_to_next_meters ?? spot.distance_to_next_meters;
+
+  return (
+    <li className="flex flex-col">
+      <div className="flex items-start gap-4 border border-line bg-paper px-5 py-4">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-olive font-sans-jp text-sm font-semibold text-olive">
+          {spot.position}
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            {spot.spot_type === "greentea" ? (
+              <ChawanIcon size={20} color="#608060" />
+            ) : (
+              <ToriiIcon size={20} color="#905050" />
+            )}
+            <Link
+              href={href}
+              className="font-mincho text-lg text-ink transition-colors hover:text-olive"
+            >
+              {spot.name}
+            </Link>
+          </div>
+          {spot.address && (
+            <p className="mt-1 font-serif-jp text-sm text-muted">
+              {spot.address}
+            </p>
+          )}
+          {spot.access && (
+            <p className="mt-0.5 font-sans-jp text-xs text-muted">
+              {spot.access}
+            </p>
+          )}
+        </div>
+      </div>
+      {!isLast && (
+        <div className="flex items-center gap-2 py-2 pl-9 font-sans-jp text-xs tracking-[0.1em] text-muted">
+          <span aria-hidden="true">↓</span>
+          {spot.transport && (
+            <span className="border border-line-soft px-2 py-0.5 text-olive">
+              {transportLabel(spot.transport)}
+            </span>
+          )}
+          {legMeters !== null && <span>{formatDistance(legMeters)}</span>}
+          {spot.duration_to_next_seconds !== null && (
+            <span>{formatDuration(spot.duration_to_next_seconds)}</span>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/route/RouteDetailView.tsx
+++ b/src/components/route/RouteDetailView.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
 import Hairline from "@/components/brand/Hairline";
-import RouteMap from "@/components/route/RouteMap";
+import RouteMap from "./RouteMap";
 import {
   ApiError,
   deleteRoute,

--- a/src/components/route/RouteEditForm.tsx
+++ b/src/components/route/RouteEditForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import useSWR from "swr";
+import RouteBuilder from "@/components/route/RouteBuilder";
+import { ApiError, getErrorStatus, getRoute, isUnauthorized } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import type { RouteDetailResponse } from "@/types";
+
+type RouteEditFormProps = {
+  id: string;
+};
+
+type SwrKey = readonly [string, string];
+
+// 編集フォームは初期値ロードに認証が必要なため、クライアントで取得してから
+// RouteBuilder（mode=edit）へ initial を渡す。
+export default function RouteEditForm({ id }: RouteEditFormProps) {
+  const authToken = useAuthToken();
+  const callbackUrl = `/routes/${id}/edit`;
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
+
+  const fetcher = ([, token]: SwrKey): Promise<RouteDetailResponse> =>
+    getRoute(id, token);
+
+  const { data, error, isLoading } = useSWR<
+    RouteDetailResponse,
+    ApiError,
+    SwrKey | null
+  >(authToken ? ([`/routes/${id}`, authToken] as const) : null, fetcher);
+
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) void handleSessionExpired();
+  }, [sessionExpired, handleSessionExpired]);
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          コースの編集にはログインが必要です。
+        </p>
+        <Link
+          href={`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (error || !data) {
+    const notFound = getErrorStatus(error) === 404;
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-8 text-center">
+        <p role="alert" className="font-serif-jp text-sm text-muted">
+          {notFound
+            ? "コースが見つかりませんでした。"
+            : "コースの取得に失敗しました。時間を置いてお試しください。"}
+        </p>
+        <Link
+          href="/routes"
+          className="mt-4 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          コース一覧へ
+        </Link>
+      </div>
+    );
+  }
+
+  return <RouteBuilder mode="edit" initial={data.data} />;
+}

--- a/src/components/route/RouteEditForm.tsx
+++ b/src/components/route/RouteEditForm.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import useSWR from "swr";
-import RouteBuilder from "@/components/route/RouteBuilder";
+import RouteBuilder from "./RouteBuilder";
 import { ApiError, getErrorStatus, getRoute, isUnauthorized } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
 import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";

--- a/src/components/route/RouteList.tsx
+++ b/src/components/route/RouteList.tsx
@@ -54,6 +54,12 @@ export default function RouteList({ page = 1 }: RouteListProps) {
             ? {
                 ...current,
                 data: current.data.filter((r) => r.id !== id),
+                // 件数表示・Pagination が参照する meta も併せて減算し、
+                // 再検証までの間に古い件数を見せないようにする。
+                meta: {
+                  ...current.meta,
+                  total_count: Math.max(0, current.meta.total_count - 1),
+                },
               }
             : current,
         { revalidate: false },

--- a/src/components/route/RouteList.tsx
+++ b/src/components/route/RouteList.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import {
+  ApiError,
+  deleteRoute,
+  getRoutes,
+  isUnauthorized,
+} from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import type { RouteListResponse } from "@/types";
+
+type SwrKey = readonly [string, string];
+
+export default function RouteList() {
+  const authToken = useAuthToken();
+  const handleSessionExpired = useSessionExpiredHandler("/routes");
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const fetcher = ([, token]: SwrKey): Promise<RouteListResponse> =>
+    getRoutes(token);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    RouteListResponse,
+    ApiError,
+    SwrKey | null
+  >(authToken ? (["/routes", authToken] as const) : null, fetcher);
+
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) void handleSessionExpired();
+  }, [sessionExpired, handleSessionExpired]);
+
+  const onDelete = async (id: number) => {
+    if (!authToken) {
+      await handleSessionExpired();
+      return;
+    }
+    if (!window.confirm("このコースを削除しますか？")) return;
+    setDeletingId(id);
+    try {
+      await deleteRoute(id, authToken);
+      await mutate(
+        (current) =>
+          current
+            ? {
+                ...current,
+                data: current.data.filter((r) => r.id !== id),
+              }
+            : current,
+        { revalidate: false },
+      );
+    } catch (err) {
+      if (isUnauthorized(err)) {
+        await handleSessionExpired();
+        return;
+      }
+      window.alert("削除に失敗しました。時間を置いてお試しください。");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          モデルコースの表示・作成にはログインが必要です。
+        </p>
+        <Link
+          href="/auth/login?callbackUrl=%2Froutes"
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <p className="font-sans-jp text-[11px] tracking-[0.2em] text-muted">
+          {data ? `${data.meta.total_count} 件のコース` : ""}
+        </p>
+        <Link
+          href="/routes/new"
+          className="border border-olive bg-olive px-5 py-2 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark"
+        >
+          ＋ 新しいコース
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+          読み込み中…
+        </p>
+      ) : error ? (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {isUnauthorized(error)
+            ? "ログインの有効期限が切れました。再度ログインしてください。"
+            : "コースの取得に失敗しました。時間を置いてお試しください。"}
+        </p>
+      ) : !data || data.data.length === 0 ? (
+        <p className="border border-line-soft bg-paper px-5 py-8 text-center font-serif-jp text-sm text-muted">
+          まだモデルコースがありません。「＋ 新しいコース」から作成してみましょう。
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {data.data.map((route) => (
+            <li
+              key={route.id}
+              className="flex flex-col gap-3 border border-line bg-paper px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="flex flex-1 flex-col gap-1">
+                <Link
+                  href={`/routes/${route.id}`}
+                  className="font-mincho text-lg text-ink transition-colors hover:text-olive"
+                >
+                  {route.name}
+                </Link>
+                {route.description && (
+                  <p className="font-serif-jp text-sm leading-[1.8] text-muted">
+                    {route.description}
+                  </p>
+                )}
+                <p className="font-sans-jp text-[11px] tracking-[0.15em] text-olive">
+                  スポット {route.spot_count} 件
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Link
+                  href={`/routes/${route.id}`}
+                  className="border border-line px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:border-olive hover:text-olive"
+                >
+                  詳細
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => onDelete(route.id)}
+                  disabled={deletingId === route.id}
+                  className="border border-bengara px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-bengara transition-colors hover:bg-bengara hover:text-paper disabled:opacity-50"
+                >
+                  {deletingId === route.id ? "削除中…" : "削除"}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/route/RouteList.tsx
+++ b/src/components/route/RouteList.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
+import Pagination from "@/components/common/Pagination";
 import {
   ApiError,
   deleteRoute,
@@ -13,21 +14,25 @@ import { useAuthToken } from "@/lib/api/useAuthToken";
 import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
 import type { RouteListResponse } from "@/types";
 
-type SwrKey = readonly [string, string];
+type RouteListProps = {
+  page?: number;
+};
 
-export default function RouteList() {
+type SwrKey = readonly [string, string, number];
+
+export default function RouteList({ page = 1 }: RouteListProps) {
   const authToken = useAuthToken();
   const handleSessionExpired = useSessionExpiredHandler("/routes");
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
-  const fetcher = ([, token]: SwrKey): Promise<RouteListResponse> =>
-    getRoutes(token);
+  const fetcher = ([, token, p]: SwrKey): Promise<RouteListResponse> =>
+    getRoutes(token, p);
 
   const { data, error, isLoading, mutate } = useSWR<
     RouteListResponse,
     ApiError,
     SwrKey | null
-  >(authToken ? (["/routes", authToken] as const) : null, fetcher);
+  >(authToken ? (["/routes", authToken, page] as const) : null, fetcher);
 
   const sessionExpired = !!error && isUnauthorized(error);
   useEffect(() => {
@@ -150,6 +155,14 @@ export default function RouteList() {
             </li>
           ))}
         </ul>
+      )}
+
+      {data && data.meta.total_pages > 1 && (
+        <Pagination
+          basePath="/routes"
+          currentPage={data.meta.current_page}
+          totalPages={data.meta.total_pages}
+        />
       )}
     </div>
   );

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import {
   AdvancedMarker,
   APIProvider,
@@ -23,7 +23,9 @@ function hasCoords(spot: RouteSpot): boolean {
 
 export default function RouteMap({ spots }: RouteMapProps) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
-  const points = spots.filter(hasCoords);
+  // 参照を安定させ、RoutePolyline / FitBounds の effect が親の再描画で
+  // 無駄に再実行されないようにする（ユーザーの pan/zoom を保持）。
+  const points = useMemo(() => spots.filter(hasCoords), [spots]);
 
   if (!apiKey) {
     return (

--- a/src/components/route/RouteMap.tsx
+++ b/src/components/route/RouteMap.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  AdvancedMarker,
+  APIProvider,
+  Map,
+  useMap,
+  useMapsLibrary,
+} from "@vis.gl/react-google-maps";
+import type { RouteSpot } from "@/types";
+
+type RouteMapProps = {
+  spots: RouteSpot[];
+};
+
+const KYOTO_CENTER = { lat: 35.0116, lng: 135.7681 };
+
+// 緯度経度が解決できたスポットのみ地図に載せる（削除済みスポットは lat/lng が 0）。
+function hasCoords(spot: RouteSpot): boolean {
+  return spot.latitude !== 0 || spot.longitude !== 0;
+}
+
+export default function RouteMap({ spots }: RouteMapProps) {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? "";
+  const points = spots.filter(hasCoords);
+
+  if (!apiKey) {
+    return (
+      <div className="border border-bengara bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-relaxed text-bengara-dark">
+          Google Maps の API キーが設定されていません。NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+          を .env.local に設定すると地図が表示されます。
+        </p>
+      </div>
+    );
+  }
+
+  if (points.length === 0) {
+    return (
+      <div className="border border-line bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm text-muted">
+          地図に表示できるスポットがありません。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-line bg-paper">
+      <div className="h-[50vh] min-h-[360px] w-full">
+        <APIProvider apiKey={apiKey} libraries={["marker"]}>
+          <Map
+            mapId={
+              process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID?.trim() || "DEMO_MAP_ID"
+            }
+            defaultCenter={
+              points[0]
+                ? { lat: points[0].latitude, lng: points[0].longitude }
+                : KYOTO_CENTER
+            }
+            defaultZoom={14}
+            gestureHandling="greedy"
+            disableDefaultUI={false}
+            clickableIcons={false}
+          >
+            {points.map((spot) => (
+              <AdvancedMarker
+                key={`${spot.spot_type}-${spot.id}-${spot.position}`}
+                position={{ lat: spot.latitude, lng: spot.longitude }}
+                title={spot.name}
+              >
+                <OrderBadge position={spot.position} kind={spot.spot_type} />
+              </AdvancedMarker>
+            ))}
+            <RoutePolyline points={points} />
+            <FitBounds points={points} />
+          </Map>
+        </APIProvider>
+      </div>
+    </div>
+  );
+}
+
+function OrderBadge({
+  position,
+  kind,
+}: {
+  position: number;
+  kind: "greentea" | "temple";
+}) {
+  const color = kind === "greentea" ? "#608060" : "#905050";
+  return (
+    <div
+      className="flex h-8 w-8 items-center justify-center rounded-full border-2 bg-paper font-sans-jp text-sm font-semibold shadow-[0_2px_0_rgba(61,51,34,0.15)]"
+      style={{ borderColor: color, color }}
+    >
+      {position}
+    </div>
+  );
+}
+
+// スポットを順に結ぶ経路線。@vis.gl/react-google-maps は Polyline を提供しないため、
+// useMapsLibrary("maps") で読み込んだ Polyline を imperative に生成・破棄する。
+function RoutePolyline({ points }: { points: RouteSpot[] }) {
+  const map = useMap();
+  const mapsLib = useMapsLibrary("maps");
+  useEffect(() => {
+    if (!map || !mapsLib || points.length < 2) return;
+    const polyline = new mapsLib.Polyline({
+      path: points.map((p) => ({ lat: p.latitude, lng: p.longitude })),
+      geodesic: true,
+      strokeColor: "#4a90a4",
+      strokeOpacity: 0.9,
+      strokeWeight: 3,
+    });
+    polyline.setMap(map);
+    return () => polyline.setMap(null);
+  }, [map, mapsLib, points]);
+  return null;
+}
+
+// 全スポットが収まるよう地図をズーム/センタリングする。
+function FitBounds({ points }: { points: RouteSpot[] }) {
+  const map = useMap();
+  const coreLib = useMapsLibrary("core");
+  useEffect(() => {
+    if (!map || !coreLib || points.length === 0) return;
+    if (points.length === 1) {
+      map.setCenter({ lat: points[0].latitude, lng: points[0].longitude });
+      map.setZoom(15);
+      return;
+    }
+    const bounds = new coreLib.LatLngBounds();
+    for (const p of points) {
+      bounds.extend({ lat: p.latitude, lng: p.longitude });
+    }
+    map.fitBounds(bounds, 64);
+  }, [map, coreLib, points]);
+  return null;
+}

--- a/src/components/route/__tests__/RouteBuilder.test.tsx
+++ b/src/components/route/__tests__/RouteBuilder.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RouteBuilder from "@/components/route/RouteBuilder";
+import { apiUrl } from "@tests/msw/writeApiHandlers";
+import { server } from "@tests/msw/server";
+
+const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock, back: vi.fn() }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const greenteasPayload = {
+  greenteas: [
+    {
+      id: 1,
+      name: "茶寮都路里",
+      description: "",
+      address: "",
+      access: "",
+      phone_number: "",
+      business_hours: "",
+      holiday: "",
+      homepage: "",
+      closed: false,
+      img: "",
+      latitude: 35.0036,
+      longitude: 135.7714,
+      genres: [],
+      likes_count: 0,
+    },
+  ],
+  meta: { current_page: 1, total_pages: 1, total_count: 1 },
+};
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  pushMock.mockReset();
+  refreshMock.mockReset();
+  signOutMock.mockReset();
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "mock:mock-alice" },
+    status: "authenticated",
+  });
+  server.use(
+    http.get(apiUrl("/greenteas"), () => HttpResponse.json(greenteasPayload)),
+    http.get(apiUrl("/temples"), () =>
+      HttpResponse.json({
+        temples: [],
+        meta: { current_page: 1, total_pages: 1, total_count: 0 },
+      }),
+    ),
+  );
+});
+
+function renderWithSwr(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("RouteBuilder（作成）", () => {
+  it("スポット未追加で保存するとバリデーションエラーを出す", async () => {
+    renderWithSwr(<RouteBuilder mode="create" />);
+
+    await userEvent.type(screen.getByLabelText(/コース名/), "テストコース");
+    await userEvent.click(screen.getByRole("button", { name: "コースを作成" }));
+
+    expect(
+      await screen.findByText(/スポットを1件以上追加してください/),
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("候補からスポットを追加して作成すると詳細へ遷移する", async () => {
+    let postedBody: unknown;
+    server.use(
+      http.post(apiUrl("/routes"), async ({ request }) => {
+        postedBody = await request.json();
+        return HttpResponse.json(
+          {
+            data: {
+              id: 42,
+              name: "テストコース",
+              description: "",
+              created_at: "2026-07-03T00:00:00Z",
+              updated_at: "2026-07-03T00:00:00Z",
+              spots: [],
+              total_distance_meters: 0,
+              total_duration_seconds: null,
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderWithSwr(<RouteBuilder mode="create" />);
+
+    await userEvent.type(screen.getByLabelText(/コース名/), "テストコース");
+    // 候補（茶寮都路里）の追加ボタンをクリック
+    const candidate = await screen.findByRole("button", { name: /茶寮都路里/ });
+    await userEvent.click(candidate);
+
+    // 選択リストに反映される
+    const selectedSection = screen
+      .getByRole("heading", { name: /コースのスポット/ })
+      .closest("section") as HTMLElement;
+    expect(within(selectedSection).getByText("茶寮都路里")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "コースを作成" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/routes/42");
+    });
+    expect(postedBody).toMatchObject({
+      route: {
+        name: "テストコース",
+        spots: [{ spot_type: "greentea", spot_id: 1 }],
+      },
+    });
+  });
+});

--- a/src/components/route/__tests__/RouteList.test.tsx
+++ b/src/components/route/__tests__/RouteList.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RouteList from "@/components/route/RouteList";
+import { apiUrl } from "@tests/msw/writeApiHandlers";
+import { server } from "@tests/msw/server";
+
+const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+});
+
+function renderWithSwr(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+const routesPayload = {
+  data: [
+    {
+      id: 1,
+      name: "祇園抹茶巡り",
+      description: "神社とお茶屋さんを巡る",
+      spot_count: 2,
+      created_at: "2026-07-03T10:00:00.000Z",
+      updated_at: "2026-07-03T10:00:00.000Z",
+    },
+  ],
+  meta: { current_page: 1, total_pages: 1, total_count: 1 },
+};
+
+describe("RouteList", () => {
+  it("未ログインではログイン案内と callbackUrl 付きリンクを出す", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<RouteList />);
+
+    expect(
+      screen.getByText(/モデルコースの表示・作成にはログインが必要/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /ログインへ/ })).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Froutes",
+    );
+  });
+
+  it("一覧を表示し、削除すると行が消える", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "mock:mock-alice" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(apiUrl("/routes"), () => HttpResponse.json(routesPayload)),
+      http.delete(apiUrl("/routes/:id"), () =>
+        HttpResponse.text(null, { status: 204 }),
+      ),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithSwr(<RouteList />);
+
+    expect(
+      await screen.findByRole("link", { name: "祇園抹茶巡り" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("スポット 2 件")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("link", { name: "祇園抹茶巡り" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("空のときは案内文を出す", async () => {
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "mock:mock-alice" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(apiUrl("/routes"), () =>
+        HttpResponse.json({
+          data: [],
+          meta: { current_page: 1, total_pages: 1, total_count: 0 },
+        }),
+      ),
+    );
+
+    renderWithSwr(<RouteList />);
+
+    expect(
+      await screen.findByText(/まだモデルコースがありません/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -32,6 +32,13 @@ export {
   deleteGreenteaComment,
   deleteTempleComment,
 } from "./comments";
+export {
+  getRoutes,
+  getRoute,
+  createRoute,
+  updateRoute,
+  deleteRoute,
+} from "./routes";
 export { exchangeOAuthForJwt, getCurrentUser, revokeJwt } from "./auth";
 export type {
   AuthProvider,

--- a/src/lib/api/mock/__tests__/routes.test.ts
+++ b/src/lib/api/mock/__tests__/routes.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { RouteDetailResponse, RouteListResponse } from "@/types";
+import { ApiError } from "@/lib/api/error";
+import { mockClient } from "../index";
+import { resetMockStore } from "../state";
+
+const auth = (userId: string): RequestInit => ({
+  headers: { Authorization: `Bearer mock:${userId}` },
+});
+
+const jsonBody = (userId: string, body: unknown): RequestInit => ({
+  method: "POST",
+  headers: { Authorization: `Bearer mock:${userId}` },
+  body: JSON.stringify(body),
+});
+
+const sampleRoute = {
+  route: {
+    name: "祇園抹茶巡り",
+    description: "神社とお茶屋さんを巡る",
+    spots: [
+      { spot_type: "temple", spot_id: 2, transport: "walk" },
+      { spot_type: "greentea", spot_id: 1 },
+    ],
+  },
+};
+
+async function createSample(userId: string): Promise<RouteDetailResponse> {
+  return mockClient<RouteDetailResponse>("/routes", jsonBody(userId, sampleRoute));
+}
+
+beforeEach(() => {
+  resetMockStore();
+});
+
+describe("mockClient POST /routes", () => {
+  it("認証必須（トークン無しは 401）", async () => {
+    await expect(
+      mockClient("/routes", { method: "POST", body: JSON.stringify(sampleRoute) }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("スポット順・位置・距離・所要時間を計算して詳細形で返す", async () => {
+    const res = await createSample("mock-alice");
+    expect(res.data.name).toBe("祇園抹茶巡り");
+    expect(res.data.spots).toHaveLength(2);
+    expect(res.data.spots.map((s) => s.position)).toEqual([1, 2]);
+    // 最初の leg は距離・経路距離・所要時間が算出される
+    expect(res.data.spots[0].distance_to_next_meters).toBeGreaterThan(0);
+    expect(res.data.spots[0].route_distance_to_next_meters).toBeGreaterThan(0);
+    expect(res.data.spots[0].duration_to_next_seconds).toBeGreaterThan(0);
+    // 最後の要素は全て null、transport も null
+    expect(res.data.spots[1].distance_to_next_meters).toBeNull();
+    expect(res.data.spots[1].transport).toBeNull();
+    // 合計
+    expect(res.data.total_distance_meters).toBeGreaterThan(0);
+    expect(res.data.total_duration_seconds).toBeGreaterThan(0);
+  });
+
+  it("単一スポットのルートは total_duration_seconds が null・total_distance が 0", async () => {
+    const res = await mockClient<RouteDetailResponse>(
+      "/routes",
+      jsonBody("mock-alice", {
+        route: { name: "一箇所", spots: [{ spot_type: "temple", spot_id: 1 }] },
+      }),
+    );
+    expect(res.data.total_duration_seconds).toBeNull();
+    expect(res.data.total_distance_meters).toBe(0);
+    expect(res.data.spots[0].distance_to_next_meters).toBeNull();
+  });
+
+  it("name 空は 422", async () => {
+    await expect(
+      createBad("mock-alice", { name: "", spots: [{ spot_type: "temple", spot_id: 1 }] }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("spots 空配列は 422", async () => {
+    await expect(
+      createBad("mock-alice", { name: "空", spots: [] }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("不正な spot_type は 422", async () => {
+    await expect(
+      createBad("mock-alice", {
+        name: "x",
+        spots: [{ spot_type: "hotel", spot_id: 1 }],
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("存在しない spot_id は 422", async () => {
+    await expect(
+      createBad("mock-alice", {
+        name: "x",
+        spots: [{ spot_type: "temple", spot_id: 9999 }],
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("不正な transport は 422", async () => {
+    await expect(
+      createBad("mock-alice", {
+        name: "x",
+        spots: [{ spot_type: "temple", spot_id: 1, transport: "teleport" }],
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("route キー欠落は 400", async () => {
+    await expect(
+      mockClient("/routes", jsonBody("mock-alice", { name: "x" })),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+function createBad(userId: string, route: unknown) {
+  return mockClient("/routes", jsonBody(userId, { route }));
+}
+
+describe("mockClient GET /routes（一覧）", () => {
+  it("自分のルートのみ spot_count 付きで返す", async () => {
+    await createSample("mock-alice");
+    await createSample("mock-bob");
+
+    const res = await mockClient<RouteListResponse>("/routes", auth("mock-alice"));
+    expect(res.data).toHaveLength(1);
+    expect(res.data[0].spot_count).toBe(2);
+    expect(res.meta.total_count).toBe(1);
+  });
+
+  it("未認証は 401", async () => {
+    await expect(mockClient("/routes")).rejects.toBeInstanceOf(ApiError);
+    await expect(mockClient("/routes")).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("mockClient GET /routes/:id（詳細）", () => {
+  it("自分のルートは詳細を返す", async () => {
+    const created = await createSample("mock-alice");
+    const res = await mockClient<RouteDetailResponse>(
+      `/routes/${created.data.id}`,
+      auth("mock-alice"),
+    );
+    expect(res.data.id).toBe(created.data.id);
+    expect(res.data.spots).toHaveLength(2);
+  });
+
+  it("他人のルートは 404", async () => {
+    const created = await createSample("mock-alice");
+    await expect(
+      mockClient(`/routes/${created.data.id}`, auth("mock-bob")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("存在しない ID は 404", async () => {
+    await expect(
+      mockClient("/routes/9999", auth("mock-alice")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("mockClient PATCH /routes/:id（更新）", () => {
+  const patch = (userId: string, id: number, body: unknown): RequestInit => ({
+    method: "PATCH",
+    headers: { Authorization: `Bearer mock:${userId}` },
+    body: JSON.stringify(body),
+  });
+
+  it("spots を渡すと総入れ替えして再計算する", async () => {
+    const created = await createSample("mock-alice");
+    const res = await mockClient<RouteDetailResponse>(
+      `/routes/${created.data.id}`,
+      patch("mock-alice", created.data.id, {
+        route: {
+          name: "新ルート",
+          spots: [{ spot_type: "temple", spot_id: 3, transport: "train" }],
+        },
+      }),
+    );
+    expect(res.data.name).toBe("新ルート");
+    expect(res.data.spots).toHaveLength(1);
+    expect(res.data.spots[0].id).toBe(3);
+  });
+
+  it("spots を渡さないと name/description のみ部分更新し既存スポットを保持する", async () => {
+    const created = await createSample("mock-alice");
+    const res = await mockClient<RouteDetailResponse>(
+      `/routes/${created.data.id}`,
+      patch("mock-alice", created.data.id, {
+        route: { description: "説明だけ更新" },
+      }),
+    );
+    expect(res.data.description).toBe("説明だけ更新");
+    expect(res.data.name).toBe("祇園抹茶巡り");
+    expect(res.data.spots).toHaveLength(2);
+  });
+
+  it("spots 空配列は 422（既存スポットは保持）", async () => {
+    const created = await createSample("mock-alice");
+    await expect(
+      mockClient(
+        `/routes/${created.data.id}`,
+        patch("mock-alice", created.data.id, { route: { spots: [] } }),
+      ),
+    ).rejects.toMatchObject({ status: 422 });
+    const after = await mockClient<RouteDetailResponse>(
+      `/routes/${created.data.id}`,
+      auth("mock-alice"),
+    );
+    expect(after.data.spots).toHaveLength(2);
+  });
+
+  it("他人のルートは 404", async () => {
+    const created = await createSample("mock-alice");
+    await expect(
+      mockClient(
+        `/routes/${created.data.id}`,
+        patch("mock-bob", created.data.id, { route: { name: "乗っ取り" } }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("mockClient DELETE /routes/:id", () => {
+  const del = (userId: string): RequestInit => ({
+    method: "DELETE",
+    headers: { Authorization: `Bearer mock:${userId}` },
+  });
+
+  it("削除すると以後 404 になる", async () => {
+    const created = await createSample("mock-alice");
+    const res = await mockClient<void>(
+      `/routes/${created.data.id}`,
+      del("mock-alice"),
+    );
+    expect(res).toBeUndefined();
+    await expect(
+      mockClient(`/routes/${created.data.id}`, auth("mock-alice")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("他人のルートは削除できず 404", async () => {
+    const created = await createSample("mock-alice");
+    await expect(
+      mockClient(`/routes/${created.data.id}`, del("mock-bob")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/src/lib/api/mock/__tests__/routes.test.ts
+++ b/src/lib/api/mock/__tests__/routes.test.ts
@@ -108,6 +108,12 @@ describe("mockClient POST /routes", () => {
     ).rejects.toMatchObject({ status: 422 });
   });
 
+  it("非オブジェクトの spot 要素（[null]）は TypeError ではなく 422", async () => {
+    await expect(
+      createBad("mock-alice", { name: "x", spots: [null] }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
   it("route キー欠落は 400", async () => {
     await expect(
       mockClient("/routes", jsonBody("mock-alice", { name: "x" })),

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -12,12 +12,18 @@ import type {
   GreenteaListResponse,
   NearbyResponse,
   NearbySpot,
+  RouteDetail,
+  RouteDetailResponse,
+  RouteListItem,
+  RouteListResponse,
+  RouteSpot,
   Temple,
   TempleDetailResponse,
   TempleLike,
   TempleLikeListResponse,
   TempleLikeResponse,
   TempleListResponse,
+  Transport,
 } from "@/types";
 import { distanceMeters } from "@/lib/utils/distance";
 import type { AdminCommentListResponse } from "@/types";
@@ -41,25 +47,31 @@ import {
   adminDeleteTempleComment,
   createMockGreentea,
   createMockTemple,
+  createRouteRecord,
   deleteGreenteaComment,
   deleteMockGreentea,
   deleteMockTemple,
+  deleteRouteRecord,
   deleteTempleComment,
   extractMockUserId,
   getMockGreenteas,
   getMockTemples,
   getGreenteaLikeDelta,
   getGreenteaLikedIds,
+  getRouteForOwner,
   getTempleLikeDelta,
   getTempleLikedIds,
   listAllComments,
   listGreenteaComments,
+  listRoutesByOwner,
   listTempleComments,
   removeGreenteaLike,
   removeTempleLike,
   updateMockGreentea,
   updateMockTemple,
+  updateRouteRecord,
 } from "./state";
+import type { StoredRoute, StoredRouteSpot } from "./state";
 
 const PER_PAGE = 12;
 
@@ -624,7 +636,233 @@ export async function mockClient<T>(
     }
   }
 
+  // --- モデルルート（routes）: 全メソッド認証必須・自分のルートのみ操作可 ---
+  {
+    const isRouteList = path === "/routes";
+    const routeIdMatch = path.match(/^\/routes\/(\d+)$/);
+    if (isRouteList || routeIdMatch) {
+      const uid = requireMockUser(headers);
+
+      if (isRouteList && method === "GET") {
+        const page = Number(params.get("page")) || 1;
+        const all = listRoutesByOwner(uid);
+        const { items, meta } = paginate(all, page);
+        const data: RouteListItem[] = items.map((r) => ({
+          id: r.id,
+          name: r.name,
+          description: r.description,
+          spot_count: r.spots.length,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
+        }));
+        return { data, meta } satisfies RouteListResponse as T;
+      }
+
+      if (isRouteList && method === "POST") {
+        const body = parseRouteBody(options?.body);
+        const name = parseRouteName(body.name, true)!;
+        const description = parseRouteDescription(body.description) ?? null;
+        const spots = parseRouteSpots(body.spots, mockGreenteas, mockTemples);
+        const record = createRouteRecord(uid, { name, description, spots });
+        return {
+          data: buildRouteDetail(record, mockGreenteas, mockTemples),
+        } satisfies RouteDetailResponse as T;
+      }
+
+      if (routeIdMatch) {
+        const id = Number(routeIdMatch[1]);
+
+        if (method === "GET") {
+          const record = getRouteForOwner(id, uid);
+          if (!record) routeNotFound();
+          return {
+            data: buildRouteDetail(record, mockGreenteas, mockTemples),
+          } satisfies RouteDetailResponse as T;
+        }
+
+        if (method === "PATCH") {
+          if (!getRouteForOwner(id, uid)) routeNotFound();
+          const body = parseRouteBody(options?.body);
+          const name = parseRouteName(body.name, false);
+          const description = parseRouteDescription(body.description);
+          const spots =
+            body.spots === undefined
+              ? undefined
+              : parseRouteSpots(body.spots, mockGreenteas, mockTemples);
+          const updated = updateRouteRecord(id, uid, { name, description, spots });
+          if (!updated) routeNotFound();
+          return {
+            data: buildRouteDetail(updated, mockGreenteas, mockTemples),
+          } satisfies RouteDetailResponse as T;
+        }
+
+        if (method === "DELETE") {
+          if (!deleteRouteRecord(id, uid)) routeNotFound();
+          return undefined as T;
+        }
+      }
+    }
+  }
+
   notFound(endpoint);
+}
+
+// --- routes 用ヘルパー ---
+
+const VALID_TRANSPORTS = new Set<string>(["walk", "train", "bus", "car"]);
+
+// 移動手段ごとの mock 概算速度(m/秒)。Directions API 未接続のため所要時間の擬似算出に使う。
+const SPEED_M_PER_SEC: Record<Exclude<Transport, null>, number> = {
+  walk: 1.33,
+  bus: 5,
+  train: 11,
+  car: 8,
+};
+
+type RawRouteBody = {
+  name?: unknown;
+  description?: unknown;
+  spots?: unknown;
+};
+
+function routeUnprocessable(details: string[]): never {
+  throw new ApiError(422, { error: "Unprocessable Entity", details });
+}
+
+function routeNotFound(): never {
+  throw new ApiError(404, { error: "Not Found" });
+}
+
+function parseRouteBody(body: BodyInit | null | undefined): RawRouteBody {
+  const parsed = parseJsonBody<{ route?: unknown }>(body);
+  if (!parsed.route || typeof parsed.route !== "object") {
+    throw new ApiError(400, { error: "Bad Request" });
+  }
+  return parsed.route as RawRouteBody;
+}
+
+function parseRouteName(
+  raw: unknown,
+  required: boolean,
+): string | undefined {
+  if (raw === undefined) {
+    if (required) routeUnprocessable(["Name can't be blank"]);
+    return undefined;
+  }
+  const name = typeof raw === "string" ? raw.trim() : "";
+  if (name.length === 0) routeUnprocessable(["Name can't be blank"]);
+  return name;
+}
+
+// description は「キー欠落＝据え置き（undefined）」「null/空＝クリア」を区別する。
+function parseRouteDescription(raw: unknown): string | null | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  return String(raw);
+}
+
+function normalizeTransport(value: unknown): Transport {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string" && VALID_TRANSPORTS.has(value)) {
+    return value as Transport;
+  }
+  routeUnprocessable([`Invalid transport: ${String(value)}`]);
+}
+
+function parseRouteSpots(
+  raw: unknown,
+  greenteas: Greentea[],
+  temples: Temple[],
+): StoredRouteSpot[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    routeUnprocessable(["Spots can't be blank"]);
+  }
+  return raw.map((entry): StoredRouteSpot => {
+    const spot = entry as {
+      spot_type?: unknown;
+      spot_id?: unknown;
+      transport?: unknown;
+    };
+    if (spot.spot_type !== "greentea" && spot.spot_type !== "temple") {
+      routeUnprocessable([`Invalid spot_type: ${String(spot.spot_type)}`]);
+    }
+    const spotId = Number(spot.spot_id);
+    const exists =
+      spot.spot_type === "greentea"
+        ? greenteas.some((g) => g.id === spotId)
+        : temples.some((t) => t.id === spotId);
+    if (!Number.isFinite(spotId) || !exists) {
+      routeUnprocessable([
+        `Spot not found: ${spot.spot_type} #${String(spot.spot_id)}`,
+      ]);
+    }
+    return {
+      spot_type: spot.spot_type,
+      spot_id: spotId,
+      transport: normalizeTransport(spot.transport),
+    };
+  });
+}
+
+// StoredRoute を詳細レスポンス形へ。スポット座標を解決し、各 leg の直線距離・
+// 経路距離(≈直線×1.3)・所要時間(移動手段別の概算速度)を算出する。
+function buildRouteDetail(
+  route: StoredRoute,
+  greenteas: Greentea[],
+  temples: Temple[],
+): RouteDetail {
+  const lastIndex = route.spots.length - 1;
+  const spots: RouteSpot[] = route.spots.map((s, idx) => {
+    const src =
+      s.spot_type === "greentea"
+        ? greenteas.find((g) => g.id === s.spot_id)
+        : temples.find((t) => t.id === s.spot_id);
+    return {
+      position: idx + 1,
+      spot_type: s.spot_type,
+      // 移動手段は「次スポットへの手段」。最後の要素は null。
+      transport: idx === lastIndex ? null : s.transport,
+      id: s.spot_id,
+      name: src?.name ?? "(削除されたスポット)",
+      address: src?.address ?? "",
+      access: src?.access ?? "",
+      latitude: src?.latitude ?? 0,
+      longitude: src?.longitude ?? 0,
+      img: src?.img ?? "",
+      distance_to_next_meters: null,
+      route_distance_to_next_meters: null,
+      duration_to_next_seconds: null,
+    };
+  });
+
+  let totalDistance = 0;
+  let totalDuration = 0;
+  let hasLeg = false;
+  for (let i = 0; i < spots.length - 1; i++) {
+    const a = spots[i];
+    const b = spots[i + 1];
+    const straight = distanceMeters(a, b);
+    const routeDistance = Math.round(straight * 1.3);
+    const speed = SPEED_M_PER_SEC[a.transport ?? "walk"];
+    const duration = Math.round(routeDistance / speed);
+    a.distance_to_next_meters = straight;
+    a.route_distance_to_next_meters = routeDistance;
+    a.duration_to_next_seconds = duration;
+    totalDistance += routeDistance;
+    totalDuration += duration;
+    hasLeg = true;
+  }
+
+  return {
+    id: route.id,
+    name: route.name,
+    description: route.description,
+    created_at: route.created_at,
+    updated_at: route.updated_at,
+    spots,
+    total_distance_meters: totalDistance,
+    total_duration_seconds: hasLeg ? totalDuration : null,
+  };
 }
 
 function parseJsonBody<T>(body: BodyInit | null | undefined): T {

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -778,6 +778,11 @@ function parseRouteSpots(
     routeUnprocessable(["Spots can't be blank"]);
   }
   return raw.map((entry): StoredRouteSpot => {
+    // null や非オブジェクト（spots: [null] 等）は型アサーション前に弾く。
+    // これがないと spot.spot_type 参照で TypeError になり 422 にならない。
+    if (typeof entry !== "object" || entry === null) {
+      routeUnprocessable([`Invalid spot: ${JSON.stringify(entry)}`]);
+    }
     const spot = entry as {
       spot_type?: unknown;
       spot_id?: unknown;

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -7,12 +7,36 @@
 // Next.js dev サーバーは HMR で module-level の変数がリセットされてしまい、
 // 開発中にいいね・コメントが突然消えて混乱するため、globalThis にぶら下げる。
 
-import type { Comment, Greentea, GreenteaInput, Temple, TempleInput } from "@/types";
+import type {
+  Comment,
+  Greentea,
+  GreenteaInput,
+  SpotType,
+  Temple,
+  TempleInput,
+  Transport,
+} from "@/types";
 
 type UserId = string;
 type CommentRecord = { comment: Comment; ownerId: UserId };
 
 export type DeleteResult = "deleted" | "not_found" | "forbidden";
+
+export type StoredRouteSpot = {
+  spot_type: SpotType;
+  spot_id: number;
+  transport: Transport;
+};
+
+export type StoredRoute = {
+  id: number;
+  ownerId: UserId;
+  name: string;
+  description: string | null;
+  spots: StoredRouteSpot[];
+  created_at: string;
+  updated_at: string;
+};
 
 type MockStore = {
   greenteaLikes: Map<UserId, Set<number>>;
@@ -23,8 +47,10 @@ type MockStore = {
   templeLikeCountDelta: Map<number, number>;
   nextCommentId: { value: number };
   nextResourceId: { value: number };
+  nextRouteId: { value: number };
   greenteas: Greentea[] | null;
   temples: Temple[] | null;
+  routes: StoredRoute[];
 };
 
 const globalKey = Symbol.for("matcha-to-jinja.mock-store");
@@ -42,8 +68,10 @@ const store: MockStore = ((): MockStore => {
       templeLikeCountDelta: new Map(),
       nextCommentId: { value: 1000 },
       nextResourceId: { value: 9000 },
+      nextRouteId: { value: 1 },
       greenteas: null,
       temples: null,
+      routes: [],
     };
   }
   return g[globalKey]!;
@@ -60,8 +88,10 @@ export function resetMockStore(): void {
   store.templeLikeCountDelta.clear();
   store.nextCommentId.value = 1000;
   store.nextResourceId.value = 9000;
+  store.nextRouteId.value = 1;
   store.greenteas = null;
   store.temples = null;
+  store.routes = [];
 }
 
 function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
@@ -411,4 +441,70 @@ export function listAllComments(): Array<{
     }
   }
   return result;
+}
+
+// --- モデルルート（routes）: ユーザーごとの CRUD ---
+
+export function listRoutesByOwner(ownerId: UserId): StoredRoute[] {
+  return store.routes.filter((r) => r.ownerId === ownerId);
+}
+
+// 見つからない or 所有者が異なる場合は null（呼び出し側は 404 として扱う）。
+export function getRouteForOwner(
+  id: number,
+  ownerId: UserId,
+): StoredRoute | null {
+  return (
+    store.routes.find((r) => r.id === id && r.ownerId === ownerId) ?? null
+  );
+}
+
+export function createRouteRecord(
+  ownerId: UserId,
+  input: {
+    name: string;
+    description: string | null;
+    spots: StoredRouteSpot[];
+  },
+): StoredRoute {
+  const now = new Date().toISOString();
+  const route: StoredRoute = {
+    id: store.nextRouteId.value++,
+    ownerId,
+    name: input.name,
+    description: input.description,
+    spots: input.spots,
+    created_at: now,
+    updated_at: now,
+  };
+  store.routes.push(route);
+  return route;
+}
+
+// spots を渡すと総入れ替え、渡さない（undefined）と name/description のみ部分更新。
+export function updateRouteRecord(
+  id: number,
+  ownerId: UserId,
+  input: {
+    name?: string;
+    description?: string | null;
+    spots?: StoredRouteSpot[];
+  },
+): StoredRoute | null {
+  const route = getRouteForOwner(id, ownerId);
+  if (!route) return null;
+  if (input.name !== undefined) route.name = input.name;
+  if (input.description !== undefined) route.description = input.description;
+  if (input.spots !== undefined) route.spots = input.spots;
+  route.updated_at = new Date().toISOString();
+  return route;
+}
+
+export function deleteRouteRecord(id: number, ownerId: UserId): boolean {
+  const idx = store.routes.findIndex(
+    (r) => r.id === id && r.ownerId === ownerId,
+  );
+  if (idx < 0) return false;
+  store.routes.splice(idx, 1);
+  return true;
 }

--- a/src/lib/api/routes.ts
+++ b/src/lib/api/routes.ts
@@ -1,0 +1,58 @@
+import type {
+  RouteDetailResponse,
+  RouteInput,
+  RouteListResponse,
+} from "@/types";
+import { apiClient, buildQuery } from "./client";
+
+// モデルルート API。ハンドオフ doc（/api/v1/routes 契約）に対応。
+// 全エンドポイント JWT 認証必須のため authToken を必ず受け取る。
+
+export function getRoutes(
+  authToken: string,
+  page?: number,
+): Promise<RouteListResponse> {
+  return apiClient<RouteListResponse>(`/routes${buildQuery({ page })}`, {
+    authToken,
+  });
+}
+
+export function getRoute(
+  id: number | string,
+  authToken: string,
+): Promise<RouteDetailResponse> {
+  return apiClient<RouteDetailResponse>(`/routes/${id}`, { authToken });
+}
+
+export function createRoute(
+  input: RouteInput,
+  authToken: string,
+): Promise<RouteDetailResponse> {
+  return apiClient<RouteDetailResponse>("/routes", {
+    method: "POST",
+    body: JSON.stringify({ route: input }),
+    authToken,
+  });
+}
+
+export function updateRoute(
+  id: number | string,
+  input: RouteInput,
+  authToken: string,
+): Promise<RouteDetailResponse> {
+  return apiClient<RouteDetailResponse>(`/routes/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ route: input }),
+    authToken,
+  });
+}
+
+export function deleteRoute(
+  id: number | string,
+  authToken: string,
+): Promise<void> {
+  return apiClient<void>(`/routes/${id}`, {
+    method: "DELETE",
+    authToken,
+  });
+}

--- a/src/lib/utils/__tests__/format.test.ts
+++ b/src/lib/utils/__tests__/format.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDistance,
+  formatDuration,
+  transportLabel,
+} from "@/lib/utils/format";
+
+describe("formatDistance", () => {
+  it("1000m 未満は m 表記", () => {
+    expect(formatDistance(0)).toBe("0m");
+    expect(formatDistance(480)).toBe("480m");
+    expect(formatDistance(999)).toBe("999m");
+  });
+
+  it("1000m 以上は km 表記（小数第1位）", () => {
+    expect(formatDistance(1000)).toBe("1.0km");
+    expect(formatDistance(1500)).toBe("1.5km");
+    expect(formatDistance(12340)).toBe("12.3km");
+  });
+});
+
+describe("formatDuration", () => {
+  it("null は「所要時間不明」", () => {
+    expect(formatDuration(null)).toBe("所要時間不明");
+  });
+
+  it("60分未満は「約N分」（最低1分）", () => {
+    expect(formatDuration(0)).toBe("約1分");
+    expect(formatDuration(1080)).toBe("約18分");
+    expect(formatDuration(3540)).toBe("約59分");
+  });
+
+  it("60分以上は時間表記", () => {
+    expect(formatDuration(3600)).toBe("約1時間");
+    expect(formatDuration(5400)).toBe("約1時間30分");
+    expect(formatDuration(9000)).toBe("約2時間30分");
+  });
+});
+
+describe("transportLabel", () => {
+  it("各手段を日本語化し、null は空文字", () => {
+    expect(transportLabel("walk")).toBe("徒歩");
+    expect(transportLabel("train")).toBe("電車");
+    expect(transportLabel("bus")).toBe("バス");
+    expect(transportLabel("car")).toBe("車");
+    expect(transportLabel(null)).toBe("");
+  });
+});

--- a/src/lib/utils/__tests__/format.test.ts
+++ b/src/lib/utils/__tests__/format.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  formatDistance,
-  formatDuration,
-  transportLabel,
-} from "@/lib/utils/format";
+import { formatDistance, formatDuration, transportLabel } from "../format";
 
 describe("formatDistance", () => {
   it("1000m 未満は m 表記", () => {

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,37 @@
+// 距離・所要時間の表示フォーマット。routes（モデルルート）の距離/時間表示や
+// nearby の距離表示など、複数箇所で共通利用する。
+
+// メートルを「◯m」/「◯.◯km」で表す。1000m 未満は m、以上は km（小数第1位）。
+export function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`;
+  return `${(meters / 1000).toFixed(1)}km`;
+}
+
+// 秒を「約N分」/「約N時間M分」で表す。算出できない（null）場合は「所要時間不明」。
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null) return "所要時間不明";
+  const totalMinutes = Math.max(1, Math.round(seconds / 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `約${minutes}分`;
+  if (minutes === 0) return `約${hours}時間`;
+  return `約${hours}時間${minutes}分`;
+}
+
+// 移動手段の日本語ラベル。null（＝ルート末尾など）は空表示にできるよう "" を返す。
+export function transportLabel(
+  transport: "walk" | "train" | "bus" | "car" | null,
+): string {
+  switch (transport) {
+    case "walk":
+      return "徒歩";
+    case "train":
+      return "電車";
+    case "bus":
+      return "バス";
+    case "car":
+      return "車";
+    default:
+      return "";
+  }
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,3 +1,5 @@
+import type { Transport } from "@/types";
+
 // 距離・所要時間の表示フォーマット。routes（モデルルート）の距離/時間表示や
 // nearby の距離表示など、複数箇所で共通利用する。
 
@@ -19,9 +21,7 @@ export function formatDuration(seconds: number | null): string {
 }
 
 // 移動手段の日本語ラベル。null（＝ルート末尾など）は空表示にできるよう "" を返す。
-export function transportLabel(
-  transport: "walk" | "train" | "bus" | "car" | null,
-): string {
+export function transportLabel(transport: Transport): string {
   switch (transport) {
     case "walk":
       return "徒歩";

--- a/src/lib/validation/route.ts
+++ b/src/lib/validation/route.ts
@@ -1,22 +1,32 @@
 import { z } from "zod";
-import type { RouteInput } from "@/types";
+import type { RouteInput, SpotType, Transport } from "@/types";
+
+// zod enum の値は types/route.ts の union を単一の真実として派生させる
+// （新しい spot_type / transport を追加しても両者がずれないようにする）。
+const SPOT_TYPES = ["greentea", "temple"] as const satisfies readonly SpotType[];
+const TRANSPORTS = [
+  "walk",
+  "train",
+  "bus",
+  "car",
+] as const satisfies readonly Exclude<Transport, null>[];
 
 // モデルルート作成/編集フォームのスキーマ。
 // name は必須（非空）、spots は 1 件以上。transport は任意（未設定は null 扱い）。
-export const transportSchema = z.enum(["walk", "train", "bus", "car"]).nullable();
+export const transportSchema = z.enum(TRANSPORTS).nullable();
 
 export const routeSpotSchema = z.object({
-  spot_type: z.enum(["greentea", "temple"]),
+  spot_type: z.enum(SPOT_TYPES),
   spot_id: z.number(),
   transport: transportSchema,
 });
 
 export const routeFormSchema = z.object({
-  name: z.string().trim().min(1, { message: "コース名は必須です" }),
+  name: z.string().trim().min(1, { error: "コース名は必須です" }),
   description: z.string(),
   spots: z
     .array(routeSpotSchema)
-    .min(1, { message: "スポットを1件以上追加してください" }),
+    .min(1, { error: "スポットを1件以上追加してください" }),
 });
 
 export type RouteFormValues = z.infer<typeof routeFormSchema>;

--- a/src/lib/validation/route.ts
+++ b/src/lib/validation/route.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import type { RouteInput } from "@/types";
+
+// モデルルート作成/編集フォームのスキーマ。
+// name は必須（非空）、spots は 1 件以上。transport は任意（未設定は null 扱い）。
+export const transportSchema = z.enum(["walk", "train", "bus", "car"]).nullable();
+
+export const routeSpotSchema = z.object({
+  spot_type: z.enum(["greentea", "temple"]),
+  spot_id: z.number(),
+  transport: transportSchema,
+});
+
+export const routeFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "コース名は必須です" }),
+  description: z.string(),
+  spots: z
+    .array(routeSpotSchema)
+    .min(1, { message: "スポットを1件以上追加してください" }),
+});
+
+export type RouteFormValues = z.infer<typeof routeFormSchema>;
+
+// フォーム値を API の RouteInput に整形する。
+// includeSpots=false のときは spots を省略し、name/description のみの部分更新にする
+// （ハンドオフ doc: spots を渡さない PATCH は経路再計算を行わない）。
+export function toRouteInput(
+  values: RouteFormValues,
+  includeSpots = true,
+): RouteInput {
+  const input: RouteInput = {
+    name: values.name.trim(),
+    description: values.description,
+  };
+  if (includeSpots) {
+    input.spots = values.spots.map((s) => ({
+      spot_type: s.spot_type,
+      spot_id: s.spot_id,
+      transport: s.transport,
+    }));
+  }
+  return input;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,17 @@ export type {
   TempleLikeResponse,
 } from "./like";
 export type {
+  SpotType,
+  Transport,
+  RouteSpotInput,
+  RouteInput,
+  RouteSpot,
+  RouteDetail,
+  RouteListItem,
+  RouteListResponse,
+  RouteDetailResponse,
+} from "./route";
+export type {
   Meta,
   NearbySpot,
   GreenteaDetail,

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,0 +1,71 @@
+import type { Meta } from "./api";
+
+export type SpotType = "greentea" | "temple";
+export type Transport = "walk" | "train" | "bus" | "car" | null;
+
+// 作成・更新リクエスト（POST/PATCH の body の route キー配下）。
+// spots の配列順がそのままルート順になる。
+export interface RouteSpotInput {
+  spot_type: SpotType;
+  spot_id: number;
+  transport?: Transport;
+}
+
+export interface RouteInput {
+  name: string;
+  description?: string;
+  // PATCH で省略すると name/description のみ部分更新（既存スポット保持）。
+  spots?: RouteSpotInput[];
+}
+
+// 詳細レスポンスの各スポット（position 昇順）。
+export interface RouteSpot {
+  position: number;
+  spot_type: SpotType;
+  // 次スポットへの移動手段。最後の要素や未設定は null。
+  transport: Transport;
+  id: number;
+  name: string;
+  address: string;
+  access: string;
+  latitude: number;
+  longitude: number;
+  img: string;
+  // 次スポットまでの直線距離(m)。最後の要素は null。
+  distance_to_next_meters: number | null;
+  // Directions API の経路距離/所要時間。未算出・失敗時は null。
+  route_distance_to_next_meters: number | null;
+  duration_to_next_seconds: number | null;
+}
+
+export interface RouteDetail {
+  id: number;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  spots: RouteSpot[];
+  // 合計距離(m 整数)。経路距離優先＋無い leg は直線距離でフォールバック。
+  total_distance_meters: number;
+  // 合計所要時間(秒)。算出済み leg のみ合算。1つも無ければ null。
+  total_duration_seconds: number | null;
+}
+
+// 一覧レスポンス要素（軽量シリアライザ。spots は返さず件数のみ）。
+export interface RouteListItem {
+  id: number;
+  name: string;
+  description: string | null;
+  spot_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RouteListResponse {
+  data: RouteListItem[];
+  meta: Meta;
+}
+
+export interface RouteDetailResponse {
+  data: RouteDetail;
+}


### PR DESCRIPTION
## 概要

抹茶スイーツ店と神社仏閣を選んで **モデルコース（巡りコース）** を作成・保存できる機能を新規実装しました。

これまでこのリポジトリにモデルコース関連の画面・型・API は存在しませんでしたが、バックエンド greentea_temple 側で `/api/v1/routes`（CRUD）契約が固まったため、ハンドオフ資料を正としてフロント側を先行実装しています。CLAUDE.md の「フロント先行のためのモック戦略」に従い、`NEXT_PUBLIC_USE_MOCK` で **モック / 実 API を切り替えられる形** にしているため、Rails API 未接続でも一覧・作成・詳細・編集・削除が動作します。

## 実装内容

### 型・API・モック
- `types/route.ts` … `RouteInput` / `RouteDetail` / `RouteSpot` / `RouteListItem` 等（snake_case・`data` ラップの契約に一致）
- `lib/api/routes.ts` … `getRoutes` / `getRoute` / `createRoute` / `updateRoute` / `deleteRoute`（全て JWT 必須）
- `lib/api/mock/state.ts`・`mock/index.ts` … routes の CRUD をモック実装
  - 全エンドポイント認証必須、他人／存在しない ID は `404`、`name` 空・`spots` 空・不正な `spot_type`/`spot_id`/`transport` は `422`、`route` キー欠落は `400`
  - 直線距離＋経路距離（概算）と移動手段別の所要時間を算出。最後のスポットの各距離・`transport` は `null`
  - `PATCH` は契約通り「`spots` あり＝総入れ替え＋再計算 / `spots` なし＝`name`・`description` のみ部分更新（既存スポット保持）」

### 画面・コンポーネント
- `app/routes/`（一覧 / `new` 作成 / `[id]` 詳細 / `[id]/edit` 編集）。いずれも認証必須で、未ログインはログイン導線を表示
- `components/route/`
  - `RouteBuilder` … スポット選択（抹茶店／神社仏閣タブ＋名前検索）、**上下ボタンでの並び替え**、移動手段セレクト、作成／編集の保存
    - 編集時に並び順・スポットが未変更なら `spots` を省いた `PATCH` を送り、不要な経路再計算を避けます
  - `RouteMap` … 順序付きマーカー＋ Polyline で経路を可視化（`useMapsLibrary` 利用。API キー未設定時は案内表示）
  - `RouteList` / `RouteDetailView` / `RouteEditForm` … 一覧・削除、詳細（合計距離・所要時間、経路値優先・直線距離フォールバック、`所要時間不明` 分岐）、編集初期値ロード
- `lib/utils/format.ts` … 距離・所要時間・移動手段ラベルの表示整形
- `lib/validation/route.ts` … zod スキーマ（`name` 必須・`spots` 1件以上）
- マイページ（`app/mypage/page.tsx`）にモデルコースへの導線カードを追加

## テスト
- モック CRUD（認証 / 所有者 / バリデーション / `PATCH` の `spots` 有無 / 距離・所要時間算出）
- `format` ユーティリティ（`所要時間不明` を含む）
- 主要コンポーネント（`RouteList` の一覧・削除・空表示、`RouteBuilder` の追加・バリデーション・作成遷移）

## 動作確認
- `pnpm lint` … エラーなし
- `pnpm test` … 全 236 件パス（うち本 PR 追加分 31 件）
- `pnpm build` … 成功（`/routes`, `/routes/[id]`, `/routes/[id]/edit`, `/routes/new` 生成を確認）

## 補足
- ハンドオフ資料の内容を `docs/migration-plan.md` に routes 契約として追記するのは、別 PR で対応する想定です（本 PR ではコード実装に集中）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrBFvSvMdrqzG42qR4GpYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrBFvSvMdrqzG42qR4GpYp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Model Course” section with list, detail, create, and edit screens.
  * Users can browse courses, view course maps and spot details, and create or update routes.
  * Added pagination and route deletion from the course list.

* **Bug Fixes**
  * Improved logged-out handling by showing sign-in prompts before route actions.
  * Added clearer empty, loading, and not-found states across route screens.

* **Tests**
  * Expanded coverage for route creation, listing, deletion, and formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->