### PR TITLE
docs: 実装済み routes（モデルコース）機能をドキュメントに反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ src/
     temples/                  # 神社 一覧 + [id]/ 詳細
     nearby/                   # 現在地検索（CSR）
     mypage/                   # マイページ + お気に入り（認証必須）
+    routes/                   # モデルコース 一覧/詳細/作成(new)/編集([id]/edit)（認証必須・CSR）
+    admin/                    # 管理画面（greenteas/temples CRUD + comments モデレーション、AdminGuard）
     terms/, privacy/          # 静的ページ
     auth/login/, auth/callback/
     api/auth/[...nextauth]/   # NextAuth.js ルート
@@ -50,13 +52,15 @@ src/
     layout/                   # Header, Footer, Navigation
     greentea/, temple/        # Card / List / Detail / Search
     map/                      # GoogleMap, LocationMarker
+    route/                    # RouteList / RouteBuilder / RouteCreateForm / RouteEditForm / RouteDetailView / RouteMap
+    admin/                    # AdminNav / GreenteaForm / TempleForm / *AdminTable / CommentModerationList / DeleteConfirmDialog
     common/                   # LikeButton, CommentSection, Pagination, ShareButtons 等
     auth/                     # LoginButton, UserMenu
   lib/
-    api/                      # client.ts + 各リソースの API 関数
+    api/                      # client.ts + 各リソースの API 関数（routes.ts / admin/ 含む）
     auth.ts                   # NextAuth 設定
     utils/                    # distance.ts, format.ts
-  types/                      # greentea / temple / user / comment / api
+  types/                      # greentea / temple / user / comment / route / api
 ```
 
 エイリアス: `@/*` → `./src/*`（`tsconfig.json`）。
@@ -65,9 +69,10 @@ src/
 
 - ベースURL: `process.env.NEXT_PUBLIC_API_URL` + `/api/v1`
 - レスポンスの JSON 形は `docs/migration-plan.md` の 1-3 が「契約」。これを型定義（`types/`）と一致させる。
-- 主な型: `Greentea`, `Temple`, `Genre`, `Area`, `User`, `Comment`, `PaginatedResponse<T>`。
+- 主な型: `Greentea`, `Temple`, `Genre`, `Area`, `User`, `Comment`, `RouteDetail` / `RouteListItem`, `PaginatedResponse<T>`。
 - 一覧は `meta`（`current_page` / `total_pages` / `total_count`）付き。詳細は近隣スポット（1.5km以内）と距離情報を含む。
 - 検索パラメータは Ransack 形式（例: `q[name_cont]`）。
+- **モデルコース（`/api/v1/routes`）**は全エンドポイント JWT 認証必須（自分のコースのみ CRUD）。契約は `docs/migration-plan.md` 1-3「モデルコース（routes）」。リクエストボディは `route` キー配下で、`spots` の配列順がコース順になる。
 
 ### フロント先行のためのモック戦略
 - Rails API が未完成でも進められるよう、API クライアントは **環境変数でモック / 実 API を切り替えられる** 形にする。
@@ -85,6 +90,7 @@ src/
 | 詳細 | SSR | SEO + 動的（コメント等） |
 | 現在地検索 | CSR | Geolocation API 依存 |
 | マイページ | CSR | 認証必須・SEO不要 |
+| モデルコース（一覧/詳細/作成/編集） | CSR | 全 API が JWT 認証必須・自分のデータのみ、SEO不要 |
 | ログイン / 利用規約 / プライバシー | SSG | 静的 |
 
 ## コーディング規約

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -36,6 +36,7 @@ namespace :api do
     resources :temple_likes, only: [:index, :create, :destroy]
     resources :greenteacomments, only: [:index, :create, :destroy]
     resources :templecomments, only: [:index, :create, :destroy]
+    resources :routes, only: [:index, :show, :create, :update, :destroy] # モデルコース（JWT 必須）
     get 'nearby', to: 'nearby#search'
     resource :current_user, only: [:show]
     post 'auth/:provider', to: 'auth#create'
@@ -58,6 +59,7 @@ app/controllers/api/v1/
 ├── greenteacomments_controller.rb
 ├── templecomments_controller.rb
 ├── nearby_controller.rb        # 近隣検索
+├── routes_controller.rb        # モデルコース CRUD（JWT 必須）
 ├── current_user_controller.rb  # ログインユーザー情報
 └── auth_controller.rb          # OAuth認証
 ```
@@ -142,7 +144,7 @@ app/controllers/api/v1/
 お気に入りの抹茶店・神社を並べて「自分だけの京都モデルコース」を作る機能。
 **全エンドポイント JWT 認証必須**（`Authorization: Bearer <token>`）で、自分が作成したコースのみ取得・編集・削除できる。
 
-```
+```text
 GET    /api/v1/routes            # 自分のコース一覧（ページネーション）
 GET    /api/v1/routes/:id        # コース詳細（スポット・距離・所要時間）
 POST   /api/v1/routes            # コース作成

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -137,6 +137,108 @@ app/controllers/api/v1/
 }
 ```
 
+#### モデルコース（routes）
+
+お気に入りの抹茶店・神社を並べて「自分だけの京都モデルコース」を作る機能。
+**全エンドポイント JWT 認証必須**（`Authorization: Bearer <token>`）で、自分が作成したコースのみ取得・編集・削除できる。
+
+```
+GET    /api/v1/routes            # 自分のコース一覧（ページネーション）
+GET    /api/v1/routes/:id        # コース詳細（スポット・距離・所要時間）
+POST   /api/v1/routes            # コース作成
+PATCH  /api/v1/routes/:id        # コース更新（spots 省略で name/description のみ部分更新）
+DELETE /api/v1/routes/:id        # コース削除
+```
+
+##### GET /api/v1/routes（一覧）
+一覧は軽量シリアライザで `spots` を返さず件数（`spot_count`）のみ含める。
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "祇園さんぽ",
+      "description": "抹茶と建仁寺めぐり",
+      "spot_count": 3,
+      "created_at": "2026-06-01T10:00:00Z",
+      "updated_at": "2026-06-01T10:00:00Z"
+    }
+  ],
+  "meta": { "current_page": 1, "total_pages": 2, "total_count": 15 }
+}
+```
+
+##### GET /api/v1/routes/:id（詳細）
+`spots` は `position` 昇順。各スポットは次スポットへの移動手段（`transport`）と距離・所要時間を持つ。
+`distance_to_next_meters` は直線距離、`route_distance_to_next_meters` / `duration_to_next_seconds` は Google Directions API の経路値（未算出・失敗時は `null`）。配列末尾のスポットはこれらが `null`。
+
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "祇園さんぽ",
+    "description": "抹茶と建仁寺めぐり",
+    "created_at": "2026-06-01T10:00:00Z",
+    "updated_at": "2026-06-01T10:00:00Z",
+    "spots": [
+      {
+        "position": 1,
+        "spot_type": "greentea",
+        "transport": "walk",
+        "id": 1,
+        "name": "茶寮都路里",
+        "address": "京都市東山区...",
+        "access": "祇園四条駅から徒歩5分",
+        "latitude": 35.0036,
+        "longitude": 135.7714,
+        "img": "https://...",
+        "distance_to_next_meters": 450,
+        "route_distance_to_next_meters": 520,
+        "duration_to_next_seconds": 360
+      },
+      {
+        "position": 2,
+        "spot_type": "temple",
+        "transport": null,
+        "id": 3,
+        "name": "建仁寺",
+        "address": "京都市東山区...",
+        "access": "祇園四条駅から徒歩7分",
+        "latitude": 35.0000,
+        "longitude": 135.7740,
+        "img": "https://...",
+        "distance_to_next_meters": null,
+        "route_distance_to_next_meters": null,
+        "duration_to_next_seconds": null
+      }
+    ],
+    "total_distance_meters": 520,
+    "total_duration_seconds": 360
+  }
+}
+```
+
+##### POST /api/v1/routes / PATCH /api/v1/routes/:id（作成・更新）
+リクエストボディは `route` キー配下。`spots` の配列順がそのままコース順になる。
+`transport` は各スポットから**次のスポットへの**移動手段（`"walk" | "train" | "bus" | "car" | null`）。
+PATCH で `spots` を省略すると既存スポットを保持したまま `name` / `description` のみ部分更新する。
+
+```json
+{
+  "route": {
+    "name": "祇園さんぽ",
+    "description": "抹茶と建仁寺めぐり",
+    "spots": [
+      { "spot_type": "greentea", "spot_id": 1, "transport": "walk" },
+      { "spot_type": "temple", "spot_id": 3, "transport": null }
+    ]
+  }
+}
+```
+
+作成・更新の成功レスポンスは詳細（`GET /api/v1/routes/:id`）と同形。`DELETE` は 204。
+
 ### 1-4. 認証方式の変更
 
 現在の Sorcery セッションベース認証から、**JWT トークン認証**に移行する。
@@ -258,6 +360,14 @@ src/
 │   │   │   └── page.tsx              # お気に入り抹茶店
 │   │   └── temple-likes/
 │   │       └── page.tsx              # お気に入り神社
+│   ├── routes/                       # モデルコース（認証必須・CSR）
+│   │   ├── page.tsx                  # コース一覧
+│   │   ├── new/
+│   │   │   └── page.tsx              # コース作成
+│   │   └── [id]/
+│   │       ├── page.tsx              # コース詳細
+│   │       └── edit/
+│   │           └── page.tsx          # コース編集
 │   ├── terms/
 │   │   └── page.tsx                  # 利用規約
 │   ├── privacy/
@@ -290,6 +400,13 @@ src/
 │   ├── map/
 │   │   ├── GoogleMap.tsx             # Google Maps コンポーネント
 │   │   └── LocationMarker.tsx        # マーカー
+│   ├── route/
+│   │   ├── RouteList.tsx             # コース一覧
+│   │   ├── RouteBuilder.tsx          # コース組み立て（スポット選択・並べ替え）
+│   │   ├── RouteCreateForm.tsx       # コース作成フォーム
+│   │   ├── RouteEditForm.tsx         # コース編集フォーム
+│   │   ├── RouteDetailView.tsx       # コース詳細表示
+│   │   └── RouteMap.tsx              # コース地図
 │   ├── common/
 │   │   ├── LikeButton.tsx            # いいねボタン
 │   │   ├── CommentSection.tsx        # コメントセクション
@@ -307,6 +424,7 @@ src/
 │   │   ├── temples.ts                # 神社 API
 │   │   ├── likes.ts                  # いいね API
 │   │   ├── comments.ts               # コメント API
+│   │   ├── routes.ts                 # モデルコース API（JWT 必須）
 │   │   └── auth.ts                   # 認証 API
 │   ├── auth.ts                       # NextAuth 設定
 │   └── utils/
@@ -317,6 +435,7 @@ src/
     ├── temple.ts                     # 神社型定義
     ├── user.ts                       # ユーザー型定義
     ├── comment.ts                    # コメント型定義
+    ├── route.ts                      # モデルコース型定義
     └── api.ts                        # API レスポンス型定義
 ```
 
@@ -384,6 +503,7 @@ export interface PaginatedResponse<T> {
 | 神社詳細 | SSR | 同上 |
 | 現在地検索 | CSR | ブラウザの Geolocation API 依存 |
 | マイページ | CSR | 認証必須、SEO不要 |
+| モデルコース（一覧/詳細/作成/編集） | CSR | 全 API が JWT 認証必須・自分のデータのみ、SEO不要 |
 | ログイン | SSG | 静的ページ |
 | 利用規約/プライバシーポリシー | SSG | 静的コンテンツ |
 


### PR DESCRIPTION
## 概要

実装・マージ済みの **routes（モデルコース）機能** が `CLAUDE.md` / `docs/migration-plan.md` に一切反映されていなかったギャップを解消するドキュメント整合 PR です。

オープン issue（#51 / #64 / #81 / #27 / #26）はすべて Rails バックエンド（greentea_temple）またはインフラ手作業に依存しており、このリポジトリ単独で完了できるものがありませんでした。その精査の過程で、追跡 issue のない routes 機能（コミット `6f8cda2` 〜で実装）がドキュメントに未記載であることを発見したため、外部依存なしで着手できる本整合を先行対応しています。

## 変更内容

### `docs/migration-plan.md`
- **1-3 API レスポンス設計** に `/api/v1/routes` の API 契約を追記
  - 一覧 / 詳細 / 作成・更新 / 削除の各エンドポイント（全て JWT 認証必須・自分のコースのみ）
  - レスポンス例（一覧の軽量シリアライザ `spot_count`、詳細の `spots`・`transport`・距離/所要時間、末尾スポットの `null` 挙動）
  - リクエスト例（`route` キー配下、`spots` の配列順がコース順、PATCH の部分更新）
- **2-2 ディレクトリ構成** に `app/routes/`・`components/route/`・`lib/api/routes.ts`・`types/route.ts` を追記
- **2-4 レンダリング戦略** にモデルコース（CSR・認証必須）を追記

### `CLAUDE.md`
- ディレクトリ構成に `routes/`（併せて未記載だった `admin/`）を追記
- 主な型に `RouteDetail` / `RouteListItem` を追記し、routes の契約（JWT 必須・`route` キー配下）を明記
- レンダリング戦略表にモデルコース（CSR）を追記

## 補足

- ドキュメントのみの変更で、コードには一切手を入れていません（236 テスト green / ESLint 警告ゼロは変更前後で不変）。
- routes 機能には追跡 issue が存在しないため、実 API 結合（Rails 側 `/api/v1/routes` 実装待ち）を管理する場合は #51 / #81 と同様に別途 issue 化を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ubwr38RiY38t9k98zjFA7

---
_Generated by [Claude Code](https://claude.ai/code/session_014ubwr38RiY38t9k98zjFA7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the product and API plan for “model course” routes, including create, view, edit, and list flows.
  * Clarified that route data is user-specific, requires sign-in, and preserves spot order when building a course.
  * Added expected response behavior for listing, details, saving, and deleting routes, plus planned client-side page rendering for route screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->