### PR TITLE
実API結合の前提整備（422エラー表示の堅牢化 / lib/api テスト拡充 / ESLint CLI 移行）

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,11 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  // `eslint .` はビルド成果物も対象にするため明示的に無視する。
+  // （`next lint` はこれらを既定で除外していた。）
+  {
+    ignores: [".next/", "out/", "build/", "coverage/", "next-env.d.ts"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/lib/api/__tests__/comments.test.ts
+++ b/src/lib/api/__tests__/comments.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import { endpoint } from "@tests/msw/endpoint";
 import { server } from "@tests/msw/server";
 import {
   createGreenteaComment,
@@ -10,15 +11,13 @@ import {
   getTempleComments,
 } from "../comments";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
-const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
-
-// 記録した最後のリクエストのメソッド/クエリ/ボディ/認可ヘッダを検証するためのヘルパ。
+// 記録した最後のリクエストのメソッド/クエリ/ボディ/認可ヘッダ/path id を検証するためのヘルパ。
 type Captured = {
   method?: string;
   url?: URL;
   auth?: string | null;
   body?: unknown;
+  id?: string;
 };
 
 describe("comments API クライアント", () => {
@@ -126,7 +125,7 @@ describe("comments API クライアント", () => {
           ({ request, params }) => {
             captured.method = request.method;
             captured.auth = request.headers.get("Authorization");
-            (captured as Captured & { id?: string }).id = params.id as string;
+            captured.id = params.id as string;
             return new HttpResponse(null, { status: 204 });
           },
         ),
@@ -136,7 +135,7 @@ describe("comments API クライアント", () => {
 
       expect(captured.method).toBe("DELETE");
       expect(captured.auth).toBe("Bearer tok-abc");
-      expect((captured as Captured & { id?: string }).id).toBe("200");
+      expect(captured.id).toBe("200");
       expect(res).toBeUndefined();
     });
 

--- a/src/lib/api/__tests__/comments.test.ts
+++ b/src/lib/api/__tests__/comments.test.ts
@@ -1,0 +1,153 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import {
+  createGreenteaComment,
+  createTempleComment,
+  deleteGreenteaComment,
+  deleteTempleComment,
+  getGreenteaComments,
+  getTempleComments,
+} from "../comments";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+// 記録した最後のリクエストのメソッド/クエリ/ボディ/認可ヘッダを検証するためのヘルパ。
+type Captured = {
+  method?: string;
+  url?: URL;
+  auth?: string | null;
+  body?: unknown;
+};
+
+describe("comments API クライアント", () => {
+  describe("一覧取得", () => {
+    it("getGreenteaComments は ?greentea_id= 付きで GET する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/greenteacomments"), ({ request }) => {
+          captured.method = request.method;
+          captured.url = new URL(request.url);
+          return HttpResponse.json({
+            comments: [
+              {
+                id: 1,
+                body: "美味しい",
+                user: { id: 10, name: "わたし" },
+                created_at: "2026-06-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      const res = await getGreenteaComments(42);
+
+      expect(captured.method).toBe("GET");
+      expect(captured.url?.searchParams.get("greentea_id")).toBe("42");
+      expect(res.comments).toHaveLength(1);
+      expect(res.comments[0].body).toBe("美味しい");
+    });
+
+    it("getTempleComments は ?temple_id= 付きで GET する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/templecomments"), ({ request }) => {
+          captured.url = new URL(request.url);
+          return HttpResponse.json({ comments: [] });
+        }),
+      );
+
+      const res = await getTempleComments(7);
+
+      expect(captured.url?.searchParams.get("temple_id")).toBe("7");
+      expect(res.comments).toEqual([]);
+    });
+  });
+
+  describe("投稿", () => {
+    it("createGreenteaComment は POST し body と Bearer を送る", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.post(endpoint("/greenteacomments"), async ({ request }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.body = await request.json();
+          return HttpResponse.json({
+            comment: {
+              id: 200,
+              body: "投稿本文",
+              user: { id: 10, name: "わたし" },
+              created_at: "2026-06-01T00:00:00Z",
+            },
+          });
+        }),
+      );
+
+      const res = await createGreenteaComment(42, "投稿本文", "tok-abc");
+
+      expect(captured.method).toBe("POST");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.body).toEqual({ greentea_id: 42, body: "投稿本文" });
+      expect(res.comment.id).toBe(200);
+    });
+
+    it("createTempleComment は temple_id を含む body を送る", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.post(endpoint("/templecomments"), async ({ request }) => {
+          captured.auth = request.headers.get("Authorization");
+          captured.body = await request.json();
+          return HttpResponse.json({
+            comment: {
+              id: 201,
+              body: "神社の投稿",
+              user: { id: 10, name: "わたし" },
+              created_at: "2026-06-01T00:00:00Z",
+            },
+          });
+        }),
+      );
+
+      await createTempleComment(7, "神社の投稿", "tok-xyz");
+
+      expect(captured.auth).toBe("Bearer tok-xyz");
+      expect(captured.body).toEqual({ temple_id: 7, body: "神社の投稿" });
+    });
+  });
+
+  describe("削除", () => {
+    it("deleteGreenteaComment は :id を含む path へ DELETE し 204 で undefined を返す", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.delete(
+          endpoint("/greenteacomments/:id"),
+          ({ request, params }) => {
+            captured.method = request.method;
+            captured.auth = request.headers.get("Authorization");
+            (captured as Captured & { id?: string }).id = params.id as string;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      const res = await deleteGreenteaComment(200, "tok-abc");
+
+      expect(captured.method).toBe("DELETE");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect((captured as Captured & { id?: string }).id).toBe("200");
+      expect(res).toBeUndefined();
+    });
+
+    it("deleteTempleComment も 204 で undefined を返す", async () => {
+      server.use(
+        http.delete(endpoint("/templecomments/:id"), () =>
+          HttpResponse.text(null, { status: 204 }),
+        ),
+      );
+
+      await expect(deleteTempleComment(201, "tok-xyz")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/lib/api/__tests__/error.test.ts
+++ b/src/lib/api/__tests__/error.test.ts
@@ -60,6 +60,33 @@ describe("error ユーティリティ", () => {
       ).toBe("むり");
     });
 
+    it("{ errors: { field: [...] } }（Rails 標準ハッシュ）を連結する", () => {
+      const err = new ApiError(422, {
+        errors: {
+          name: ["を入力してください"],
+          spots: ["は1件以上必要です", "の並び順が不正です"],
+        },
+      });
+      expect(getApiErrorMessage(err, "fb")).toBe(
+        "を入力してください / は1件以上必要です / の並び順が不正です",
+      );
+    });
+
+    it("{ errors: { field: '...' } }（値が単一文字列）も拾う", () => {
+      const err = new ApiError(422, { errors: { base: "保存できません" } });
+      expect(getApiErrorMessage(err, "fb")).toBe("保存できません");
+    });
+
+    it("{ details: [...] }（mock 形式）を拾い、汎用 error より優先する", () => {
+      const err = new ApiError(422, {
+        error: "Unprocessable Entity",
+        details: ["name は必須です", "spots は空にできません"],
+      });
+      expect(getApiErrorMessage(err, "fb")).toBe(
+        "name は必須です / spots は空にできません",
+      );
+    });
+
     it("errors が空配列・非文字列のみなら fallback", () => {
       expect(getApiErrorMessage(new ApiError(422, { errors: [] }), "fb")).toBe(
         "fb",

--- a/src/lib/api/__tests__/likes.test.ts
+++ b/src/lib/api/__tests__/likes.test.ts
@@ -1,0 +1,135 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import {
+  getGreenteaLikes,
+  getTempleLikes,
+  likeGreentea,
+  likeTemple,
+  unlikeGreentea,
+  unlikeTemple,
+} from "../likes";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+type Captured = {
+  method?: string;
+  auth?: string | null;
+  body?: unknown;
+  id?: string;
+};
+
+describe("likes API クライアント", () => {
+  describe("お気に入り一覧", () => {
+    it("getGreenteaLikes は Bearer 付きで GET する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/greentea_likes"), ({ request }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          return HttpResponse.json({
+            greentea_likes: [
+              { id: 1, greentea: { id: 5 }, created_at: "2026-06-01T00:00:00Z" },
+            ],
+          });
+        }),
+      );
+
+      const res = await getGreenteaLikes("tok-abc");
+
+      expect(captured.method).toBe("GET");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(res.greentea_likes).toHaveLength(1);
+    });
+
+    it("getTempleLikes は Bearer 付きで GET する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/temple_likes"), ({ request }) => {
+          captured.auth = request.headers.get("Authorization");
+          return HttpResponse.json({ temple_likes: [] });
+        }),
+      );
+
+      const res = await getTempleLikes("tok-xyz");
+
+      expect(captured.auth).toBe("Bearer tok-xyz");
+      expect(res.temple_likes).toEqual([]);
+    });
+  });
+
+  describe("いいね追加", () => {
+    it("likeGreentea は greentea_id を body に載せて POST する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.post(endpoint("/greentea_likes"), async ({ request }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.body = await request.json();
+          return HttpResponse.json({
+            greentea_like: { id: 99, greentea_id: 5, user_id: 1 },
+          });
+        }),
+      );
+
+      const res = await likeGreentea(5, "tok-abc");
+
+      expect(captured.method).toBe("POST");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.body).toEqual({ greentea_id: 5 });
+      expect(res.greentea_like.id).toBe(99);
+    });
+
+    it("likeTemple は temple_id を body に載せて POST する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.post(endpoint("/temple_likes"), async ({ request }) => {
+          captured.body = await request.json();
+          return HttpResponse.json({
+            temple_like: { id: 88, temple_id: 3, user_id: 1 },
+          });
+        }),
+      );
+
+      await likeTemple(3, "tok-xyz");
+
+      expect(captured.body).toEqual({ temple_id: 3 });
+    });
+  });
+
+  describe("いいね解除", () => {
+    it("unlikeGreentea は path に対象 id を渡して DELETE し undefined を返す", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.delete(endpoint("/greentea_likes/:id"), ({ request, params }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.id = params.id as string;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      const res = await unlikeGreentea(5, "tok-abc");
+
+      expect(captured.method).toBe("DELETE");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      // フロントは like_id ではなく対象スポットの id を path に渡す実装。
+      expect(captured.id).toBe("5");
+      expect(res).toBeUndefined();
+    });
+
+    it("unlikeTemple も対象 id を path に渡して DELETE する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.delete(endpoint("/temple_likes/:id"), ({ params }) => {
+          captured.id = params.id as string;
+          return HttpResponse.text(null, { status: 204 });
+        }),
+      );
+
+      await expect(unlikeTemple(3, "tok-xyz")).resolves.toBeUndefined();
+      expect(captured.id).toBe("3");
+    });
+  });
+});

--- a/src/lib/api/__tests__/likes.test.ts
+++ b/src/lib/api/__tests__/likes.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import { endpoint } from "@tests/msw/endpoint";
 import { server } from "@tests/msw/server";
 import {
   getGreenteaLikes,
@@ -9,9 +10,6 @@ import {
   unlikeGreentea,
   unlikeTemple,
 } from "../likes";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
-const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
 type Captured = {
   method?: string;

--- a/src/lib/api/__tests__/routes.test.ts
+++ b/src/lib/api/__tests__/routes.test.ts
@@ -1,0 +1,173 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@tests/msw/server";
+import type { RouteInput } from "@/types";
+import {
+  createRoute,
+  deleteRoute,
+  getRoute,
+  getRoutes,
+  updateRoute,
+} from "../routes";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+type Captured = {
+  method?: string;
+  url?: URL;
+  auth?: string | null;
+  body?: unknown;
+  id?: string;
+};
+
+const listItem = {
+  id: 1,
+  name: "祇園めぐり",
+  description: null,
+  spot_count: 3,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+};
+
+const detail = {
+  id: 1,
+  name: "祇園めぐり",
+  description: "抹茶と神社",
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  spots: [],
+  total_distance_meters: 0,
+  total_duration_seconds: null,
+};
+
+describe("routes API クライアント", () => {
+  describe("一覧取得", () => {
+    it("getRoutes は Bearer 付きで GET し、page を指定すると ?page= が付く", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/routes"), ({ request }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.url = new URL(request.url);
+          return HttpResponse.json({
+            data: [listItem],
+            meta: { current_page: 2, total_pages: 3, total_count: 25 },
+          });
+        }),
+      );
+
+      const res = await getRoutes("tok-abc", 2);
+
+      expect(captured.method).toBe("GET");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.url?.searchParams.get("page")).toBe("2");
+      expect(res.data[0].spot_count).toBe(3);
+      expect(res.meta.total_count).toBe(25);
+    });
+
+    it("getRoutes は page 未指定なら ?page= を付けない", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/routes"), ({ request }) => {
+          captured.url = new URL(request.url);
+          return HttpResponse.json({
+            data: [],
+            meta: { current_page: 1, total_pages: 1, total_count: 0 },
+          });
+        }),
+      );
+
+      await getRoutes("tok-abc");
+
+      expect(captured.url?.searchParams.has("page")).toBe(false);
+    });
+  });
+
+  describe("詳細取得", () => {
+    it("getRoute は :id を含む path へ Bearer 付きで GET する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.get(endpoint("/routes/:id"), ({ request, params }) => {
+          captured.auth = request.headers.get("Authorization");
+          captured.id = params.id as string;
+          return HttpResponse.json({ data: detail });
+        }),
+      );
+
+      const res = await getRoute(1, "tok-abc");
+
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.id).toBe("1");
+      expect(res.data.name).toBe("祇園めぐり");
+    });
+  });
+
+  describe("作成・更新", () => {
+    const input: RouteInput = {
+      name: "新コース",
+      description: "説明",
+      spots: [
+        { spot_type: "greentea", spot_id: 5, transport: "walk" },
+        { spot_type: "temple", spot_id: 9, transport: null },
+      ],
+    };
+
+    it("createRoute は body を { route: input } でラップして POST する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.post(endpoint("/routes"), async ({ request }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.body = await request.json();
+          return HttpResponse.json({ data: detail });
+        }),
+      );
+
+      await createRoute(input, "tok-abc");
+
+      expect(captured.method).toBe("POST");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.body).toEqual({ route: input });
+    });
+
+    it("updateRoute は :id へ { route: input } を PATCH する", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.patch(endpoint("/routes/:id"), async ({ request, params }) => {
+          captured.method = request.method;
+          captured.id = params.id as string;
+          captured.body = await request.json();
+          return HttpResponse.json({ data: detail });
+        }),
+      );
+
+      await updateRoute(1, input, "tok-abc");
+
+      expect(captured.method).toBe("PATCH");
+      expect(captured.id).toBe("1");
+      expect(captured.body).toEqual({ route: input });
+    });
+  });
+
+  describe("削除", () => {
+    it("deleteRoute は :id へ DELETE し 204 で undefined を返す", async () => {
+      const captured: Captured = {};
+      server.use(
+        http.delete(endpoint("/routes/:id"), ({ request, params }) => {
+          captured.method = request.method;
+          captured.auth = request.headers.get("Authorization");
+          captured.id = params.id as string;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      const res = await deleteRoute(1, "tok-abc");
+
+      expect(captured.method).toBe("DELETE");
+      expect(captured.auth).toBe("Bearer tok-abc");
+      expect(captured.id).toBe("1");
+      expect(res).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/api/__tests__/routes.test.ts
+++ b/src/lib/api/__tests__/routes.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import { endpoint } from "@tests/msw/endpoint";
 import { server } from "@tests/msw/server";
 import type { RouteInput } from "@/types";
 import {
@@ -9,9 +10,6 @@ import {
   getRoutes,
   updateRoute,
 } from "../routes";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
-const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
 type Captured = {
   method?: string;

--- a/src/lib/api/error.ts
+++ b/src/lib/api/error.ts
@@ -32,21 +32,45 @@ export function isValidationError(error: unknown): boolean {
   return getErrorStatus(error) === 422;
 }
 
-// Rails のエラーボディから表示用メッセージを取り出す。
-// 形式ゆれ（{ errors: [...] } / { error: "..." } / { message: "..." }）を吸収し、
+// string / string[] / { field: string | string[] } のいずれからも文字列メッセージを
+// 平坦化して集める。空要素・非文字列は捨てる。
+function collectMessages(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.length > 0 ? [value] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string" && v.length > 0);
+  }
+  if (value && typeof value === "object") {
+    // Rails の { field: ["msg", ...] } / { field: "msg" }（ActiveModel errors）を展開する。
+    return Object.values(value).flatMap((v) => collectMessages(v));
+  }
+  return [];
+}
+
+// Rails / mock のエラーボディから表示用メッセージを取り出す。
+// 形式ゆれを吸収する:
+//   - { errors: ["msg", ...] }                （文字列配列）
+//   - { errors: { field: ["msg"] | "msg" } }  （Rails ActiveModel 標準ハッシュ）
+//   - { details: ["msg", ...] }               （本リポジトリ mock の 422）
+//   - { error: "msg" } / { message: "msg" }   （単一メッセージ）
+// フィールド別ハッシュや details は具体的なので、汎用になりがちな error/message より優先する。
 // どれにも当てはまらなければ fallback を返す。
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   const data = getErrorData(error);
   if (data && typeof data === "object") {
     const obj = data as Record<string, unknown>;
-    if (Array.isArray(obj.errors)) {
-      const messages = obj.errors.filter(
-        (e): e is string => typeof e === "string",
-      );
-      if (messages.length > 0) return messages.join(" / ");
+
+    const errorsMessages = collectMessages(obj.errors);
+    if (errorsMessages.length > 0) return errorsMessages.join(" / ");
+
+    const detailsMessages = collectMessages(obj.details);
+    if (detailsMessages.length > 0) return detailsMessages.join(" / ");
+
+    if (typeof obj.error === "string" && obj.error.length > 0) return obj.error;
+    if (typeof obj.message === "string" && obj.message.length > 0) {
+      return obj.message;
     }
-    if (typeof obj.error === "string") return obj.error;
-    if (typeof obj.message === "string") return obj.message;
   }
   return fallback;
 }

--- a/tests/msw/endpoint.ts
+++ b/tests/msw/endpoint.ts
@@ -1,0 +1,6 @@
+// API クライアントのテストで実 API の URL を組み立てる共有ヘルパー。
+// 各 spec が env フォールバックと `/api/v1` prefix を重複定義しないよう集約する。
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+export const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;


### PR DESCRIPTION
## 概要

オープンな実装系 issue（#51 / #64 / #81 / #89）は greentea_temple（Rails API）の実装待ちで着手できないため、**このリポジトリ単体で完結でき、実 API 結合が来たときに効いてくる「前提整備」3 件**を issue 化して対応した。

いずれもフロント単体で完結し、既存挙動への回帰なし。

- Closes #90
- Closes #91
- Closes #92

## 変更内容

### #90 422 バリデーションエラー表示の堅牢化（`fix`）

`getApiErrorMessage`（`src/lib/api/error.ts`）が拾えるエラーボディ形式を拡張。

- **Rails 標準の `{ errors: { field: ["msg"] | "msg" } }`（ActiveModel ハッシュ）を吸収** — 従来は未対応でフォームにメッセージが出なかった
- **mock の `{ error: "Unprocessable Entity", details: [...] }` の `details` を吸収**し、汎用的な `error` より優先 — mock モードでもフィールド別メッセージが表示される
- `string` / `string[]` / ハッシュ値を `collectMessages` で平坦化
- 既存の `{ errors: [...] }` / `{ error }` / `{ message }` は維持
- `error.test.ts` に各形式のケースを追加

→ 消費側（`GreenteaForm` / `TempleForm` / `RouteBuilder` / `CommentSection`）が具体的な 422 メッセージを表示できるようになり、#51 / #64 / #81 / #89 の実 API 結合の前提が整う。

### #91 lib/api リソース関数のテスト拡充（`test`）

実 API 結合で最初に叩く API クライアントの薄かったテストを、MSW で補強。

- `comments.ts`（33% → 100%）/ `likes.ts`（50% → 100%）/ `routes.ts`（60% → 100%）に単体テスト 18 件追加
- method / path / query / body / `Authorization: Bearer` / レスポンス解析を検証
- `lib/api` ディレクトリ全体 **88.5% → 98.1%**（statements）

→ 実 API に向けたときのリクエスト形・レスポンス解釈の回帰防止の安全網。

### #92 `next lint` 廃止対応 — ESLint CLI へ移行（`chore`）

`next lint` は Next.js 16 で削除されるため、削除前に直接実行へ移行。

- `package.json`: `"lint"` を `next lint` → `eslint .`
- `eslint.config.mjs`: `eslint .` 用に `.next/` / `out/` / `build/` / `coverage/` / `next-env.d.ts` を `ignores`
- `next/core-web-vitals`・`next/typescript` 継承と `no-restricted-imports`（import 規約チェック）は維持し、違反ファイルで発火することを確認済み
- `pnpm lint` が deprecation 警告なしで従来同等に green

## 動作確認

- ✅ `pnpm test` — 257 tests / 38 files すべて green（+21）
- ✅ `pnpm lint` — クリーン（deprecation 警告なし）
- ✅ `npx tsc --noEmit` — 型エラーなし

## 補足

3 件は独立した変更のためコミットを分けている（`861466d` / `74aa8b0` / `7f44a0b`）。レビューはコミット単位でも追える。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU7UoCLJk6WKjBiKPpfMqE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages by supporting more response formats, including detailed and field-level validation errors.
  * Linting now consistently excludes generated build files and coverage output.

* **Tests**
  * Added comprehensive coverage for comments, likes, routes, and API error handling.
  * Verified authentication, request parameters, request bodies, response mapping, and deletion behavior across API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->