### PR TITLE
表示系コンポーネント / metadata ユーティリティのテスト拡充

### DIFF
--- a/src/components/common/__tests__/ComingSoon.test.tsx
+++ b/src/components/common/__tests__/ComingSoon.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ComingSoon from "@/components/common/ComingSoon";
+
+describe("ComingSoon", () => {
+  it("title を見出しに表示する", () => {
+    render(<ComingSoon title="マイページ" />);
+
+    expect(
+      screen.getByRole("heading", { name: "マイページ" }),
+    ).toBeInTheDocument();
+  });
+
+  it("description 未指定なら既定の準備中文言を表示する", () => {
+    render(<ComingSoon title="マイページ" />);
+
+    expect(
+      screen.getByText(/このページは現在準備中です/),
+    ).toBeInTheDocument();
+  });
+
+  it("description を渡すとその文言を表示する", () => {
+    render(<ComingSoon title="ルート" description="近日公開します。" />);
+
+    expect(screen.getByText("近日公開します。")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/このページは現在準備中です/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("トップへ戻るリンクを表示する", () => {
+    render(<ComingSoon title="マイページ" />);
+
+    expect(
+      screen.getByRole("link", { name: "トップへ戻る" }),
+    ).toHaveAttribute("href", "/");
+  });
+});

--- a/src/components/common/__tests__/ShareButtons.test.tsx
+++ b/src/components/common/__tests__/ShareButtons.test.tsx
@@ -24,7 +24,10 @@ describe("ShareButtons", () => {
     render(<ShareButtons title="伏見稲荷大社" />);
 
     const twitter = await screen.findByLabelText("X（Twitter）でシェア");
+    const line = screen.getByLabelText("LINEでシェア");
     expect(twitter).toHaveAttribute("target", "_blank");
     expect(twitter).toHaveAttribute("rel", "noopener noreferrer");
+    expect(line).toHaveAttribute("target", "_blank");
+    expect(line).toHaveAttribute("rel", "noopener noreferrer");
   });
 });

--- a/src/components/common/__tests__/ShareButtons.test.tsx
+++ b/src/components/common/__tests__/ShareButtons.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ShareButtons from "@/components/common/ShareButtons";
+
+describe("ShareButtons", () => {
+  it("マウント後に X / LINE のシェアリンクを表示する", async () => {
+    render(<ShareButtons title="中村藤吉本店" />);
+
+    const twitter = await screen.findByLabelText("X（Twitter）でシェア");
+    const line = screen.getByLabelText("LINEでシェア");
+
+    const url = window.location.href;
+    expect(twitter).toHaveAttribute(
+      "href",
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent("中村藤吉本店")}&url=${encodeURIComponent(url)}`,
+    );
+    expect(line).toHaveAttribute(
+      "href",
+      `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`,
+    );
+  });
+
+  it("シェアリンクは別タブ・noopener で開く", async () => {
+    render(<ShareButtons title="伏見稲荷大社" />);
+
+    const twitter = await screen.findByLabelText("X（Twitter）でシェア");
+    expect(twitter).toHaveAttribute("target", "_blank");
+    expect(twitter).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/src/components/greentea/__tests__/GreenteaList.test.tsx
+++ b/src/components/greentea/__tests__/GreenteaList.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import GreenteaList from "@/components/greentea/GreenteaList";
+import type { Greentea } from "@/types";
+
+const baseGreentea: Greentea = {
+  id: 1,
+  name: "中村藤吉本店",
+  description: "宇治の老舗抹茶店。",
+  address: "京都府宇治市宇治壱番10",
+  access: "JR宇治駅から徒歩3分",
+  phone_number: "0774-22-7800",
+  business_hours: "10:00-17:00",
+  holiday: "無休",
+  homepage: "https://tokichi.jp",
+  closed: false,
+  img: "",
+  latitude: 34.9,
+  longitude: 135.8,
+  genres: [],
+  likes_count: 42,
+};
+
+describe("GreenteaList", () => {
+  it("空配列なら見つからなかった旨を表示する", () => {
+    render(<GreenteaList greenteas={[]} />);
+
+    expect(
+      screen.getByText("該当する抹茶店が見つかりませんでした。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+
+  it("要素があれば件数分のカードを一覧表示する", () => {
+    const greenteas: Greentea[] = [
+      { ...baseGreentea, id: 1, name: "中村藤吉本店" },
+      { ...baseGreentea, id: 2, name: "茶寮都路里" },
+    ];
+    render(<GreenteaList greenteas={greenteas} />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(
+      screen.getByRole("heading", { name: "中村藤吉本店" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "茶寮都路里" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Footer from "@/components/layout/Footer";
+
+describe("Footer", () => {
+  it("非公式である旨と出典の免責を表示する", () => {
+    render(<Footer />);
+
+    expect(
+      screen.getByText(/非公式のファンサイト/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/出典/)).toBeInTheDocument();
+  });
+
+  it("利用規約 / プライバシー / 現在地から のリンクを表示する", () => {
+    render(<Footer />);
+
+    expect(screen.getByRole("link", { name: "利用規約" })).toHaveAttribute(
+      "href",
+      "/terms",
+    );
+    expect(
+      screen.getByRole("link", { name: "プライバシー" }),
+    ).toHaveAttribute("href", "/privacy");
+    expect(
+      screen.getByRole("link", { name: "現在地から" }),
+    ).toHaveAttribute("href", "/nearby");
+  });
+
+  it("現在の年号を著作権表記に含める", () => {
+    render(<Footer />);
+
+    const year = new Date().getFullYear();
+    expect(
+      screen.getByText(new RegExp(`${year}\\s*抹茶と神社。`)),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Navigation.test.tsx
+++ b/src/components/layout/__tests__/Navigation.test.tsx
@@ -53,5 +53,7 @@ describe("Navigation", () => {
     render(<Navigation orientation="vertical" />);
 
     expect(screen.getAllByRole("link")).toHaveLength(NAV_LINKS.length);
+    // prop が無視されて横並びになったら落ちるよう、縦並びのクラスも検証する。
+    expect(screen.getByRole("list")).toHaveClass("flex-col");
   });
 });

--- a/src/components/layout/__tests__/Navigation.test.tsx
+++ b/src/components/layout/__tests__/Navigation.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Navigation, { NAV_LINKS } from "@/components/layout/Navigation";
+
+let currentPathname = "/";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => currentPathname,
+}));
+
+beforeEach(() => {
+  currentPathname = "/";
+});
+
+describe("Navigation", () => {
+  it("全てのナビリンクを表示する", () => {
+    render(<Navigation />);
+
+    for (const link of NAV_LINKS) {
+      expect(
+        screen.getByRole("link", { name: link.label }),
+      ).toHaveAttribute("href", link.href);
+    }
+  });
+
+  it("トップ（/）は完全一致のときだけアクティブ", () => {
+    currentPathname = "/";
+    render(<Navigation />);
+
+    expect(screen.getByRole("link", { name: "トップ" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(
+      screen.getByRole("link", { name: "抹茶スイーツ" }),
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("配下パスは前方一致でアクティブになる", () => {
+    currentPathname = "/greenteas/1";
+    render(<Navigation />);
+
+    expect(
+      screen.getByRole("link", { name: "抹茶スイーツ" }),
+    ).toHaveAttribute("aria-current", "page");
+    // トップは前方一致の対象外（/ は完全一致のみ）
+    expect(screen.getByRole("link", { name: "トップ" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("orientation=vertical でも全リンクを表示する", () => {
+    render(<Navigation orientation="vertical" />);
+
+    expect(screen.getAllByRole("link")).toHaveLength(NAV_LINKS.length);
+  });
+});

--- a/src/components/temple/__tests__/TempleList.test.tsx
+++ b/src/components/temple/__tests__/TempleList.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TempleList from "@/components/temple/TempleList";
+import type { Temple } from "@/types";
+
+const baseTemple: Temple = {
+  id: 1,
+  name: "伏見稲荷大社",
+  description: "千本鳥居で知られる神社。",
+  address: "京都府京都市伏見区深草藪之内町68",
+  access: "JR稲荷駅すぐ",
+  phone_number: "075-641-7331",
+  business_hours: "24時間",
+  holiday: "無休",
+  homepage: "https://inari.jp",
+  img: "",
+  latitude: 34.9,
+  longitude: 135.7,
+  areas: [],
+  likes_count: 88,
+};
+
+describe("TempleList", () => {
+  it("空配列なら見つからなかった旨を表示する", () => {
+    render(<TempleList temples={[]} />);
+
+    expect(
+      screen.getByText("該当する神社仏閣が見つかりませんでした。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+
+  it("要素があれば件数分のカードを一覧表示する", () => {
+    const temples: Temple[] = [
+      { ...baseTemple, id: 1, name: "伏見稲荷大社" },
+      { ...baseTemple, id: 2, name: "清水寺" },
+    ];
+    render(<TempleList temples={temples} />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(
+      screen.getByRole("heading", { name: "伏見稲荷大社" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "清水寺" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/lib/utils/__tests__/metadata.test.ts
+++ b/src/lib/utils/__tests__/metadata.test.ts
@@ -1,0 +1,65 @@
+import type { ResolvingMetadata } from "next";
+import { describe, expect, it } from "vitest";
+import { buildSpotMetadata } from "../metadata";
+
+// buildSpotMetadata は parent（ルート）の解決済み metadata から
+// og:image / twitter:image を引き継ぐ。ResolvingMetadata は Promise 互換なので
+// 必要なフィールドだけ持つオブジェクトを resolve して渡す。
+function fakeParent(
+  openGraphImages: unknown,
+  twitterImages: unknown,
+): ResolvingMetadata {
+  return Promise.resolve({
+    openGraph: { images: openGraphImages },
+    twitter: { images: twitterImages },
+  }) as unknown as ResolvingMetadata;
+}
+
+describe("buildSpotMetadata", () => {
+  it("title / description を設定する", async () => {
+    const meta = await buildSpotMetadata(
+      "中村藤吉本店",
+      "宇治の老舗抹茶店。",
+      fakeParent([], []),
+    );
+
+    expect(meta.title).toBe("中村藤吉本店");
+    expect(meta.description).toBe("宇治の老舗抹茶店。");
+    expect(meta.openGraph?.title).toBe("中村藤吉本店");
+    expect(meta.twitter?.title).toBe("中村藤吉本店");
+  });
+
+  it("親のサイト共通 og:image / twitter:image を継承する（画像継承の回帰防止）", async () => {
+    const ogImages = [{ url: "https://example.com/og.png" }];
+    const twitterImages = [{ url: "https://example.com/twitter.png" }];
+
+    const meta = await buildSpotMetadata(
+      "伏見稲荷大社",
+      "千本鳥居の神社。",
+      fakeParent(ogImages, twitterImages),
+    );
+
+    expect(meta.openGraph?.images).toBe(ogImages);
+    expect(meta.twitter?.images).toBe(twitterImages);
+  });
+
+  it("openGraph は article / ja_JP / siteName を持つ", async () => {
+    const meta = await buildSpotMetadata("店名", "説明", fakeParent([], []));
+
+    expect(meta.openGraph).toMatchObject({
+      type: "article",
+      locale: "ja_JP",
+      siteName: "抹茶と神社。",
+    });
+    expect(meta.twitter?.card).toBe("summary_large_image");
+  });
+
+  it("親に画像が無くても空配列にフォールバックして壊れない", async () => {
+    const empty = Promise.resolve({}) as unknown as ResolvingMetadata;
+
+    const meta = await buildSpotMetadata("店名", "説明", empty);
+
+    expect(meta.openGraph?.images).toEqual([]);
+    expect(meta.twitter?.images).toEqual([]);
+  });
+});

--- a/src/lib/utils/__tests__/metadata.test.ts
+++ b/src/lib/utils/__tests__/metadata.test.ts
@@ -26,7 +26,9 @@ describe("buildSpotMetadata", () => {
     expect(meta.title).toBe("中村藤吉本店");
     expect(meta.description).toBe("宇治の老舗抹茶店。");
     expect(meta.openGraph?.title).toBe("中村藤吉本店");
+    expect(meta.openGraph?.description).toBe("宇治の老舗抹茶店。");
     expect(meta.twitter?.title).toBe("中村藤吉本店");
+    expect(meta.twitter?.description).toBe("宇治の老舗抹茶店。");
   });
 
   it("親のサイト共通 og:image / twitter:image を継承する（画像継承の回帰防止）", async () => {


### PR DESCRIPTION
## 概要

フロント単体で完結できる改善として、**外部依存（Google Maps 等）が薄く純粋な表示系コンポーネントと metadata ユーティリティ**のテストを追加した。現状カバレッジ 0〜20% でリグレッションに気づけなかった箇所を補強する。

- Closes #94

## 変更内容

いずれもテスト追加のみ。プロダクションコードの変更はなし。

| 対象 | テスト内容 |
|------|-----------|
| `src/lib/utils/metadata.ts` | `buildSpotMetadata` の `title`/`description` 設定、**親（ルート）の og:image / twitter:image 継承**（過去に修正した OGP 画像継承の回帰防止）、親に画像が無いケースのフォールバック |
| `src/components/layout/Footer.tsx` | 非公式である旨の免責・出典注意書き、各リンク（利用規約 / プライバシー / 現在地から）、動的な年号 |
| `src/components/layout/Navigation.tsx` | 全ナビリンク表示、`aria-current="page"` の付与（`/` は完全一致・配下パスは前方一致）、`orientation=vertical` |
| `src/components/greentea/GreenteaList.tsx` | 空配列時の「見つかりませんでした」表示、要素ありでカード一覧 |
| `src/components/temple/TempleList.tsx` | 同上（神社仏閣） |
| `src/components/common/ComingSoon.tsx` | title / description（既定文言含む）・トップへ戻るリンク |
| `src/components/common/ShareButtons.tsx` | マウント後に X / LINE のシェア URL（`encodeURIComponent` 済み）、別タブ・`noopener` |

`NearbyMap` / `RouteMap` は Google Maps API 依存が重くモックコストが高いため今回のスコープ外。

## 動作確認

- ✅ `pnpm test` — 278 tests / 45 files すべて green（+21）
- ✅ `pnpm lint` — クリーン
- ✅ 全体カバレッジ 56.6% → 58.4%（statements）。対象 7 ファイルはいずれも高カバレッジに到達

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU7UoCLJk6WKjBiKPpfMqE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Coming Soon, sharing buttons, navigation, footer, temple lists, and green tea lists.
  * Added validation for empty and populated list states, links, active navigation states, accessibility attributes, and metadata behavior.
  * Verified social sharing links, default content, inherited images, and fallback metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->