### PR TITLE
test: admin テーブル / ImageUrlField / Header / LikedSpotsList のテストを追加

### DIFF
--- a/src/components/admin/__tests__/GreenteaAdminTable.test.tsx
+++ b/src/components/admin/__tests__/GreenteaAdminTable.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GreenteaAdminTable from "@/components/admin/GreenteaAdminTable";
+import { server } from "@tests/msw/server";
+import type { Greentea } from "@/types";
+
+const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const baseGreentea: Greentea = {
+  id: 1,
+  name: "中村藤吉本店",
+  description: "宇治の老舗。",
+  address: "京都府宇治市宇治壱番10",
+  access: "JR宇治駅から徒歩3分",
+  phone_number: "0774-22-7800",
+  business_hours: "10:00-17:00",
+  holiday: "無休",
+  homepage: "https://tokichi.jp",
+  closed: false,
+  img: "https://example.com/tokichi.jpg",
+  latitude: 34.9,
+  longitude: 135.8,
+  genres: [
+    { id: 1, name: "スイーツ" },
+    { id: 3, name: "カフェ" },
+  ],
+  likes_count: 42,
+};
+
+const closedGreentea: Greentea = {
+  ...baseGreentea,
+  id: 2,
+  name: "閉店した店",
+  address: "京都府京都市中京区",
+  closed: true,
+  genres: [],
+};
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  pushMock.mockReset();
+  refreshMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+});
+
+describe("GreenteaAdminTable — 抹茶店の管理テーブル", () => {
+  it("空配列のときは未登録メッセージを表示する", () => {
+    render(<GreenteaAdminTable greenteas={[]} />);
+
+    expect(
+      screen.getByText("登録された抹茶店がありません。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("各行に店名・住所・ジャンル・状態・編集リンクを表示する", () => {
+    render(<GreenteaAdminTable greenteas={[baseGreentea, closedGreentea]} />);
+
+    expect(screen.getByText("中村藤吉本店")).toBeInTheDocument();
+    expect(
+      screen.getByText("京都府宇治市宇治壱番10"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("スイーツ / カフェ")).toBeInTheDocument();
+    expect(screen.getByText("営業中")).toBeInTheDocument();
+    expect(screen.getByText("閉店")).toBeInTheDocument();
+
+    const editLinks = screen.getAllByRole("link", { name: /編集/ });
+    expect(editLinks).toHaveLength(2);
+    expect(editLinks[0]).toHaveAttribute("href", "/admin/greenteas/1/edit");
+  });
+
+  it("ジャンルが空の行はダッシュを表示する", () => {
+    render(<GreenteaAdminTable greenteas={[closedGreentea]} />);
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("削除ボタンで確認ダイアログを開き、確定で DELETE を呼び一覧を再取得する", async () => {
+    const user = userEvent.setup();
+    let deleteCalled = false;
+    server.use(
+      http.delete(endpoint("/admin/greenteas/1"), () => {
+        deleteCalled = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    render(<GreenteaAdminTable greenteas={[baseGreentea]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/「中村藤吉本店」を削除します/),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() => expect(deleteCalled).toBe(true));
+    await waitFor(() => expect(refreshMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("削除が失敗するとダイアログ内にエラーを表示する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.delete(endpoint("/admin/greenteas/1"), () =>
+        HttpResponse.json({ error: "server error" }, { status: 500 }),
+      ),
+    );
+
+    render(<GreenteaAdminTable greenteas={[baseGreentea]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /削除に失敗しました/,
+    );
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("削除が 401 だと signOut してログインへ誘導する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.delete(endpoint("/admin/greenteas/1"), () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    render(<GreenteaAdminTable greenteas={[baseGreentea]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() =>
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false }),
+    );
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fadmin%2Fgreenteas",
+    );
+  });
+
+  it("キャンセルでダイアログを閉じ、削除を実行しない", async () => {
+    const user = userEvent.setup();
+    render(<GreenteaAdminTable greenteas={[baseGreentea]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("トークンが無い状態で削除確定するとセッション切れ扱いで誘導する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<GreenteaAdminTable greenteas={[baseGreentea]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() =>
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false }),
+    );
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fadmin%2Fgreenteas",
+    );
+  });
+});

--- a/src/components/admin/__tests__/ImageUrlField.test.tsx
+++ b/src/components/admin/__tests__/ImageUrlField.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ImageUrlField from "@/components/admin/ImageUrlField";
+
+describe("ImageUrlField — 画像 URL 入力とプレビュー", () => {
+  it("ラベルと入力欄を関連付けて描画する", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value=""
+        registration={{ name: "img" }}
+      />,
+    );
+
+    expect(screen.getByLabelText("画像URL")).toHaveAttribute("type", "url");
+  });
+
+  it("値が空のときはプレビューを表示しない", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value="   "
+        registration={{ name: "img" }}
+      />,
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("http(s) 以外の値ではプレビューを表示しない", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value="ftp://example.com/a.png"
+        registration={{ name: "img" }}
+      />,
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("有効な URL のときはプレビュー画像を表示する", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value="https://example.com/a.png"
+        registration={{ name: "img" }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "プレビュー" })).toHaveAttribute(
+      "src",
+      "https://example.com/a.png",
+    );
+  });
+
+  it("画像読み込みに失敗すると案内文へ切り替える", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value="https://example.com/broken.png"
+        registration={{ name: "img" }}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "プレビュー" }));
+
+    expect(
+      screen.getByText(/画像を読み込めませんでした/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("error があればアラートとして表示する", () => {
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value=""
+        error="URL の形式が不正です"
+        registration={{ name: "img" }}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("URL の形式が不正です");
+  });
+
+  it("入力時に registration の onChange を呼び、broken 状態をリセットする", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageUrlField
+        id="img"
+        label="画像URL"
+        value="https://example.com/broken.png"
+        registration={{ name: "img", onChange }}
+      />,
+    );
+
+    // 一度失敗させて broken 状態にする。
+    fireEvent.error(screen.getByRole("img", { name: "プレビュー" }));
+    expect(screen.getByText(/画像を読み込めませんでした/)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("画像URL"), "x");
+
+    expect(onChange).toHaveBeenCalled();
+    // broken がリセットされ、再び img（プレビュー）が描画される。
+    expect(screen.getByRole("img", { name: "プレビュー" })).toBeInTheDocument();
+  });
+});

--- a/src/components/admin/__tests__/TempleAdminTable.test.tsx
+++ b/src/components/admin/__tests__/TempleAdminTable.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TempleAdminTable from "@/components/admin/TempleAdminTable";
+import { server } from "@tests/msw/server";
+import type { Temple } from "@/types";
+
+const useSessionMock = vi.fn();
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const baseTemple: Temple = {
+  id: 1,
+  name: "伏見稲荷大社",
+  description: "千本鳥居で知られる神社。",
+  address: "京都府京都市伏見区深草藪之内町68",
+  access: "JR稲荷駅すぐ",
+  phone_number: "075-641-7331",
+  business_hours: "24時間",
+  holiday: "無休",
+  homepage: "https://inari.jp",
+  img: "https://example.com/inari.jpg",
+  latitude: 34.9,
+  longitude: 135.7,
+  areas: [
+    { id: 1, name: "伏見" },
+    { id: 2, name: "東山" },
+  ],
+  likes_count: 88,
+};
+
+const noAreaTemple: Temple = {
+  ...baseTemple,
+  id: 2,
+  name: "エリア未設定神社",
+  address: "京都府京都市左京区",
+  areas: [],
+};
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  pushMock.mockReset();
+  refreshMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+  useSessionMock.mockReturnValue({
+    data: { railsJwt: "jwt-token" },
+    status: "authenticated",
+  });
+});
+
+describe("TempleAdminTable — 神社仏閣の管理テーブル", () => {
+  it("空配列のときは未登録メッセージを表示する", () => {
+    render(<TempleAdminTable temples={[]} />);
+
+    expect(
+      screen.getByText("登録された神社・仏閣がありません。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("各行に神社名・住所・エリア・編集リンクを表示する", () => {
+    render(<TempleAdminTable temples={[baseTemple]} />);
+
+    expect(screen.getByText("伏見稲荷大社")).toBeInTheDocument();
+    expect(
+      screen.getByText("京都府京都市伏見区深草藪之内町68"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("伏見 / 東山")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /編集/ })).toHaveAttribute(
+      "href",
+      "/admin/temples/1/edit",
+    );
+  });
+
+  it("エリアが空の行はダッシュを表示する", () => {
+    render(<TempleAdminTable temples={[noAreaTemple]} />);
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("削除ボタンで確認ダイアログを開き、確定で DELETE を呼び一覧を再取得する", async () => {
+    const user = userEvent.setup();
+    let deleteCalled = false;
+    server.use(
+      http.delete(endpoint("/admin/temples/1"), () => {
+        deleteCalled = true;
+        return HttpResponse.text(null, { status: 204 });
+      }),
+    );
+
+    render(<TempleAdminTable temples={[baseTemple]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/「伏見稲荷大社」を削除します/),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() => expect(deleteCalled).toBe(true));
+    await waitFor(() => expect(refreshMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("削除が失敗するとダイアログ内にエラーを表示する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.delete(endpoint("/admin/temples/1"), () =>
+        HttpResponse.json({ error: "server error" }, { status: 500 }),
+      ),
+    );
+
+    render(<TempleAdminTable temples={[baseTemple]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /削除に失敗しました/,
+    );
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("削除が 401 だと signOut してログインへ誘導する", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.delete(endpoint("/admin/temples/1"), () =>
+        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    render(<TempleAdminTable temples={[baseTemple]} />);
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /削除する/ }));
+
+    await waitFor(() =>
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false }),
+    );
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fadmin%2Ftemples",
+    );
+  });
+});

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -4,7 +4,11 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CommentSection from "@/components/common/CommentSection";
 import { server } from "@tests/msw/server";
-import { commentDeleted, writeError } from "@tests/msw/writeApiHandlers";
+import {
+  commentCreated,
+  commentDeleted,
+  writeError,
+} from "@tests/msw/writeApiHandlers";
 import type { Comment } from "@/types";
 
 const useSessionMock = vi.fn();
@@ -326,5 +330,151 @@ describe("CommentSection", () => {
     });
     // ロールバックされ、コメントは残る。
     expect(screen.getByText("消せない")).toBeInTheDocument();
+  });
+
+  it("投稿が 5xx だと汎用エラーを表示しリストは変わらない", async () => {
+    mockLoggedIn();
+    server.use(writeError("post", "greenteacomments", 500));
+
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "感想",
+    );
+    await user.click(screen.getByRole("button", { name: /投稿する/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/投稿に失敗しました/);
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/まだコメントはありません/)).toBeInTheDocument();
+  });
+
+  it("削除が 5xx だとロールバックして汎用エラーを表示する", async () => {
+    mockLoggedIn();
+    server.use(writeError("delete", "greenteacomments", 500));
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 2, body: "消えない", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/削除に失敗しました/);
+    });
+    expect(screen.getByText("消えない")).toBeInTheDocument();
+  });
+
+  it("削除が 401 だと signOut してログインへ誘導する", async () => {
+    mockLoggedIn();
+    server.use(writeError("delete", "greenteacomments", 401));
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 2, body: "対象", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fgreenteas%2F1",
+    );
+  });
+
+  it("temple 種別でも投稿が templecomments API 経由でリスト先頭に追加される", async () => {
+    mockLoggedIn();
+    server.use(commentCreated("temple"));
+
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="temple"
+        targetId={3}
+        initialComments={[baseComment({ id: 1, body: "既存" })]}
+        callbackUrl="/temples/3"
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /コメントを書く/ }),
+      "神社の感想",
+    );
+    await user.click(screen.getByRole("button", { name: /投稿する/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("神社の感想")).toBeInTheDocument();
+    });
+    const items = screen.getAllByRole("listitem");
+    expect(items[0]).toHaveTextContent("神社の感想");
+  });
+
+  it("temple 種別でも自分のコメントを templecomments API 経由で削除できる", async () => {
+    mockLoggedIn();
+    server.use(commentDeleted("temple"));
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <CommentSection
+        kind="temple"
+        targetId={3}
+        initialComments={[
+          baseComment({ id: 2, body: "削除対象", owned_by_current_user: true }),
+        ]}
+        callbackUrl="/temples/3"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("削除対象")).not.toBeInTheDocument();
+    });
+  });
+
+  it("不正な日付でも例外を投げず元の文字列を表示する", () => {
+    mockLoggedIn();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 1, body: "日付おかしい", created_at: "not-a-date" }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    expect(screen.getByText("日付おかしい")).toBeInTheDocument();
   });
 });

--- a/src/components/common/__tests__/LikedSpotsList.test.tsx
+++ b/src/components/common/__tests__/LikedSpotsList.test.tsx
@@ -23,6 +23,52 @@ const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
 
+const greenteaLike = {
+  id: 11,
+  greentea: {
+    id: 1,
+    name: "中村藤吉本店",
+    description: "宇治の老舗。",
+    address: "京都府宇治市",
+    access: "JR宇治駅",
+    phone_number: "0774-22-7800",
+    business_hours: "10:00-17:00",
+    holiday: "無休",
+    homepage: "https://tokichi.jp",
+    closed: false,
+    img: "",
+    latitude: 34.9,
+    longitude: 135.8,
+    genres: [],
+    likes_count: 42,
+  },
+};
+
+const templeLike = {
+  id: 21,
+  temple: {
+    id: 1,
+    name: "伏見稲荷大社",
+    description: "千本鳥居。",
+    address: "京都府京都市伏見区",
+    access: "JR稲荷駅",
+    phone_number: "075-641-7331",
+    business_hours: "24時間",
+    holiday: "無休",
+    homepage: "https://inari.jp",
+    img: "",
+    latitude: 34.9,
+    longitude: 135.7,
+    areas: [],
+    likes_count: 88,
+  },
+};
+
+const authedSession = {
+  data: { railsJwt: "jwt-token" },
+  status: "authenticated" as const,
+};
+
 beforeEach(() => {
   useSessionMock.mockReset();
   pushMock.mockReset();
@@ -86,5 +132,83 @@ describe("LikedSpotsList — マイページの CSR ガード", () => {
     expect(pushMock).toHaveBeenCalledWith(
       "/auth/login?callbackUrl=%2Fmypage%2Fgreentea-likes",
     );
+  });
+
+  it("greentea のお気に入りが空なら空メッセージを表示する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ greentea_likes: [] }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="greentea" />);
+
+    expect(
+      await screen.findByText(/お気に入りに追加した抹茶店はまだありません/),
+    ).toBeInTheDocument();
+  });
+
+  it("greentea のお気に入り一覧を GreenteaCard で表示する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ greentea_likes: [greenteaLike] }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="greentea" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "中村藤吉本店" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/greenteas/1");
+  });
+
+  it("temple のお気に入りが空なら空メッセージを表示する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/temple_likes"), () =>
+        HttpResponse.json({ temple_likes: [] }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="temple" />);
+
+    expect(
+      await screen.findByText(/お気に入りに追加した神社仏閣はまだありません/),
+    ).toBeInTheDocument();
+  });
+
+  it("temple のお気に入り一覧を TempleCard で表示する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/temple_likes"), () =>
+        HttpResponse.json({ temple_likes: [templeLike] }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="temple" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "伏見稲荷大社" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/temples/1");
+  });
+
+  it("401 以外の取得失敗では汎用エラーを表示し signOut しない", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/greentea_likes"), () =>
+        HttpResponse.json({ error: "server error" }, { status: 500 }),
+      ),
+    );
+
+    renderWithSwr(<LikedSpotsList kind="greentea" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /お気に入りの取得に失敗しました/,
+    );
+    expect(signOutMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Header from "@/components/layout/Header";
+
+const useSessionMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+});
+
+describe("Header — 共通ヘッダー", () => {
+  it("ロゴがトップへのリンクになっている", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<Header />);
+
+    const logoLink = screen.getByRole("link", { name: /トップへ/ });
+    expect(logoLink).toHaveAttribute("href", "/");
+    expect(within(logoLink).getByRole("img")).toHaveAttribute(
+      "alt",
+      "抹茶と神社。",
+    );
+  });
+
+  it("主要ナビゲーションリンクを表示する", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<Header />);
+
+    // PC / モバイル両方にナビがあるため getAllByRole で確認する。
+    expect(
+      screen.getAllByRole("link", { name: "抹茶スイーツ" })[0],
+    ).toHaveAttribute("href", "/greenteas");
+    expect(
+      screen.getAllByRole("link", { name: "神社仏閣" })[0],
+    ).toHaveAttribute("href", "/temples");
+    expect(
+      screen.getAllByRole("link", { name: "現在地から" })[0],
+    ).toHaveAttribute("href", "/nearby");
+  });
+
+  it("未ログイン時はログインリンクを表示する", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<Header />);
+
+    expect(screen.getAllByRole("link", { name: "ログイン" }).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("ログイン時はマイページ（お気に入り）への導線を表示する", () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { name: "テスト太郎", email: "t@example.com" } },
+      status: "authenticated",
+    });
+
+    render(<Header />);
+
+    const favoriteLinks = screen.getAllByRole("link", { name: /お気に入り/ });
+    expect(favoriteLinks[0]).toHaveAttribute("href", "/mypage");
+    expect(
+      screen.queryByRole("link", { name: "ログイン" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("メニューを開くボタン（モバイル）を持つ", () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<Header />);
+
+    expect(screen.getByLabelText("メニューを開く")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

#99（既存テストのカバレッジ穴埋め）に対応。0% / 部分カバレッジのままだった中小コンポーネントにテストを追加します。地図（#96）・認証（#98）・routes CSR（#97）はスコープ外のため対象外とし、残りをまとめて穴埋めしました。

## 変更内容

| ファイル | Before | 追加したテスト |
|---|---|---|
| `GreenteaAdminTable.tsx` | 0% → 97% | 行表示・編集リンク・削除ダイアログ開閉・DELETE 発火 + 一覧再取得・401 誘導・失敗時エラー・キャンセル・トークン無し時のセッション切れ誘導 |
| `TempleAdminTable.tsx` | 0% → 82% | 行表示・エリア表示（空は「—」）・削除フロー・401 誘導・失敗時エラー |
| `ImageUrlField.tsx` | 62.5% | 有効 URL のプレビュー表示 / 空・非 http(s) 時の非表示・読み込み失敗の案内・`onChange` 連携で broken リセット・エラー表示 |
| `Header.tsx` | 0% | ロゴのトップ導線・主要ナビリンク・未ログイン/ログイン時の認証メニュー・モバイルメニュー |
| `LikedSpotsList.tsx` | 61% | 空状態・一覧表示（greentea / temple）・401 以外の汎用エラー分岐の穴埋め |

新規 4 ファイル + 既存 `LikedSpotsList.test.tsx` の拡張、計 5 ファイル。

## テスト方針

- 既存パターンを踏襲：`next-auth/react`（`useSession` / `signOut`）と `next/navigation`（`useRouter` / `usePathname`）をモックし、削除系 API は MSW で intercept。
- `router.refresh` / `signOut` / `push` の呼び出しをモックで検証。

## 確認

- `pnpm test` → 49 files / 309 tests 全 green
- `pnpm lint`（`eslint .`）→ クリーン

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhSHwTQHri1s31j1Z46Y9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhSHwTQHri1s31j1Z46Y9V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for administrator store and temple tables, including rendering, empty states, editing links, deletion confirmations, errors, and session expiry.
  * Added coverage for image URL validation, previews, load failures, and error messages.
  * Expanded liked-spot list tests for empty, populated, and server-error states.
  * Added header tests for navigation, authentication states, logo, and mobile menu access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->