### PR TITLE
test: 地図コンポーネント（NearbyMap / RouteMap）のテストを追加 (#96)

### DIFF
--- a/src/components/map/__tests__/NearbyMap.test.tsx
+++ b/src/components/map/__tests__/NearbyMap.test.tsx
@@ -71,7 +71,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  vi.restoreAllMocks();
+  // このファイルは vi.spyOn を使わず vi.fn() のみのため restoreAllMocks は無効。
+  // vi.fn の呼び出し履歴をクリアして次テストへ持ち越さない。
+  vi.clearAllMocks();
 });
 
 describe("NearbyMap", () => {

--- a/src/components/map/__tests__/NearbyMap.test.tsx
+++ b/src/components/map/__tests__/NearbyMap.test.tsx
@@ -1,0 +1,320 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import NearbyMap from "@/components/map/NearbyMap";
+import type { NearbyResponse } from "@/types";
+import { apiUrl } from "@tests/msw/writeApiHandlers";
+import { server } from "@tests/msw/server";
+import {
+  clearGeolocation,
+  installGeolocation,
+  permissionDeniedError,
+  positionUnavailableError,
+  rejectWith,
+  resolveWith,
+} from "@tests/mocks/geolocation";
+import { mapInstance, resetGoogleMapsMock } from "@tests/mocks/googleMaps";
+
+vi.mock("@vis.gl/react-google-maps", () => import("@tests/mocks/googleMaps"));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// 京都圏内 / 圏外の座標。
+const KYOTO_POINT = { latitude: 35.02, longitude: 135.77 };
+const OUTSIDE_POINT = { latitude: 35.68, longitude: 139.76 }; // 東京
+
+const nearbyData: NearbyResponse = {
+  greenteas: [
+    {
+      id: 1,
+      name: "一保堂茶舗",
+      latitude: 35.013,
+      longitude: 135.767,
+      distance_meters: 320,
+    },
+  ],
+  temples: [
+    {
+      id: 2,
+      name: "八坂神社",
+      latitude: 35.0036,
+      longitude: 135.7786,
+      distance_meters: 1200,
+    },
+  ],
+};
+
+const emptyData: NearbyResponse = { greenteas: [], temples: [] };
+
+function nearbyHandler(data: NearbyResponse) {
+  return http.get(apiUrl("/nearby"), () => HttpResponse.json(data));
+}
+
+beforeEach(() => {
+  resetGoogleMapsMock();
+  vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", "test-key");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("NearbyMap", () => {
+  it("API キー未設定なら設定エラーを表示し、地図も現在地取得も行わない", () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", "");
+    const { getCurrentPosition } = installGeolocation();
+
+    render(<NearbyMap />);
+
+    expect(
+      screen.getByText(/Google Maps の API キーが設定されていません/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("map")).not.toBeInTheDocument();
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("Geolocation 非対応ブラウザでは非対応メッセージを出す", async () => {
+    clearGeolocation();
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText(/お使いのブラウザは位置情報に対応していません/),
+    ).toBeInTheDocument();
+  });
+
+  it("位置情報が拒否されると案内を出し、再試行できる", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    rejectWith(getCurrentPosition, permissionDeniedError());
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText(/位置情報の利用が拒否されました/),
+    ).toBeInTheDocument();
+    // 地図は京都市中心部で描画される。
+    expect(screen.getByTestId("map")).toHaveAttribute(
+      "data-center",
+      JSON.stringify({ lat: 35.0116, lng: 135.7681 }),
+    );
+    // 半径ボタンは位置未取得なので無効。
+    expect(screen.getByRole("button", { name: "1.5 km" })).toBeDisabled();
+
+    // 再試行で今度は成功させる。
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(nearbyHandler(nearbyData));
+    await userEvent.click(
+      screen.getByRole("button", { name: "もう一度試す" }),
+    );
+
+    expect(await screen.findByText("一保堂茶舗")).toBeInTheDocument();
+  });
+
+  it("現在地取得の失敗（拒否以外）ではエラー案内を出す", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    rejectWith(getCurrentPosition, positionUnavailableError());
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText(/現在地を取得できませんでした/),
+    ).toBeInTheDocument();
+  });
+
+  it("京都圏内で現在地取得に成功すると近隣スポットを取得・表示する", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(nearbyHandler(nearbyData));
+
+    render(<NearbyMap />);
+
+    // 一覧に抹茶店・神社が並ぶ。
+    expect(await screen.findByText("一保堂茶舗")).toBeInTheDocument();
+    expect(screen.getByText("八坂神社")).toBeInTheDocument();
+
+    // 件数表示（各カラム 1 件）。
+    const counts = screen.getAllByText("1 件");
+    expect(counts).toHaveLength(2);
+
+    // 距離フォーマット（m / km）。
+    expect(screen.getByText("320m")).toBeInTheDocument();
+    expect(screen.getByText("1.2km")).toBeInTheDocument();
+
+    // marker: 現在地 + スポット 2 件。
+    await waitFor(() => {
+      expect(screen.getAllByTestId("advanced-marker").length).toBe(3);
+    });
+    expect(screen.getByTitle("現在地")).toBeInTheDocument();
+
+    // 圏内なので京都中心へ寄せる注意書きは出ない。
+    expect(
+      screen.queryByText(/現在地が京都府の外のようです/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("一覧のスポットを選ぶと InfoWindow を開き、地図をそこへ寄せる", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(nearbyHandler(nearbyData));
+
+    render(<NearbyMap />);
+    await screen.findByText("一保堂茶舗");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "一保堂茶舗 を地図で表示" }),
+    );
+
+    // InfoWindow が開き、詳細リンクを持つ。
+    const infoWindow = await screen.findByTestId("info-window");
+    expect(within(infoWindow).getByText("抹茶店")).toBeInTheDocument();
+    expect(within(infoWindow).getByRole("link", { name: /詳細を見る/ })).toHaveAttribute(
+      "href",
+      "/greenteas/1",
+    );
+    // 選択スポットの位置へ panTo。
+    expect(mapInstance.panTo).toHaveBeenCalledWith({
+      lat: 35.013,
+      lng: 135.767,
+    });
+
+    // 閉じると InfoWindow が消える。
+    await userEvent.click(
+      within(infoWindow).getByRole("button", {
+        name: "情報ウィンドウを閉じる",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("info-window")).not.toBeInTheDocument();
+    });
+  });
+
+  it("地図上の marker をクリックしても InfoWindow を開く", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(nearbyHandler(nearbyData));
+
+    render(<NearbyMap />);
+    await screen.findByText("一保堂茶舗");
+
+    // 神社 marker（title で特定）をクリック。
+    await userEvent.click(screen.getByTitle("八坂神社"));
+
+    const infoWindow = await screen.findByTestId("info-window");
+    expect(within(infoWindow).getByText("神社仏閣")).toBeInTheDocument();
+    expect(
+      within(infoWindow).getByRole("link", { name: /詳細を見る/ }),
+    ).toHaveAttribute("href", "/temples/2");
+  });
+
+  it("現在地取得中は取得中の案内を出す", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    // success/error を呼ばず requesting のまま留める。
+    getCurrentPosition.mockImplementation(() => {});
+
+    render(<NearbyMap />);
+
+    expect(await screen.findByText("現在地を取得中…")).toBeInTheDocument();
+  });
+
+  it("京都圏外の現在地は京都市中心部へ寄せ、その旨の案内を出す", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, OUTSIDE_POINT);
+    server.use(nearbyHandler(nearbyData));
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText(/現在地が京都府の外のようです/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/距離は京都市中心部からの目安です/),
+    ).toBeInTheDocument();
+    // origin は京都中心へ寄る（現在地ではなく京都市中心部マーカー）。
+    expect(screen.getByTitle("京都市中心部")).toBeInTheDocument();
+    expect(screen.getByTestId("map")).toHaveAttribute(
+      "data-center",
+      JSON.stringify({ lat: 35.0116, lng: 135.7681 }),
+    );
+  });
+
+  it("近隣スポットが 0 件のときは半径を広げる案内を出す", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(nearbyHandler(emptyData));
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText(/指定した範囲には登録されたスポットがありません/),
+    ).toBeInTheDocument();
+    // 各カラムに空メッセージ。
+    expect(
+      screen.getAllByText("該当するスポットはありません。"),
+    ).toHaveLength(2);
+  });
+
+  it("近隣スポット取得が失敗するとステータスに応じたエラー文を出す", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    server.use(
+      http.get(apiUrl("/nearby"), () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    render(<NearbyMap />);
+
+    expect(
+      await screen.findByText("近隣スポットの取得に失敗しました（500）。"),
+    ).toBeInTheDocument();
+  });
+
+  it("半径を変えると再取得し、選択中の半径が aria-pressed になる", async () => {
+    const { getCurrentPosition } = installGeolocation();
+    resolveWith(getCurrentPosition, KYOTO_POINT);
+    const requestedRadii: string[] = [];
+    server.use(
+      http.get(apiUrl("/nearby"), ({ request }) => {
+        const url = new URL(request.url);
+        requestedRadii.push(url.searchParams.get("radius") ?? "");
+        return HttpResponse.json(nearbyData);
+      }),
+    );
+
+    render(<NearbyMap />);
+    await screen.findByText("一保堂茶舗");
+
+    // 初期半径 1.5km で取得済み。
+    expect(requestedRadii).toContain("1.5");
+    expect(screen.getByRole("button", { name: "1.5 km" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // 2.0km へ変更 → 再取得。
+    await userEvent.click(screen.getByRole("button", { name: "2.0 km" }));
+
+    await waitFor(() => {
+      expect(requestedRadii).toContain("2");
+    });
+    expect(screen.getByRole("button", { name: "2.0 km" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/src/components/route/__tests__/RouteMap.test.tsx
+++ b/src/components/route/__tests__/RouteMap.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RouteMap from "@/components/route/RouteMap";
+import type { RouteSpot } from "@/types";
+import {
+  boundsInstances,
+  mapInstance,
+  polylineInstances,
+  resetGoogleMapsMock,
+} from "@tests/mocks/googleMaps";
+
+vi.mock("@vis.gl/react-google-maps", () => import("@tests/mocks/googleMaps"));
+
+function makeSpot(overrides: Partial<RouteSpot> = {}): RouteSpot {
+  return {
+    position: 1,
+    spot_type: "greentea",
+    transport: null,
+    id: 1,
+    name: "スポット",
+    address: "京都市",
+    access: "駅から徒歩5分",
+    latitude: 35.0,
+    longitude: 135.7,
+    img: "",
+    distance_to_next_meters: null,
+    route_distance_to_next_meters: null,
+    duration_to_next_seconds: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetGoogleMapsMock();
+  vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", "test-key");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("RouteMap", () => {
+  it("API キー未設定なら設定を促すメッセージを出す", () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", "");
+
+    render(<RouteMap spots={[makeSpot()]} />);
+
+    expect(
+      screen.getByText(/Google Maps の API キーが設定されていません/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("map")).not.toBeInTheDocument();
+  });
+
+  it("表示できるスポットが無いとき（空配列）は案内文を出す", () => {
+    render(<RouteMap spots={[]} />);
+
+    expect(
+      screen.getByText("地図に表示できるスポットがありません。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("map")).not.toBeInTheDocument();
+  });
+
+  it("緯度経度が 0 のスポット（削除済み）は除外され、全滅なら案内文を出す", () => {
+    render(
+      <RouteMap
+        spots={[makeSpot({ id: 1, latitude: 0, longitude: 0 })]}
+      />,
+    );
+
+    expect(
+      screen.getByText("地図に表示できるスポットがありません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("スポット 1 件では marker を出し、その位置に setCenter/setZoom する", () => {
+    render(
+      <RouteMap
+        spots={[makeSpot({ position: 1, latitude: 35.01, longitude: 135.76 })]}
+      />,
+    );
+
+    const markers = screen.getAllByTestId("advanced-marker");
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toHaveAttribute("title", "スポット");
+
+    // 1 件のときは fitBounds ではなく setCenter + setZoom。
+    expect(mapInstance.setCenter).toHaveBeenCalledWith({
+      lat: 35.01,
+      lng: 135.76,
+    });
+    expect(mapInstance.setZoom).toHaveBeenCalledWith(15);
+    // 1 件では経路線は引かない。
+    expect(polylineInstances).toHaveLength(0);
+    expect(mapInstance.fitBounds).not.toHaveBeenCalled();
+  });
+
+  it("複数スポットを position 順に marker 表示し、順序どおりに経路線を引く", () => {
+    const spots = [
+      makeSpot({
+        position: 1,
+        id: 10,
+        spot_type: "greentea",
+        name: "一保堂",
+        latitude: 35.01,
+        longitude: 135.76,
+      }),
+      makeSpot({
+        position: 2,
+        id: 20,
+        spot_type: "temple",
+        name: "八坂神社",
+        latitude: 35.02,
+        longitude: 135.77,
+      }),
+      makeSpot({
+        position: 3,
+        id: 30,
+        spot_type: "greentea",
+        name: "茶寮都路里",
+        latitude: 35.03,
+        longitude: 135.78,
+      }),
+    ];
+
+    render(<RouteMap spots={spots} />);
+
+    // 順序バッジ（position 番号）が 1→2→3 で並ぶ。
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+
+    const markers = screen.getAllByTestId("advanced-marker");
+    expect(markers.map((m) => m.getAttribute("title"))).toEqual([
+      "一保堂",
+      "八坂神社",
+      "茶寮都路里",
+    ]);
+
+    // 経路線が 1 本引かれ、path はスポット順のまま。
+    expect(polylineInstances).toHaveLength(1);
+    expect(polylineInstances[0].options.path).toEqual([
+      { lat: 35.01, lng: 135.76 },
+      { lat: 35.02, lng: 135.77 },
+      { lat: 35.03, lng: 135.78 },
+    ]);
+    expect(polylineInstances[0].setMap).toHaveBeenCalledWith(mapInstance);
+
+    // fitBounds は全スポットを extend した bounds で呼ばれる。
+    expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+    expect(boundsInstances).toHaveLength(1);
+    expect(boundsInstances[0].points).toEqual([
+      { lat: 35.01, lng: 135.76 },
+      { lat: 35.02, lng: 135.77 },
+      { lat: 35.03, lng: 135.78 },
+    ]);
+  });
+
+  it("座標が無いスポットは経路・marker から除外される", () => {
+    const spots = [
+      makeSpot({ position: 1, id: 1, latitude: 35.01, longitude: 135.76 }),
+      makeSpot({ position: 2, id: 2, latitude: 0, longitude: 0 }),
+      makeSpot({ position: 3, id: 3, latitude: 35.03, longitude: 135.78 }),
+    ];
+
+    render(<RouteMap spots={spots} />);
+
+    const markers = screen.getAllByTestId("advanced-marker");
+    expect(markers).toHaveLength(2);
+    // 経路 path も有効な 2 点のみ。
+    expect(polylineInstances[0].options.path).toEqual([
+      { lat: 35.01, lng: 135.76 },
+      { lat: 35.03, lng: 135.78 },
+    ]);
+  });
+
+  it("アンマウント時に経路線を破棄する（setMap(null)）", () => {
+    const spots = [
+      makeSpot({ position: 1, id: 1, latitude: 35.01, longitude: 135.76 }),
+      makeSpot({ position: 2, id: 2, latitude: 35.02, longitude: 135.77 }),
+    ];
+
+    const { unmount } = render(<RouteMap spots={spots} />);
+    expect(polylineInstances).toHaveLength(1);
+
+    unmount();
+
+    expect(polylineInstances[0].setMap).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/tests/mocks/geolocation.ts
+++ b/tests/mocks/geolocation.ts
@@ -1,0 +1,86 @@
+// navigator.geolocation のテスト用モック。
+// NearbyMap は getCurrentPosition の成功/拒否/失敗で分岐するため、それぞれの
+// パスを再現できるヘルパーを提供する。jsdom は geolocation を実装しないので、
+// テスト側で明示的に install/clear する。
+import { vi } from "vitest";
+
+type SuccessCallback = (position: { coords: GeolocationCoordsLike }) => void;
+type ErrorCallback = (error: GeolocationErrorLike) => void;
+
+export type GeolocationCoordsLike = {
+  latitude: number;
+  longitude: number;
+};
+
+export type GeolocationErrorLike = {
+  code: number;
+  PERMISSION_DENIED: number;
+  POSITION_UNAVAILABLE: number;
+  TIMEOUT: number;
+  message: string;
+};
+
+// GeolocationPositionError の code 定数。
+export const GEO_ERROR = {
+  PERMISSION_DENIED: 1,
+  POSITION_UNAVAILABLE: 2,
+  TIMEOUT: 3,
+} as const;
+
+function makeError(code: number, message: string): GeolocationErrorLike {
+  return {
+    code,
+    PERMISSION_DENIED: GEO_ERROR.PERMISSION_DENIED,
+    POSITION_UNAVAILABLE: GEO_ERROR.POSITION_UNAVAILABLE,
+    TIMEOUT: GEO_ERROR.TIMEOUT,
+    message,
+  };
+}
+
+export const permissionDeniedError = () =>
+  makeError(GEO_ERROR.PERMISSION_DENIED, "User denied Geolocation");
+
+export const positionUnavailableError = () =>
+  makeError(GEO_ERROR.POSITION_UNAVAILABLE, "Position unavailable");
+
+/** navigator.geolocation を差し替え、getCurrentPosition の spy を返す。 */
+export function installGeolocation() {
+  const getCurrentPosition =
+    vi.fn<
+      (success: SuccessCallback, error?: ErrorCallback, options?: unknown) => void
+    >();
+  Object.defineProperty(navigator, "geolocation", {
+    value: { getCurrentPosition },
+    configurable: true,
+    writable: true,
+  });
+  return { getCurrentPosition };
+}
+
+/**
+ * navigator から geolocation を取り除く（非対応ブラウザの再現）。
+ * `"geolocation" in navigator` が false になるよう own property を削除する。
+ */
+export function clearGeolocation() {
+  delete (navigator as { geolocation?: unknown }).geolocation;
+}
+
+/** 現在地取得に成功するよう getCurrentPosition を設定する。 */
+export function resolveWith(
+  getCurrentPosition: ReturnType<typeof installGeolocation>["getCurrentPosition"],
+  coords: GeolocationCoordsLike,
+) {
+  getCurrentPosition.mockImplementation((success) => {
+    success({ coords });
+  });
+}
+
+/** 現在地取得が失敗するよう getCurrentPosition を設定する。 */
+export function rejectWith(
+  getCurrentPosition: ReturnType<typeof installGeolocation>["getCurrentPosition"],
+  error: GeolocationErrorLike,
+) {
+  getCurrentPosition.mockImplementation((_success, onError) => {
+    onError?.(error);
+  });
+}

--- a/tests/mocks/googleMaps.tsx
+++ b/tests/mocks/googleMaps.tsx
@@ -1,0 +1,174 @@
+// @vis.gl/react-google-maps のテスト用モック。
+//
+// 実物は Google Maps JS API のロード（外部スクリプト / API キー）を前提とするため
+// jsdom では動かない。地図系コンポーネント（NearbyMap / RouteMap）のテストで
+// 共通利用できるよう、必要な named export を軽量な React 要素へ差し替える。
+//
+// 使い方（テスト側）:
+//   vi.mock("@vis.gl/react-google-maps", () => import("@tests/mocks/googleMaps"));
+//   import { mapInstance, resetGoogleMapsMock } from "@tests/mocks/googleMaps";
+// vi.mock の factory が dynamic import で本モジュールを返すため、テストが直接
+// import する mapInstance などの spy と同一インスタンスを共有できる。
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+export type LatLng = { lat: number; lng: number };
+
+// useMap() が返す地図インスタンス。pan/zoom/fitBounds の呼び出しを spy で追える。
+export const mapInstance = {
+  panTo: vi.fn<(pos: LatLng) => void>(),
+  setCenter: vi.fn<(pos: LatLng) => void>(),
+  setZoom: vi.fn<(zoom: number) => void>(),
+  fitBounds: vi.fn<(bounds: MockLatLngBounds, padding?: number) => void>(),
+};
+
+export type PolylineOptions = {
+  path: LatLng[];
+  geodesic?: boolean;
+  strokeColor?: string;
+  strokeOpacity?: number;
+  strokeWeight?: number;
+};
+
+// new maps.Polyline(...) で生成されたインスタンスを記録し、経路の順序や
+// setMap(map)/setMap(null)（マウント/アンマウント）を検証できるようにする。
+export const polylineInstances: MockPolyline[] = [];
+
+export class MockPolyline {
+  options: PolylineOptions;
+  setMap = vi.fn<(map: unknown) => void>();
+  constructor(options: PolylineOptions) {
+    this.options = options;
+    polylineInstances.push(this);
+  }
+}
+
+// new core.LatLngBounds() で生成された bounds を記録。extend で積まれた座標を検証する。
+export const boundsInstances: MockLatLngBounds[] = [];
+
+export class MockLatLngBounds {
+  points: LatLng[] = [];
+  constructor() {
+    boundsInstances.push(this);
+  }
+  extend = vi.fn((point: LatLng) => {
+    this.points.push(point);
+    return this;
+  });
+}
+
+const mapsLibrary = { Polyline: MockPolyline };
+const coreLibrary = { LatLngBounds: MockLatLngBounds };
+
+/** テスト間で spy 呼び出し履歴と生成インスタンスをリセットする。 */
+export function resetGoogleMapsMock() {
+  mapInstance.panTo.mockReset();
+  mapInstance.setCenter.mockReset();
+  mapInstance.setZoom.mockReset();
+  mapInstance.fitBounds.mockReset();
+  polylineInstances.length = 0;
+  boundsInstances.length = 0;
+}
+
+export function APIProvider({ children }: { children?: ReactNode }) {
+  return <div data-testid="api-provider">{children}</div>;
+}
+
+type MapProps = {
+  children?: ReactNode;
+  mapId?: string;
+  defaultCenter?: LatLng;
+  defaultZoom?: number;
+} & Record<string, unknown>;
+
+export function Map({ children, mapId, defaultCenter, defaultZoom }: MapProps) {
+  return (
+    <div
+      data-testid="map"
+      data-map-id={mapId}
+      data-center={defaultCenter ? JSON.stringify(defaultCenter) : undefined}
+      data-zoom={defaultZoom}
+    >
+      {children}
+    </div>
+  );
+}
+
+type AdvancedMarkerProps = {
+  children?: ReactNode;
+  position?: LatLng;
+  title?: string;
+  onClick?: () => void;
+};
+
+export function AdvancedMarker({
+  children,
+  position,
+  title,
+  onClick,
+}: AdvancedMarkerProps) {
+  return (
+    <div
+      data-testid="advanced-marker"
+      data-position={position ? JSON.stringify(position) : undefined}
+      title={title}
+      role={onClick ? "button" : undefined}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
+}
+
+type PinProps = {
+  background?: string;
+  borderColor?: string;
+  glyphColor?: string;
+};
+
+export function Pin({ background, borderColor, glyphColor }: PinProps) {
+  return (
+    <div
+      data-testid="pin"
+      data-background={background}
+      data-border-color={borderColor}
+      data-glyph-color={glyphColor}
+    />
+  );
+}
+
+type InfoWindowProps = {
+  children?: ReactNode;
+  position?: LatLng;
+  onCloseClick?: () => void;
+};
+
+export function InfoWindow({
+  children,
+  position,
+  onCloseClick,
+}: InfoWindowProps) {
+  return (
+    <div
+      data-testid="info-window"
+      data-position={position ? JSON.stringify(position) : undefined}
+    >
+      <button
+        type="button"
+        aria-label="情報ウィンドウを閉じる"
+        onClick={onCloseClick}
+      />
+      {children}
+    </div>
+  );
+}
+
+export function useMap() {
+  return mapInstance;
+}
+
+export function useMapsLibrary(name: string) {
+  if (name === "maps") return mapsLibrary;
+  if (name === "core") return coreLibrary;
+  return null;
+}


### PR DESCRIPTION
## 概要

Google Maps（`@vis.gl/react-google-maps`）依存でカバレッジ 0% だった地図コンポーネント（`NearbyMap` / `RouteMap`）にテストを追加します。あわせて、他の地図系テストからも再利用できる Google Maps / Geolocation のモック基盤を `tests/mocks/` に整備しました。

Closes #96

## 変更内容

### モック基盤（再利用可能・`tests/`）
- **`tests/mocks/googleMaps.tsx`** — `@vis.gl/react-google-maps` のテスト用モック
  - `APIProvider` / `Map` / `AdvancedMarker` / `Pin` / `InfoWindow` / `useMap` / `useMapsLibrary` を軽量な React 要素へ差し替え
  - `useMap()` が返す地図インスタンスの `panTo` / `setCenter` / `setZoom` / `fitBounds`、および `Polyline` / `LatLngBounds` の生成を spy で検証できる形に
  - `vi.mock("@vis.gl/react-google-maps", () => import("@tests/mocks/googleMaps"))` で差し替え、テストは同一モジュールの spy を共有
- **`tests/mocks/geolocation.ts`** — `navigator.geolocation` のモックヘルパー
  - 許可 / 拒否（`PERMISSION_DENIED`）/ 失敗（`POSITION_UNAVAILABLE`）/ 非対応ブラウザ の各パスを再現

### NearbyMap（`src/components/map/__tests__/NearbyMap.test.tsx`）
- API キー未設定時の設定エラー、Geolocation 非対応、位置取得の拒否/失敗と再試行
- 京都圏内で取得成功 → 近隣スポットの取得・一覧表示・件数・距離フォーマット・マーカー数
- 京都圏外 → 京都市中心部へフォールバックし案内文を表示
- 空データ時の案内、取得失敗（500）時のステータス別エラー文
- 半径切替による再取得（`aria-pressed`）、一覧/マーカーからの選択で InfoWindow 開閉・地図追従

### RouteMap（`src/components/route/__tests__/RouteMap.test.tsx`）
- API キー未設定 / 表示可能スポット 0 件の案内
- スポット 1 件（`setCenter` + `setZoom`、経路線なし）と複数件（`position` 順のマーカー・経路線・`fitBounds`）
- 座標なし（削除済み lat/lng = 0）スポットの除外、アンマウント時の経路線破棄

## カバレッジ

| ファイル | Before | After（Lines） |
|---------|--------|----------------|
| `NearbyMap.tsx` | 0% | 97% |
| `RouteMap.tsx` | 0% | 100% |

## 確認

- `pnpm test` … 全 green（57 files / 412 tests）
- `pnpm lint` … クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsTvtDMrczpALCjsxMhsAS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for nearby-location maps, including geolocation states, radius changes, empty results, API errors, markers, and location details.
  * Added route-map coverage for valid and invalid locations, markers, route lines, map positioning, and cleanup behavior.
  * Added reusable test support for simulating geolocation and Google Maps interactions without external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->