### PR TITLE
docs: README/migration-plan の npm 表記を pnpm に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@
 Rails API を起動しなくても、インメモリのモック実装でフロント単独で動かせます。
 
 ```bash
-npm install
+pnpm install
 
 # 環境変数を用意（既定で NEXT_PUBLIC_USE_MOCK=true）
 cp .env.example .env.local
 
-npm run dev
+pnpm dev
 ```
 
 [http://localhost:3000](http://localhost:3000) を開くと、`src/lib/api/mock` が応答する状態で UI を確認できます。
@@ -51,7 +51,7 @@ npm run dev
 - **`true`** … `src/lib/api/mock` のインメモリ実装が応答する（Rails 未起動で開発可）
 - **`false`** … `NEXT_PUBLIC_API_URL` に対して実 fetch を行う
 
-`NEXT_PUBLIC_*` はビルド時に埋め込まれるため、切り替えたら `npm run dev` を再起動してください。
+`NEXT_PUBLIC_*` はビルド時に埋め込まれるため、切り替えたら `pnpm dev` を再起動してください。
 
 ## 環境変数
 
@@ -71,14 +71,14 @@ npm run dev
 
 | コマンド | 内容 |
 |----------|------|
-| `npm run dev` | 開発サーバ起動（:3000） |
-| `npm run build` | 本番ビルド |
-| `npm run start` | ビルド済みアプリの起動 |
-| `npm run lint` | ESLint |
-| `npm test` | Vitest（ユニット / 統合） |
-| `npm run test:watch` | Vitest ウォッチモード |
-| `npm run test:coverage` | カバレッジ付きで実行（`coverage/` に出力） |
-| `npm run test:e2e` | Playwright E2E（モックモードで起動） |
+| `pnpm dev` | 開発サーバ起動（:3000） |
+| `pnpm build` | 本番ビルド |
+| `pnpm start` | ビルド済みアプリの起動 |
+| `pnpm lint` | ESLint |
+| `pnpm test` | Vitest（ユニット / 統合） |
+| `pnpm test:watch` | Vitest ウォッチモード |
+| `pnpm test:coverage` | カバレッジ付きで実行（`coverage/` に出力） |
+| `pnpm test:e2e` | Playwright E2E（モックモードで起動） |
 
 ## ディレクトリ構成（抜粋）
 

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -317,26 +317,26 @@ gem 'jsonapi-serializer'  # または gem 'active_model_serializers'
 
 ```bash
 # API通信
-npm install axios swr
+pnpm add axios swr
 # または
-npm install @tanstack/react-query
+pnpm add @tanstack/react-query
 
 # 地図
-npm install @react-google-maps/api
+pnpm add @react-google-maps/api
 # または
-npm install @vis.gl/react-google-maps
+pnpm add @vis.gl/react-google-maps
 
 # UI コンポーネント
-npm install daisyui@latest  # Tailwind CSS プラグイン（元のデザイン踏襲）
+pnpm add daisyui@latest  # Tailwind CSS プラグイン（元のデザイン踏襲）
 
 # 認証
-npm install next-auth  # OAuth フロー管理
+pnpm add next-auth  # OAuth フロー管理
 
 # アイコン
-npm install react-icons
+pnpm add react-icons
 
 # フォーム
-npm install react-hook-form zod @hookform/resolvers
+pnpm add react-hook-form zod @hookform/resolvers
 ```
 
 ### 2-2. ディレクトリ構成


### PR DESCRIPTION
## 概要

`docs/deploy-checklist.md` を見ながらデプロイを進めるにあたり、パッケージマネージャの表記がドキュメント間で揺れていたため統一しました。

- `docs/deploy-checklist.md` はもともと pnpm 表記（`pnpm install --frozen-lockfile` 等）
- 一方で `README.md` と `docs/migration-plan.md` には npm 表記が残っていた
- リポジトリには `pnpm-lock.yaml` のみがコミットされており（`package-lock.json` は無し）、実態は pnpm 運用のため、npm 表記側を pnpm に合わせて修正

## 変更内容

- `README.md`: クイックスタート（`npm install` → `pnpm install`、`npm run dev` → `pnpm dev`）、スクリプト一覧の各コマンド（`npm run xxx` → `pnpm xxx`）を pnpm に変更
- `docs/migration-plan.md`: Phase 2 の追加パッケージ導入例（`npm install xxx` → `pnpm add xxx`）を pnpm に変更

## 動作確認

- ドキュメントのみの変更のため、ビルド/テストへの影響なし
- `grep` で `npm install|run|test|ci|build|exec` の残存表記が無いことを確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1FckJCYhvuwCingvsuvxg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, API switching, script examples, and migration instructions to use pnpm commands instead of npm.
  * Preserved existing package selections and alternative options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->