### PR TITLE
プロフィール編集機能をマイページに追加

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -93,6 +93,18 @@ export default function MyPage() {
             抹茶スイーツ店と神社仏閣を組み合わせて、自分だけの巡りコースを作成・保存できます。
           </p>
         </Link>
+        <Link
+          href="/mypage/profile"
+          className="border border-line-soft bg-paper px-6 py-7 transition-colors hover:bg-washi-bg sm:col-span-2"
+        >
+          <p className="font-sans-jp text-[10px] tracking-[0.3em] text-olive">
+            PROFILE
+          </p>
+          <p className="mt-3 font-mincho text-xl text-ink">プロフィール編集</p>
+          <p className="mt-3 font-serif-jp text-xs leading-[1.9] text-muted">
+            表示名を変更できます。
+          </p>
+        </Link>
       </div>
     </section>
   );

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { HiArrowLeft } from "react-icons/hi2";
+import Hairline from "@/components/brand/Hairline";
+import ProfileEditForm from "@/components/auth/ProfileEditForm";
+
+export const metadata: Metadata = {
+  title: "プロフィール編集",
+};
+
+export default function ProfileEditPage() {
+  return (
+    <section className="mx-auto w-full max-w-2xl px-6 py-16">
+      <div className="mb-6">
+        <Link
+          href="/mypage"
+          className="inline-flex items-center gap-2 font-sans-jp text-xs tracking-[0.15em] text-olive transition-colors hover:text-olive-dark"
+        >
+          <HiArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          マイページへ
+        </Link>
+      </div>
+
+      <p className="font-sans-jp text-[10px] font-medium tracking-[0.4em] text-olive">
+        マイページ / PROFILE
+      </p>
+      <h1 className="mt-3 font-mincho text-3xl font-semibold tracking-[0.05em] text-ink">
+        プロフィール編集
+      </h1>
+      <Hairline width={40} className="mt-5" />
+
+      <div className="mt-10">
+        <ProfileEditForm />
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/CommentModerationList.tsx
+++ b/src/components/admin/CommentModerationList.tsx
@@ -194,7 +194,7 @@ export default function CommentModerationList() {
                   </Link>
                 </td>
                 <td className="px-4 py-3 font-serif-jp text-xs text-muted">
-                  {comment.user.name}
+                  {comment.user?.name ?? "匿名ユーザー"}
                 </td>
                 <td className="px-4 py-3 font-serif-jp text-sm leading-[1.8] text-ink">
                   <span className="block max-w-md whitespace-pre-wrap break-words">
@@ -230,7 +230,7 @@ export default function CommentModerationList() {
         title="コメントを削除"
         message={
           target
-            ? `「${target.resource_name || `#${target.resource_id}`}」への ${target.user.name} さんのコメントを削除します。この操作は取り消せません。`
+            ? `「${target.resource_name || `#${target.resource_id}`}」への ${target.user?.name ?? "匿名ユーザー"} さんのコメントを削除します。この操作は取り消せません。`
             : ""
         }
         loading={deleting}

--- a/src/components/admin/__tests__/CommentModerationList.test.tsx
+++ b/src/components/admin/__tests__/CommentModerationList.test.tsx
@@ -167,6 +167,29 @@ describe("CommentModerationList — コメントモデレーション", () => {
     expect(listCalls).toBeGreaterThanOrEqual(2);
   });
 
+  it("投稿者が欠落したコメント（user: null）でもクラッシュせず「匿名ユーザー」と表示する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue({
+      data: { railsJwt: "jwt-token" },
+      status: "authenticated",
+    });
+    server.use(
+      http.get(endpoint("/admin/comments"), () =>
+        HttpResponse.json({
+          comments: [{ ...comments[0], user: null }],
+        }),
+      ),
+    );
+
+    renderWithSwr(<CommentModerationList />);
+
+    expect(await screen.findByText("匿名ユーザー")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /削除/ }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("匿名ユーザー さんのコメントを削除します");
+  });
+
   it("一覧取得が 401 だと signOut してログインへ誘導する", async () => {
     useSessionMock.mockReturnValue({
       data: { railsJwt: "jwt-token" },

--- a/src/components/auth/ProfileEditForm.tsx
+++ b/src/components/auth/ProfileEditForm.tsx
@@ -44,7 +44,7 @@ export default function ProfileEditForm() {
     register,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, isDirty },
   } = useForm<ProfileFormValues>({
     resolver: zodResolver(profileFormSchema),
     defaultValues: { name: "" },
@@ -52,9 +52,11 @@ export default function ProfileEditForm() {
 
   // 取得完了時にフォームへ現在の表示名を反映する（defaultValues は初回マウント時点の
   // 値しか使えないため、非同期取得後は reset で明示的に流し込む）。
+  // SWR はウィンドウフォーカス時等に再検証するため、編集中（isDirty）に再取得が
+  // 走ると入力中の値が上書きされてしまう。編集中でないときだけ反映する。
   useEffect(() => {
-    if (data?.user) reset({ name: data.user.name });
-  }, [data, reset]);
+    if (data?.user && !isDirty) reset({ name: data.user.name });
+  }, [data, isDirty, reset]);
 
   const sessionExpired = !!error && isUnauthorized(error);
   useEffect(() => {
@@ -150,11 +152,17 @@ export default function ProfileEditForm() {
         <input
           id="profile-name"
           type="text"
+          aria-invalid={errors.name ? true : undefined}
+          aria-describedby={errors.name ? "profile-name-error" : undefined}
           className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
           {...register("name")}
         />
         {errors.name && (
-          <p role="alert" className="font-sans-jp text-xs text-bengara">
+          <p
+            id="profile-name-error"
+            role="alert"
+            className="font-sans-jp text-xs text-bengara"
+          >
             {errors.name.message}
           </p>
         )}

--- a/src/components/auth/ProfileEditForm.tsx
+++ b/src/components/auth/ProfileEditForm.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useSession } from "next-auth/react";
+import useSWR from "swr";
+import {
+  ApiError,
+  getApiErrorMessage,
+  getCurrentUser,
+  isUnauthorized,
+  isValidationError,
+  updateCurrentUser,
+} from "@/lib/api";
+import type { CurrentUserResponse } from "@/lib/api";
+import { useAuthToken } from "@/lib/api/useAuthToken";
+import { useSessionExpiredHandler } from "@/lib/api/useSessionExpired";
+import { profileFormSchema, type ProfileFormValues } from "@/lib/validation/user";
+
+type SwrKey = readonly [string, string];
+
+// 編集画面の初期値表示には GET /current_user を使う（NextAuth の session.user.name は
+// OAuth プロバイダの表示名で、Rails 側で更新した名前と食い違いうるため）。
+export default function ProfileEditForm() {
+  const authToken = useAuthToken();
+  const { update } = useSession();
+  const callbackUrl = "/mypage/profile";
+  const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const fetcher = ([, token]: SwrKey): Promise<CurrentUserResponse> =>
+    getCurrentUser(token);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    CurrentUserResponse,
+    ApiError,
+    SwrKey | null
+  >(authToken ? (["/current_user", authToken] as const) : null, fetcher);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues: { name: "" },
+  });
+
+  // 取得完了時にフォームへ現在の表示名を反映する（defaultValues は初回マウント時点の
+  // 値しか使えないため、非同期取得後は reset で明示的に流し込む）。
+  useEffect(() => {
+    if (data?.user) reset({ name: data.user.name });
+  }, [data, reset]);
+
+  const sessionExpired = !!error && isUnauthorized(error);
+  useEffect(() => {
+    if (sessionExpired) void handleSessionExpired();
+  }, [sessionExpired, handleSessionExpired]);
+
+  if (!authToken) {
+    return (
+      <div className="border border-line-soft bg-paper px-5 py-6">
+        <p className="font-serif-jp text-sm leading-[1.9] text-muted">
+          プロフィールの編集にはログインが必要です。
+        </p>
+        <Link
+          href={`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+          className="mt-3 inline-block border border-olive px-4 py-1.5 font-mincho text-[13px] tracking-[0.12em] text-ink transition-colors hover:bg-olive hover:text-paper"
+        >
+          ログインへ
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
+
+  if (error && !sessionExpired) {
+    return (
+      <p role="alert" className="font-serif-jp text-sm text-muted">
+        プロフィールの取得に失敗しました。時間を置いてお試しください。
+      </p>
+    );
+  }
+
+  const onSubmit = handleSubmit(async (values) => {
+    setSubmitError(null);
+    setSaved(false);
+    try {
+      const res = await updateCurrentUser(values, authToken);
+      // 直後の再取得に頼らず、PATCH のレスポンスでキャッシュとセッションを
+      // 直接更新する（キャッシュの取り回しで古い名前が一瞬見える事故を避ける）。
+      await mutate(res, { revalidate: false });
+      await update({ name: res.user.name });
+      reset({ name: res.user.name });
+      setSaved(true);
+    } catch (e) {
+      if (isUnauthorized(e)) {
+        await handleSessionExpired();
+        return;
+      }
+      if (isValidationError(e)) {
+        setSubmitError(getApiErrorMessage(e, "入力内容を確認してください。"));
+        return;
+      }
+      setSubmitError("保存に失敗しました。時間を置いてお試しください。");
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="flex max-w-md flex-col gap-5">
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="profile-name"
+          className="font-sans-jp text-[11px] tracking-[0.2em] text-olive"
+        >
+          表示名 / NAME *
+        </label>
+        <input
+          id="profile-name"
+          type="text"
+          className="h-10 border border-line bg-washi px-3 font-serif-jp text-sm text-ink placeholder:text-muted/60 focus:border-olive focus:outline-none"
+          {...register("name")}
+        />
+        {errors.name && (
+          <p role="alert" className="font-sans-jp text-xs text-bengara">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+
+      {submitError && (
+        <p role="alert" className="font-sans-jp text-xs text-bengara">
+          {submitError}
+        </p>
+      )}
+      {saved && !submitError && (
+        <p className="font-sans-jp text-xs text-olive">
+          プロフィールを更新しました。
+        </p>
+      )}
+
+      <div className="flex gap-3 pt-1">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="border border-olive bg-olive px-6 py-2 font-mincho text-[13px] tracking-[0.15em] text-paper transition-colors hover:bg-olive-dark disabled:opacity-60"
+        >
+          {isSubmitting ? "保存中…" : "変更を保存"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/auth/ProfileEditForm.tsx
+++ b/src/components/auth/ProfileEditForm.tsx
@@ -25,7 +25,7 @@ type SwrKey = readonly [string, string];
 // OAuth プロバイダの表示名で、Rails 側で更新した名前と食い違いうるため）。
 export default function ProfileEditForm() {
   const authToken = useAuthToken();
-  const { update } = useSession();
+  const { status, update } = useSession();
   const callbackUrl = "/mypage/profile";
   const handleSessionExpired = useSessionExpiredHandler(callbackUrl);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -60,6 +60,17 @@ export default function ProfileEditForm() {
   useEffect(() => {
     if (sessionExpired) void handleSessionExpired();
   }, [sessionExpired, handleSessionExpired]);
+
+  // NextAuth セッション解決中はログイン CTA を出さない。解決前は railsJwt が
+  // 一時的に undefined になり、ログイン済みでも一瞬「ログインが必要」が見えてしまうため
+  // （CommentModerationList / mypage と同じガード）。
+  if (status === "loading") {
+    return (
+      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        読み込み中…
+      </p>
+    );
+  }
 
   if (!authToken) {
     return (
@@ -98,12 +109,22 @@ export default function ProfileEditForm() {
     setSaved(false);
     try {
       const res = await updateCurrentUser(values, authToken);
-      // 直後の再取得に頼らず、PATCH のレスポンスでキャッシュとセッションを
-      // 直接更新する（キャッシュの取り回しで古い名前が一瞬見える事故を避ける）。
+      // 直後の再取得に頼らず、PATCH のレスポンスでキャッシュを直接更新する
+      // （キャッシュの取り回しで古い名前が一瞬見える事故を避ける）。
       await mutate(res, { revalidate: false });
-      await update({ name: res.user.name });
       reset({ name: res.user.name });
       setSaved(true);
+      // ヘッダー等のセッション表示名反映は best-effort。ここが失敗/null でも
+      // Rails 側の保存自体は成功しているため、保存失敗として扱わない
+      // （次回のセッション再検証で追いつく）。
+      try {
+        await update({ name: res.user.name });
+      } catch (sessionError) {
+        console.warn(
+          "[ProfileEditForm] session update failed",
+          sessionError,
+        );
+      }
     } catch (e) {
       if (isUnauthorized(e)) {
         await handleSessionExpired();

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRef } from "react";
 import { signOut } from "next-auth/react";
 import type { Session } from "next-auth";
 
@@ -10,9 +11,16 @@ type UserMenuProps = {
 
 export default function UserMenu({ user }: UserMenuProps) {
   const displayName = user.name ?? "ゲスト";
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  // <details> はページ遷移してもブラウザネイティブの開閉状態を保持したままになるため、
+  // メニュー内のリンク/ボタンをクリックした時点で明示的に閉じる。
+  const close = () => {
+    if (detailsRef.current) detailsRef.current.open = false;
+  };
 
   return (
-    <details className="dropdown dropdown-end">
+    <details ref={detailsRef} className="dropdown dropdown-end">
       <summary
         className="flex cursor-pointer list-none items-center gap-2 border border-line px-3 py-1.5 font-mincho text-[13px] text-ink transition-colors hover:bg-olive hover:text-paper"
         aria-label="ユーザーメニューを開く"
@@ -20,7 +28,10 @@ export default function UserMenu({ user }: UserMenuProps) {
         <span aria-hidden="true">◎</span>
         <span className="max-w-[8rem] truncate">{displayName}</span>
       </summary>
-      <ul className="dropdown-content menu z-50 mt-2 w-56 border border-line bg-paper p-2 font-sans-jp text-sm text-ink shadow-sm">
+      <ul
+        className="dropdown-content menu z-50 mt-2 w-56 border border-line bg-paper p-2 font-sans-jp text-sm text-ink shadow-sm"
+        onClick={close}
+      >
         <li>
           <Link href="/mypage" className="rounded-none">
             マイページ

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRef } from "react";
 import { signOut } from "next-auth/react";
 import type { Session } from "next-auth";
+import { useCloseOnOutsideClick } from "@/lib/utils/useCloseOnOutsideClick";
 
 type UserMenuProps = {
   user: NonNullable<Session["user"]>;
@@ -18,6 +19,9 @@ export default function UserMenu({ user }: UserMenuProps) {
   const close = () => {
     if (detailsRef.current) detailsRef.current.open = false;
   };
+
+  // 外側クリックでも閉じる（<details> はネイティブでは summary の再クリックでしか閉じない）。
+  useCloseOnOutsideClick(detailsRef);
 
   return (
     <details ref={detailsRef} className="dropdown dropdown-end">

--- a/src/components/auth/__tests__/ProfileEditForm.test.tsx
+++ b/src/components/auth/__tests__/ProfileEditForm.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import type { ReactElement } from "react";
-import { SWRConfig } from "swr";
+import { mutate as globalMutate, SWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProfileEditForm from "@/components/auth/ProfileEditForm";
 import { server } from "@tests/msw/server";
@@ -131,6 +131,33 @@ describe("ProfileEditForm — マイページの CSR ガード", () => {
     await waitFor(() => {
       expect(screen.getByLabelText(/表示名/)).toHaveValue("現在の名前");
     });
+  });
+
+  it("編集中（未保存）はバックグラウンド再検証で入力値が上書きされない", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "サーバー側の名前", role: "general" },
+        }),
+      ),
+    );
+
+    // このテストだけは SWR のデフォルトキャッシュを使い、`mutate` で
+    // ウィンドウフォーカス復帰等によるバックグラウンド再検証を模す
+    // （isolated Map だと外部から同じキーで mutate できないため）。
+    render(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("サーバー側の名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.type(screen.getByLabelText(/表示名/), "入力中の値");
+
+    await globalMutate(["/current_user", "jwt-token"]);
+
+    expect(screen.getByLabelText(/表示名/)).toHaveValue("入力中の値");
   });
 
   it("表示名を空にして送信するとバリデーションエラーになり API を呼ばない", async () => {

--- a/src/components/auth/__tests__/ProfileEditForm.test.tsx
+++ b/src/components/auth/__tests__/ProfileEditForm.test.tsx
@@ -1,0 +1,242 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProfileEditForm from "@/components/auth/ProfileEditForm";
+import { server } from "@tests/msw/server";
+
+const useSessionMock = vi.fn();
+const updateSessionMock = vi.fn();
+const pushMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const endpoint = (path: string) => `${API_BASE_URL}/api/v1${path}`;
+
+const authedSession = {
+  data: { railsJwt: "jwt-token" },
+  status: "authenticated" as const,
+  update: updateSessionMock,
+};
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  updateSessionMock.mockReset().mockResolvedValue(undefined);
+  pushMock.mockReset();
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+});
+
+// SWR のグローバルキャッシュをテスト間で持ち越さないよう、毎回空 Map で包む。
+function renderWithSwr(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("ProfileEditForm — マイページの CSR ガード", () => {
+  it("未ログインでは案内とログインリンク（callbackUrl=/mypage/profile）を表示する", () => {
+    useSessionMock.mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+      update: updateSessionMock,
+    });
+
+    render(<ProfileEditForm />);
+
+    expect(
+      screen.getByText(/プロフィールの編集にはログインが必要/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /ログインへ/ })).toHaveAttribute(
+      "href",
+      "/auth/login?callbackUrl=%2Fmypage%2Fprofile",
+    );
+  });
+
+  it("初期取得が 401 だと signOut してログインへ誘導する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fmypage%2Fprofile",
+    );
+  });
+
+  it("401 以外の取得失敗では汎用エラーを表示し signOut しない", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({ error: "server error" }, { status: 500 }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /プロフィールの取得に失敗しました/,
+    );
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
+  it("取得できた現在の表示名をフォームに反映する", async () => {
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "現在の名前", role: "general" },
+        }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("現在の名前");
+    });
+  });
+
+  it("表示名を空にして送信するとバリデーションエラーになり API を呼ばない", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue(authedSession);
+    let patchCalled = false;
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "現在の名前", role: "general" },
+        }),
+      ),
+      http.patch(endpoint("/current_user"), () => {
+        patchCalled = true;
+        return HttpResponse.json({
+          user: { id: 1, name: "", role: "general" },
+        });
+      }),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("現在の名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    expect(await screen.findByText("表示名は必須です")).toBeInTheDocument();
+    expect(patchCalled).toBe(false);
+  });
+
+  it("保存に成功すると PATCH を送り、成功メッセージを表示しセッションを更新する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue(authedSession);
+    let receivedBody: unknown = null;
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "旧名前", role: "general" },
+        }),
+      ),
+      http.patch(endpoint("/current_user"), async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({
+          user: { id: 1, name: "新しい名前", role: "general" },
+        });
+      }),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("旧名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.type(screen.getByLabelText(/表示名/), "新しい名前");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    expect(
+      await screen.findByText("プロフィールを更新しました。"),
+    ).toBeInTheDocument();
+    expect(receivedBody).toEqual({ user: { name: "新しい名前" } });
+    expect(updateSessionMock).toHaveBeenCalledWith({ name: "新しい名前" });
+  });
+
+  it("保存が 422 だとサーバーのエラーメッセージを表示する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "旧名前", role: "general" },
+        }),
+      ),
+      http.patch(endpoint("/current_user"), () =>
+        HttpResponse.json({ error: "Name can't be blank" }, { status: 422 }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("旧名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.type(screen.getByLabelText(/表示名/), "x");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    expect(await screen.findByText("Name can't be blank")).toBeInTheDocument();
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("保存が 401 だと signOut してログインへ誘導する", async () => {
+    const user = userEvent.setup();
+    useSessionMock.mockReturnValue(authedSession);
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "旧名前", role: "general" },
+        }),
+      ),
+      http.patch(endpoint("/current_user"), () =>
+        HttpResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("旧名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.type(screen.getByLabelText(/表示名/), "x");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(signOutMock).toHaveBeenCalledWith({ redirect: false });
+    });
+    expect(pushMock).toHaveBeenCalledWith(
+      "/auth/login?callbackUrl=%2Fmypage%2Fprofile",
+    );
+  });
+});

--- a/src/components/auth/__tests__/ProfileEditForm.test.tsx
+++ b/src/components/auth/__tests__/ProfileEditForm.test.tsx
@@ -67,6 +67,21 @@ describe("ProfileEditForm — マイページの CSR ガード", () => {
     );
   });
 
+  it("セッション解決中（loading）はログイン CTA を出さず読み込み中を表示する", () => {
+    useSessionMock.mockReturnValue({
+      data: null,
+      status: "loading",
+      update: updateSessionMock,
+    });
+
+    render(<ProfileEditForm />);
+
+    expect(screen.getByText(/読み込み中/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/プロフィールの編集にはログインが必要/),
+    ).not.toBeInTheDocument();
+  });
+
   it("初期取得が 401 だと signOut してログインへ誘導する", async () => {
     useSessionMock.mockReturnValue(authedSession);
     server.use(
@@ -180,6 +195,43 @@ describe("ProfileEditForm — マイページの CSR ガード", () => {
     ).toBeInTheDocument();
     expect(receivedBody).toEqual({ user: { name: "新しい名前" } });
     expect(updateSessionMock).toHaveBeenCalledWith({ name: "新しい名前" });
+  });
+
+  it("PATCH は成功したがセッション更新が失敗しても、保存成功として表示する", async () => {
+    const user = userEvent.setup();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    useSessionMock.mockReturnValue(authedSession);
+    updateSessionMock.mockRejectedValue(new Error("network down"));
+    server.use(
+      http.get(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "旧名前", role: "general" },
+        }),
+      ),
+      http.patch(endpoint("/current_user"), () =>
+        HttpResponse.json({
+          user: { id: 1, name: "新しい名前", role: "general" },
+        }),
+      ),
+    );
+
+    renderWithSwr(<ProfileEditForm />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/表示名/)).toHaveValue("旧名前"),
+    );
+
+    await user.clear(screen.getByLabelText(/表示名/));
+    await user.type(screen.getByLabelText(/表示名/), "新しい名前");
+    await user.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    expect(
+      await screen.findByText("プロフィールを更新しました。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/保存に失敗しました/),
+    ).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("保存が 422 だとサーバーのエラーメッセージを表示する", async () => {

--- a/src/components/auth/__tests__/UserMenu.test.tsx
+++ b/src/components/auth/__tests__/UserMenu.test.tsx
@@ -71,4 +71,23 @@ describe("UserMenu", () => {
 
     expect(details.open).toBe(false);
   });
+
+  it("メニュー外をクリックすると閉じる", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <UserMenu user={{ name: "中村さん", email: null, image: null }} />
+        <p>外側</p>
+      </div>,
+    );
+
+    const details = screen
+      .getByLabelText("ユーザーメニューを開く")
+      .closest("details")!;
+    details.open = true;
+
+    await user.click(screen.getByText("外側"));
+
+    expect(details.open).toBe(false);
+  });
 });

--- a/src/components/auth/__tests__/UserMenu.test.tsx
+++ b/src/components/auth/__tests__/UserMenu.test.tsx
@@ -43,4 +43,32 @@ describe("UserMenu", () => {
 
     expect(signOutMock).toHaveBeenCalledWith({ redirectTo: "/" });
   });
+
+  it("マイページリンクをクリックするとドロップダウンが閉じる（別ページへ遷移してもメニューが開いたままにならない）", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu user={{ name: "中村さん", email: null, image: null }} />);
+
+    const details = screen
+      .getByLabelText("ユーザーメニューを開く")
+      .closest("details")!;
+    details.open = true;
+
+    await user.click(screen.getByRole("link", { name: "マイページ" }));
+
+    expect(details.open).toBe(false);
+  });
+
+  it("ログアウトボタンをクリックするとドロップダウンが閉じる", async () => {
+    const user = userEvent.setup();
+    render(<UserMenu user={{ name: "中村さん", email: null, image: null }} />);
+
+    const details = screen
+      .getByLabelText("ユーザーメニューを開く")
+      .closest("details")!;
+    details.open = true;
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    expect(details.open).toBe(false);
+  });
 });

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -196,7 +196,7 @@ export default function CommentSection({
             <li key={comment.id} className="px-5 py-4">
               <div className="flex items-baseline justify-between gap-3">
                 <span className="font-mincho text-sm text-ink">
-                  {comment.user.name}
+                  {comment.user?.name ?? "匿名ユーザー"}
                 </span>
                 <span className="font-sans-jp text-[10px] tracking-[0.15em] text-muted">
                   {formatDate(comment.created_at)}

--- a/src/components/common/__tests__/CommentSection.test.tsx
+++ b/src/components/common/__tests__/CommentSection.test.tsx
@@ -477,4 +477,21 @@ describe("CommentSection", () => {
 
     expect(screen.getByText("日付おかしい")).toBeInTheDocument();
   });
+
+  it("投稿者が欠落したコメント（user: null）でもクラッシュせず「匿名ユーザー」と表示する", () => {
+    mockLoggedIn();
+    render(
+      <CommentSection
+        kind="greentea"
+        targetId={1}
+        initialComments={[
+          baseComment({ id: 1, body: "投稿者不明", user: null }),
+        ]}
+        callbackUrl="/greenteas/1"
+      />,
+    );
+
+    expect(screen.getByText("投稿者不明")).toBeInTheDocument();
+    expect(screen.getByText("匿名ユーザー")).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { HiBars3 } from "react-icons/hi2";
 import Logo from "@/components/brand/Logo";
+import MobileNav from "@/components/layout/MobileNav";
 import Navigation from "@/components/layout/Navigation";
 import HeaderAuth from "@/components/auth/HeaderAuth";
 
@@ -28,17 +28,7 @@ export default function Header() {
           <HeaderAuth />
         </div>
 
-        <details className="dropdown dropdown-end lg:hidden">
-          <summary className="btn btn-ghost btn-square" aria-label="メニューを開く">
-            <HiBars3 className="h-5 w-5" />
-          </summary>
-          <div className="dropdown-content z-50 mt-3 flex w-60 flex-col gap-5 border border-line bg-paper p-5">
-            <Navigation orientation="vertical" />
-            <div className="flex items-center justify-between gap-3 border-t border-line pt-4">
-              <HeaderAuth />
-            </div>
-          </div>
-        </details>
+        <MobileNav />
       </div>
     </header>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Logo from "@/components/brand/Logo";
-import MobileNav from "@/components/layout/MobileNav";
+import MobileNav from "./MobileNav";
 import Navigation from "@/components/layout/Navigation";
 import HeaderAuth from "@/components/auth/HeaderAuth";
 

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRef } from "react";
+import { HiBars3 } from "react-icons/hi2";
+import HeaderAuth from "@/components/auth/HeaderAuth";
+import Navigation from "@/components/layout/Navigation";
+
+// <details> はページ遷移してもブラウザネイティブの開閉状態を保持したままになり、
+// 別ページに移動してもメニューが開いたまま残ってしまう。メニュー内のリンク/ボタンを
+// クリックした時点（遷移が起きる直前）で明示的に閉じることで解消する。
+export default function MobileNav() {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  const close = () => {
+    if (detailsRef.current) detailsRef.current.open = false;
+  };
+
+  return (
+    <details ref={detailsRef} className="dropdown dropdown-end lg:hidden">
+      <summary className="btn btn-ghost btn-square" aria-label="メニューを開く">
+        <HiBars3 className="h-5 w-5" />
+      </summary>
+      <div
+        className="dropdown-content z-50 mt-3 flex w-60 flex-col gap-5 border border-line bg-paper p-5"
+        onClick={close}
+      >
+        <Navigation orientation="vertical" />
+        <div className="flex items-center justify-between gap-3 border-t border-line pt-4">
+          <HeaderAuth />
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import { HiBars3 } from "react-icons/hi2";
+import { useCloseOnOutsideClick } from "@/lib/utils/useCloseOnOutsideClick";
 import HeaderAuth from "../auth/HeaderAuth";
 import Navigation from "./Navigation";
 
@@ -14,6 +15,9 @@ export default function MobileNav() {
   const close = () => {
     if (detailsRef.current) detailsRef.current.open = false;
   };
+
+  // 外側クリックでも閉じる（<details> はネイティブでは summary の再クリックでしか閉じない）。
+  useCloseOnOutsideClick(detailsRef);
 
   // 入れ子の UserMenu（アバターの details）の summary クリックもこの div まで
   // バブリングしてくる。a/button 以外（= summary の開閉トグル）まで閉じてしまうと

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -2,8 +2,8 @@
 
 import { useRef } from "react";
 import { HiBars3 } from "react-icons/hi2";
-import HeaderAuth from "@/components/auth/HeaderAuth";
-import Navigation from "@/components/layout/Navigation";
+import HeaderAuth from "../auth/HeaderAuth";
+import Navigation from "./Navigation";
 
 // <details> はページ遷移してもブラウザネイティブの開閉状態を保持したままになり、
 // 別ページに移動してもメニューが開いたまま残ってしまう。メニュー内のリンク/ボタンを
@@ -15,6 +15,19 @@ export default function MobileNav() {
     if (detailsRef.current) detailsRef.current.open = false;
   };
 
+  // 入れ子の UserMenu（アバターの details）の summary クリックもこの div まで
+  // バブリングしてくる。a/button 以外（= summary の開閉トグル）まで閉じてしまうと
+  // 認証済みユーザーが UserMenu を開けなくなるため、実際に遷移/操作するリンクと
+  // ボタンのクリックだけを閉鎖トリガーにする。
+  const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      event.target instanceof Element &&
+      event.target.closest("a, button")
+    ) {
+      close();
+    }
+  };
+
   return (
     <details ref={detailsRef} className="dropdown dropdown-end lg:hidden">
       <summary className="btn btn-ghost btn-square" aria-label="メニューを開く">
@@ -22,7 +35,7 @@ export default function MobileNav() {
       </summary>
       <div
         className="dropdown-content z-50 mt-3 flex w-60 flex-col gap-5 border border-line bg-paper p-5"
-        onClick={close}
+        onClick={handleContentClick}
       >
         <Navigation orientation="vertical" />
         <div className="flex items-center justify-between gap-3 border-t border-line pt-4">

--- a/src/components/layout/__tests__/MobileNav.test.tsx
+++ b/src/components/layout/__tests__/MobileNav.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MobileNav from "@/components/layout/MobileNav";
+
+const useSessionMock = vi.fn();
+const signOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+function getDetails() {
+  return screen.getByLabelText("メニューを開く").closest("details")!;
+}
+
+beforeEach(() => {
+  useSessionMock.mockReset();
+  signOutMock.mockReset();
+});
+
+describe("MobileNav — ハンバーガーメニュー", () => {
+  it("ナビゲーションリンクをクリックすると閉じる（別ページへ遷移してもメニューが開いたままにならない）", async () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+    const user = userEvent.setup();
+    render(<MobileNav />);
+
+    const details = getDetails();
+    details.open = true;
+    expect(details.open).toBe(true);
+
+    await user.click(screen.getByRole("link", { name: "抹茶スイーツ" }));
+
+    expect(details.open).toBe(false);
+  });
+
+  it("未ログイン時、ログインリンクをクリックしても閉じる", async () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+    const user = userEvent.setup();
+    render(<MobileNav />);
+
+    const details = getDetails();
+    details.open = true;
+
+    await user.click(screen.getByRole("link", { name: "ログイン" }));
+
+    expect(details.open).toBe(false);
+  });
+
+  it("ログイン時、入れ子の UserMenu 内のボタンをクリックしても外側のメニューが閉じる", async () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { name: "抹茶太郎" } },
+      status: "authenticated",
+    });
+    const user = userEvent.setup();
+    render(<MobileNav />);
+
+    const details = getDetails();
+    details.open = true;
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    expect(details.open).toBe(false);
+  });
+});

--- a/src/components/layout/__tests__/MobileNav.test.tsx
+++ b/src/components/layout/__tests__/MobileNav.test.tsx
@@ -67,4 +67,24 @@ describe("MobileNav — ハンバーガーメニュー", () => {
 
     expect(details.open).toBe(false);
   });
+
+  it("入れ子の UserMenu を開く操作（summary クリック）では外側のメニューを閉じない", async () => {
+    useSessionMock.mockReturnValue({
+      data: { user: { name: "抹茶太郎" } },
+      status: "authenticated",
+    });
+    const user = userEvent.setup();
+    render(<MobileNav />);
+
+    const details = getDetails();
+    details.open = true;
+
+    await user.click(
+      screen.getByLabelText("ユーザーメニューを開く"),
+    );
+    expect(details.open).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+    expect(details.open).toBe(false);
+  });
 });

--- a/src/components/layout/__tests__/MobileNav.test.tsx
+++ b/src/components/layout/__tests__/MobileNav.test.tsx
@@ -87,4 +87,22 @@ describe("MobileNav — ハンバーガーメニュー", () => {
     await user.click(screen.getByRole("button", { name: "ログアウト" }));
     expect(details.open).toBe(false);
   });
+
+  it("メニュー外をクリックすると閉じる", async () => {
+    useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+    const user = userEvent.setup();
+    render(
+      <div>
+        <MobileNav />
+        <p>外側</p>
+      </div>,
+    );
+
+    const details = getDetails();
+    details.open = true;
+
+    await user.click(screen.getByText("外側"));
+
+    expect(details.open).toBe(false);
+  });
 });

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -268,6 +268,34 @@ describe("authConfig.callbacks.jwt", () => {
     expect(exchangeOAuthForJwt).not.toHaveBeenCalled();
     expect(result.railsJwt).toBeUndefined();
   });
+
+  it("trigger=update かつ session.name があれば token.name を更新する（プロフィール編集後の反映）", async () => {
+    const { authConfig } = await loadAuthModule();
+    const token = { name: "旧名前", railsJwt: "existing-jwt" };
+
+    const result = await authConfig.callbacks.jwt({
+      token,
+      trigger: "update",
+      session: { name: "新しい名前" },
+    } as JwtParams);
+
+    expect(result.name).toBe("新しい名前");
+    expect(result.railsJwt).toBe("existing-jwt");
+    expect(exchangeOAuthForJwt).not.toHaveBeenCalled();
+  });
+
+  it("trigger=update でも session.name が無ければ token.name を変更しない", async () => {
+    const { authConfig } = await loadAuthModule();
+    const token = { name: "旧名前" };
+
+    const result = await authConfig.callbacks.jwt({
+      token,
+      trigger: "update",
+      session: {},
+    } as JwtParams);
+
+    expect(result.name).toBe("旧名前");
+  });
 });
 
 describe("authConfig.callbacks.session", () => {

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -296,6 +296,34 @@ describe("authConfig.callbacks.jwt", () => {
 
     expect(result.name).toBe("旧名前");
   });
+
+  it("trigger=update の session.name は前後の空白を trim し 100 文字に切り詰める（Cookie 肥大化防止）", async () => {
+    const { authConfig } = await loadAuthModule();
+    const token = { name: "旧名前" };
+    const longName = "あ".repeat(150);
+
+    const result = await authConfig.callbacks.jwt({
+      token,
+      trigger: "update",
+      session: { name: `  ${longName}  ` },
+    } as JwtParams);
+
+    expect(result.name).toBe(longName.slice(0, 100));
+    expect(result.name).toHaveLength(100);
+  });
+
+  it("trigger=update の session.name が空白のみなら token.name を変更しない", async () => {
+    const { authConfig } = await loadAuthModule();
+    const token = { name: "旧名前" };
+
+    const result = await authConfig.callbacks.jwt({
+      token,
+      trigger: "update",
+      session: { name: "   " },
+    } as JwtParams);
+
+    expect(result.name).toBe("旧名前");
+  });
 });
 
 describe("authConfig.callbacks.session", () => {

--- a/src/lib/api/__tests__/contract.test.ts
+++ b/src/lib/api/__tests__/contract.test.ts
@@ -13,6 +13,7 @@ import {
   getTemple,
   getTemples,
   revokeJwt,
+  updateCurrentUser,
 } from "..";
 
 import areasFixture from "./fixtures/areas.list.json";
@@ -358,6 +359,70 @@ describe("API contract: 認証系", () => {
       await expect(getCurrentUser("expired-token")).rejects.toMatchObject({
         status: 401,
       });
+    });
+  });
+
+  describe("PATCH /current_user", () => {
+    it("user キー配下で name を送り、Authorization を付与する", async () => {
+      let authHeader: string | null = null;
+      let receivedBody: unknown = null;
+      server.use(
+        http.patch(endpoint("/current_user"), async ({ request }) => {
+          authHeader = request.headers.get("Authorization");
+          receivedBody = await request.json();
+          return HttpResponse.json({
+            user: { id: 42, name: "新しい表示名", role: "general" },
+          });
+        }),
+      );
+
+      const res = await updateCurrentUser(
+        { name: "新しい表示名" },
+        "rails.jwt.example-token",
+      );
+
+      expect(authHeader).toBe("Bearer rails.jwt.example-token");
+      expect(receivedBody).toEqual({ user: { name: "新しい表示名" } });
+      expect(res.user).toEqual({ id: 42, name: "新しい表示名", role: "general" });
+    });
+
+    it("422（name が空）で ApiError を throw する", async () => {
+      server.use(
+        http.patch(endpoint("/current_user"), () =>
+          HttpResponse.json(
+            { error: "Name can't be blank" },
+            { status: 422 },
+          ),
+        ),
+      );
+
+      await expect(
+        updateCurrentUser({ name: "" }, "rails.jwt.example-token"),
+      ).rejects.toMatchObject({ status: 422 });
+    });
+
+    it("400（不正なリクエスト形式）で ApiError を throw する", async () => {
+      server.use(
+        http.patch(endpoint("/current_user"), () =>
+          HttpResponse.json({ error: "Bad Request" }, { status: 400 }),
+        ),
+      );
+
+      await expect(
+        updateCurrentUser({ name: "x" }, "rails.jwt.example-token"),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("401（未認証）で ApiError を throw する", async () => {
+      server.use(
+        http.patch(endpoint("/current_user"), () =>
+          HttpResponse.json({ error: "Unauthorized" }, { status: 401 }),
+        ),
+      );
+
+      await expect(
+        updateCurrentUser({ name: "x" }, "expired-token"),
+      ).rejects.toMatchObject({ status: 401 });
     });
   });
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -27,6 +27,11 @@ export type CurrentUserResponse = {
   user: AuthUser;
 };
 
+export type UpdateCurrentUserPayload = {
+  // name を省略すると Rails 側は「変更なし」の部分更新として扱う（200 を返す）。
+  name?: string;
+};
+
 // NextAuth の jwt callback で OAuth 成功直後に呼び出し、Rails 側の JWT に交換する。
 // 受け取った JWT は session.railsJwt に格納し、以後の API 呼び出しに添付する。
 export function exchangeOAuthForJwt(
@@ -43,6 +48,19 @@ export function getCurrentUser(
   authToken: string,
 ): Promise<CurrentUserResponse> {
   return apiClient<CurrentUserResponse>("/current_user", { authToken });
+}
+
+// プロフィール編集（表示名のみ更新可）。バリデーションエラーは 422、
+// user キー欠落等の不正なボディは 400 で ApiError を throw する。
+export function updateCurrentUser(
+  payload: UpdateCurrentUserPayload,
+  authToken: string,
+): Promise<CurrentUserResponse> {
+  return apiClient<CurrentUserResponse>("/current_user", {
+    method: "PATCH",
+    body: JSON.stringify({ user: payload }),
+    authToken,
+  });
 }
 
 // signOut 時に Rails 側の JWT を失効させる。失敗してもクライアント側のログアウトは

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -39,10 +39,16 @@ export {
   updateRoute,
   deleteRoute,
 } from "./routes";
-export { exchangeOAuthForJwt, getCurrentUser, revokeJwt } from "./auth";
+export {
+  exchangeOAuthForJwt,
+  getCurrentUser,
+  revokeJwt,
+  updateCurrentUser,
+} from "./auth";
 export type {
   AuthProvider,
   OAuthExchangePayload,
   AuthExchangeResponse,
   CurrentUserResponse,
+  UpdateCurrentUserPayload,
 } from "./auth";

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -14,6 +14,7 @@ import type {
   TempleLikeResponse,
   TempleListResponse,
 } from "@/types";
+import type { CurrentUserResponse } from "@/lib/api/auth";
 import { ApiError } from "@/lib/api/error";
 import { mockClient } from "../index";
 import { resetMockStore } from "../state";
@@ -334,6 +335,92 @@ describe("mockClient comments", () => {
         ...auth("alice"),
       }),
     ).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("mockClient GET/PATCH /current_user", () => {
+  it("GET は uid から導出した表示名を返す", async () => {
+    const res = await mockClient<CurrentUserResponse>(
+      "/current_user",
+      auth("alice"),
+    );
+    expect(res.user).toEqual({ id: expect.any(Number), name: "alice", role: "general" });
+  });
+
+  it("PATCH で name を更新すると以後の GET に反映される", async () => {
+    const u = auth("alice");
+
+    const patched = await mockClient<CurrentUserResponse>("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: { name: "新しい名前" } }),
+      ...u,
+    });
+    expect(patched.user.name).toBe("新しい名前");
+
+    const after = await mockClient<CurrentUserResponse>("/current_user", u);
+    expect(after.user.name).toBe("新しい名前");
+  });
+
+  it("name を省略すると変更なしとして 200 を返す", async () => {
+    const u = auth("alice");
+
+    const res = await mockClient<CurrentUserResponse>("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: {} }),
+      ...u,
+    });
+    expect(res.user.name).toBe("alice");
+  });
+
+  it("name が空文字だと ApiError(422)", async () => {
+    await expect(
+      mockClient("/current_user", {
+        method: "PATCH",
+        body: JSON.stringify({ user: { name: "   " } }),
+        ...auth("alice"),
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("user キーが無い / オブジェクトでないと ApiError(400)", async () => {
+    await expect(
+      mockClient("/current_user", {
+        method: "PATCH",
+        body: JSON.stringify({}),
+        ...auth("alice"),
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    await expect(
+      mockClient("/current_user", {
+        method: "PATCH",
+        body: JSON.stringify({ user: "not-an-object" }),
+        ...auth("alice"),
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("未認証は ApiError(401)", async () => {
+    await expect(
+      mockClient("/current_user", {
+        method: "PATCH",
+        body: JSON.stringify({ user: { name: "x" } }),
+      }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("表示名の更新は他ユーザーに影響しない", async () => {
+    await mockClient("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: { name: "アリス改名" } }),
+      ...auth("alice"),
+    });
+
+    const bob = await mockClient<CurrentUserResponse>(
+      "/current_user",
+      auth("bob"),
+    );
+    expect(bob.user.name).toBe("bob");
   });
 });
 

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -359,6 +359,42 @@ describe("mockClient comments", () => {
     const posted = list.comments.find((c) => c.body === "改名前の投稿");
     expect(posted?.user?.name).toBe("改名後");
   });
+
+  it("PATCH /current_user で改名した後に投稿すると、POST 応答自体が改名後の表示名になる", async () => {
+    const alice = auth("alice");
+
+    await mockClient("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: { name: "改名後" } }),
+      ...alice,
+    });
+
+    const posted = await mockClient<CommentResponse>("/greenteacomments", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 1, body: "改名後の投稿" }),
+      ...alice,
+    });
+
+    expect(posted.comment.user?.name).toBe("改名後");
+  });
+
+  it("temple コメントの POST 応答も改名後の表示名になる", async () => {
+    const alice = auth("alice");
+
+    await mockClient("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: { name: "改名後" } }),
+      ...alice,
+    });
+
+    const posted = await mockClient<CommentResponse>("/templecomments", {
+      method: "POST",
+      body: JSON.stringify({ temple_id: 1, body: "改名後の投稿" }),
+      ...alice,
+    });
+
+    expect(posted.comment.user?.name).toBe("改名後");
+  });
 });
 
 describe("mockClient GET/PATCH /current_user", () => {

--- a/src/lib/api/mock/__tests__/mock.test.ts
+++ b/src/lib/api/mock/__tests__/mock.test.ts
@@ -336,6 +336,29 @@ describe("mockClient comments", () => {
       }),
     ).rejects.toBeInstanceOf(ApiError);
   });
+
+  it("PATCH /current_user で改名すると、投稿済みコメントの表示名も遡って更新される", async () => {
+    const alice = auth("alice");
+
+    await mockClient<CommentResponse>("/greenteacomments", {
+      method: "POST",
+      body: JSON.stringify({ greentea_id: 1, body: "改名前の投稿" }),
+      ...alice,
+    });
+
+    await mockClient("/current_user", {
+      method: "PATCH",
+      body: JSON.stringify({ user: { name: "改名後" } }),
+      ...alice,
+    });
+
+    const list = await mockClient<CommentListResponse>(
+      "/greenteacomments?greentea_id=1",
+      alice,
+    );
+    const posted = list.comments.find((c) => c.body === "改名前の投稿");
+    expect(posted?.user?.name).toBe("改名後");
+  });
 });
 
 describe("mockClient GET/PATCH /current_user", () => {

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -56,6 +56,7 @@ import {
   extractMockUserId,
   getMockGreenteas,
   getMockTemples,
+  getMockUserName,
   getGreenteaLikeDelta,
   getGreenteaLikedIds,
   getRouteForOwner,
@@ -67,6 +68,7 @@ import {
   listTempleComments,
   removeGreenteaLike,
   removeTempleLike,
+  setMockUserName,
   updateMockGreentea,
   updateMockTemple,
   updateRouteRecord,
@@ -362,7 +364,11 @@ export async function mockClient<T>(
     if (path === "/current_user") {
       const uid = requireMockUser(headers);
       return {
-        user: { id: hashUserId(uid), name: mockUserName(uid), role: "general" },
+        user: {
+          id: hashUserId(uid),
+          name: getMockUserName(uid, mockUserName(uid)),
+          role: "general",
+        },
       } satisfies CurrentUserResponse as T;
     }
   }
@@ -603,6 +609,30 @@ export async function mockClient<T>(
   }
 
   if (method === "PATCH") {
+    // プロフィール編集: name のみ更新可。キー欠落は「変更なし」の部分更新として 200。
+    if (path === "/current_user") {
+      const uid = requireMockUser(headers);
+      const parsed = parseJsonBody<{ user?: unknown }>(options?.body);
+      if (!parsed.user || typeof parsed.user !== "object") {
+        throw new ApiError(400, { error: "Bad Request" });
+      }
+      const { name } = parsed.user as { name?: unknown };
+      if (name !== undefined) {
+        const trimmed = typeof name === "string" ? name.trim() : "";
+        if (trimmed.length === 0) {
+          throw new ApiError(422, { error: "Name can't be blank" });
+        }
+        setMockUserName(uid, trimmed);
+      }
+      return {
+        user: {
+          id: hashUserId(uid),
+          name: getMockUserName(uid, mockUserName(uid)),
+          role: "general",
+        },
+      } satisfies CurrentUserResponse as T;
+    }
+
     // Admin: greentea 更新
     const adminGreenteasPatchMatch = path.match(/^\/admin\/greenteas\/(\d+)$/);
     if (adminGreenteasPatchMatch) {

--- a/src/lib/api/mock/index.ts
+++ b/src/lib/api/mock/index.ts
@@ -427,7 +427,7 @@ export async function mockClient<T>(
       }
       const comment = addGreenteaComment(greentea_id, uid, {
         body: body.trim(),
-        user: { id: hashUserId(uid), name: mockUserName(uid) },
+        user: { id: hashUserId(uid), name: getMockUserName(uid, mockUserName(uid)) },
       });
       return { comment } satisfies CommentResponse as T;
     }
@@ -445,7 +445,7 @@ export async function mockClient<T>(
       }
       const comment = addTempleComment(temple_id, uid, {
         body: body.trim(),
-        user: { id: hashUserId(uid), name: mockUserName(uid) },
+        user: { id: hashUserId(uid), name: getMockUserName(uid, mockUserName(uid)) },
       });
       return { comment } satisfies CommentResponse as T;
     }

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -179,12 +179,24 @@ export function getTempleLikeDelta(templeId: number): number {
   return store.templeLikeCountDelta.get(templeId) ?? 0;
 }
 
+// 投稿時点の表示名をコメントに埋め込んだままだと、後から PATCH /current_user で
+// 改名しても過去のコメントに反映されない（実際の Rails は投稿者を都度 JOIN するため
+// 常に最新の表示名になる）。読み出し時に profileNames の上書きを都度反映することで
+// 挙動を揃える。
+function resolveCommentUser(comment: Comment, ownerId: UserId): Comment {
+  if (!comment.user) return comment;
+  return {
+    ...comment,
+    user: { ...comment.user, name: getMockUserName(ownerId, comment.user.name) },
+  };
+}
+
 export function listGreenteaComments(
   greenteaId: number,
   viewerId: UserId | null,
 ): Comment[] {
   return (store.greenteaComments.get(greenteaId) ?? []).map((r) => ({
-    ...r.comment,
+    ...resolveCommentUser(r.comment, r.ownerId),
     owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
   }));
 }
@@ -194,7 +206,7 @@ export function listTempleComments(
   viewerId: UserId | null,
 ): Comment[] {
   return (store.templeComments.get(templeId) ?? []).map((r) => ({
-    ...r.comment,
+    ...resolveCommentUser(r.comment, r.ownerId),
     owned_by_current_user: viewerId !== null && r.ownerId === viewerId,
   }));
 }
@@ -435,12 +447,20 @@ export function listAllComments(): Array<{
 
   for (const [resourceId, records] of store.greenteaComments.entries()) {
     for (const r of records) {
-      result.push({ comment: r.comment, resourceType: "greentea", resourceId });
+      result.push({
+        comment: resolveCommentUser(r.comment, r.ownerId),
+        resourceType: "greentea",
+        resourceId,
+      });
     }
   }
   for (const [resourceId, records] of store.templeComments.entries()) {
     for (const r of records) {
-      result.push({ comment: r.comment, resourceType: "temple", resourceId });
+      result.push({
+        comment: resolveCommentUser(r.comment, r.ownerId),
+        resourceType: "temple",
+        resourceId,
+      });
     }
   }
   return result;

--- a/src/lib/api/mock/state.ts
+++ b/src/lib/api/mock/state.ts
@@ -51,6 +51,7 @@ type MockStore = {
   greenteas: Greentea[] | null;
   temples: Temple[] | null;
   routes: StoredRoute[];
+  profileNames: Map<UserId, string>;
 };
 
 const globalKey = Symbol.for("matcha-to-jinja.mock-store");
@@ -72,6 +73,7 @@ const store: MockStore = ((): MockStore => {
       greenteas: null,
       temples: null,
       routes: [],
+      profileNames: new Map(),
     };
   }
   return g[globalKey]!;
@@ -92,6 +94,7 @@ export function resetMockStore(): void {
   store.greenteas = null;
   store.temples = null;
   store.routes = [];
+  store.profileNames.clear();
 }
 
 function ensureSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
@@ -507,4 +510,16 @@ export function deleteRouteRecord(id: number, ownerId: UserId): boolean {
   if (idx < 0) return false;
   store.routes.splice(idx, 1);
   return true;
+}
+
+// --- プロフィール編集（表示名のみ） ---
+// mock ユーザーの表示名は本来 uid から導出する（mockUserName）だけだが、
+// PATCH /current_user で上書きされた分だけここに保持する。
+
+export function getMockUserName(userId: UserId, fallback: string): string {
+  return store.profileNames.get(userId) ?? fallback;
+}
+
+export function setMockUserName(userId: UserId, name: string): void {
+  store.profileNames.set(userId, name);
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -78,9 +78,11 @@ export const authConfig = {
     async jwt({ token, account, user, trigger, session }) {
       // useSession().update({ name }) から呼ばれる（プロフィール編集後の反映）。
       // Rails への書き込みは呼び出し側で完了済みで、ここではセッション表示用に
-      // token.name を更新するだけ。
+      // token.name を更新するだけ。session はクライアントから直接呼び出せるため、
+      // Cookie 肥大化やなりすまし的な長大値の混入を防ぐ上限を掛けておく。
       if (trigger === "update" && typeof session?.name === "string") {
-        token.name = session.name;
+        const name = session.name.trim().slice(0, 100);
+        if (name.length > 0) token.name = name;
       }
       if (account?.provider) {
         token.provider = account.provider;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -75,7 +75,13 @@ export const authConfig = {
     strategy: "jwt",
   },
   callbacks: {
-    async jwt({ token, account, user }) {
+    async jwt({ token, account, user, trigger, session }) {
+      // useSession().update({ name }) から呼ばれる（プロフィール編集後の反映）。
+      // Rails への書き込みは呼び出し側で完了済みで、ここではセッション表示用に
+      // token.name を更新するだけ。
+      if (trigger === "update" && typeof session?.name === "string") {
+        token.name = session.name;
+      }
       if (account?.provider) {
         token.provider = account.provider;
         // モック provider は Rails が無いので、ここで擬似 JWT を発行して

--- a/src/lib/utils/__tests__/useCloseOnOutsideClick.test.tsx
+++ b/src/lib/utils/__tests__/useCloseOnOutsideClick.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+import { useCloseOnOutsideClick } from "@/lib/utils/useCloseOnOutsideClick";
+
+function TestMenu() {
+  const ref = useRef<HTMLDetailsElement>(null);
+  useCloseOnOutsideClick(ref);
+  return (
+    <details ref={ref} data-testid="details">
+      <summary>toggle</summary>
+      <div>content</div>
+    </details>
+  );
+}
+
+describe("useCloseOnOutsideClick", () => {
+  it("開いている状態で外側をクリックすると閉じる", () => {
+    const { getByTestId } = render(<TestMenu />);
+    const details = getByTestId("details") as HTMLDetailsElement;
+    details.open = true;
+
+    fireEvent.click(document.body);
+
+    expect(details.open).toBe(false);
+  });
+
+  it("要素内側のクリックでは閉じない", () => {
+    const { getByTestId, getByText } = render(<TestMenu />);
+    const details = getByTestId("details") as HTMLDetailsElement;
+    details.open = true;
+
+    fireEvent.click(getByText("content"));
+
+    expect(details.open).toBe(true);
+  });
+
+  it("もともと閉じている状態では何もしない", () => {
+    const { getByTestId } = render(<TestMenu />);
+    const details = getByTestId("details") as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+
+    fireEvent.click(document.body);
+
+    expect(details.open).toBe(false);
+  });
+});

--- a/src/lib/utils/useCloseOnOutsideClick.ts
+++ b/src/lib/utils/useCloseOnOutsideClick.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+// <details> はブラウザネイティブでは外側クリックで閉じない（summary の再クリックのみ）。
+// 開いている間だけ document のクリックを監視し、要素の外側をクリックしたら閉じる。
+export function useCloseOnOutsideClick(
+  ref: RefObject<HTMLDetailsElement | null>,
+): void {
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const el = ref.current;
+      if (!el?.open) return;
+      if (event.target instanceof Node && !el.contains(event.target)) {
+        el.open = false;
+      }
+    };
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [ref]);
+}

--- a/src/lib/validation/user.ts
+++ b/src/lib/validation/user.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // PATCH /api/v1/current_user の body（{ user: { name } }）に対応するフォームスキーマ。
 // Rails 側は `validates :name, presence: true` のみ（他に編集可能フィールドが無い）。
 export const profileFormSchema = z.object({
-  name: z.string().trim().min(1, { message: "表示名は必須です" }),
+  name: z.string().trim().min(1, { error: "表示名は必須です" }),
 });
 
 export type ProfileFormValues = z.infer<typeof profileFormSchema>;

--- a/src/lib/validation/user.ts
+++ b/src/lib/validation/user.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+// PATCH /api/v1/current_user の body（{ user: { name } }）に対応するフォームスキーマ。
+// Rails 側は `validates :name, presence: true` のみ（他に編集可能フィールドが無い）。
+export const profileFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "表示名は必須です" }),
+});
+
+export type ProfileFormValues = z.infer<typeof profileFormSchema>;

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -3,7 +3,9 @@ import type { User } from "./user";
 export interface Comment {
   id: number;
   body: string;
-  user: User;
+  // 投稿者アカウントが削除済み等で Rails 側が user を含められないケースがあるため
+  // null を許容する（実際にレスポンスで欠落するのを確認済み）。
+  user: User | null;
   created_at: string;
   owned_by_current_user?: boolean;
 }


### PR DESCRIPTION
## 概要

Rails 側に追加された `PATCH /api/v1/current_user`（表示名のみ更新可）と連携し、マイページにプロフィール編集機能を追加しました。

## API 契約

- `PATCH /api/v1/current_user`
- リクエスト: `{ "user": { "name": "新しい表示名" } }`（`name` 省略時は変更なしとして 200）
- レスポンス: `GET /api/v1/current_user` と同形（`{ "user": { "id", "name", "role" } }`）
- 422（`name` 空文字）/ 400（`user` キー不正）/ 401（未認証）

## 変更内容

- `lib/api/auth.ts`: `updateCurrentUser` を追加
- `lib/validation/user.ts`: プロフィール編集フォームの zod スキーマ
- `components/auth/ProfileEditForm.tsx`: `GET /current_user` で初期値表示 → `PATCH` で更新。成功時は再取得に頼らず PATCH レスポンスで SWR キャッシュを直接更新（`mutate(res, { revalidate: false })`）し、キャッシュの取り回しで古い名前が一瞬見える事故を避ける
- `lib/auth.ts`: `useSession().update()` でセッションの表示名を反映できるよう、`jwt` コールバックに `trigger === "update"` の処理を追加
- `lib/api/mock/`: モックモード（`NEXT_PUBLIC_USE_MOCK=true`）でも `PATCH /current_user` を再現できるよう対応
- `app/mypage/profile`: 編集ページを新設し、マイページからリンクを追加

## 動作確認

- `pnpm test`（vitest）: 全パス（新規テスト22件を含む）
- `pnpm lint` / `tsc --noEmit`: エラーなし（既存の無関係な1件を除く）
- `pnpm build`: 成功
- mock ログイン → プロフィール編集 → 保存 → マイページの表示名反映まで、ブラウザで実際に動作確認済み

関連 issue はありません。

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added profile editing from My Page, including display-name updates and validation.
  - Added responsive mobile navigation with automatic menu closing after selection.
- **Bug Fixes**
  - Comments now display “匿名ユーザー” when author information is unavailable.
  - Improved profile update handling, authentication feedback, and session synchronization.
- **Tests**
  - Added coverage for profile editing, navigation behavior, comment fallbacks, authentication, and profile API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->