### PR TITLE
ハンバーガーメニュー位置調整と画像未登録スポットのプレースホルダー刷新

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -2,10 +2,12 @@ import type { Metadata, ResolvingMetadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { HiArrowLeft } from "react-icons/hi2";
+import { ChawanIcon } from "@/components/brand/icons";
 import Hairline from "@/components/brand/Hairline";
 import CommentSection from "@/components/common/CommentSection";
 import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
+import SpotHeroPlaceholder from "@/components/common/SpotHeroPlaceholder";
 import NearbySpotsMap from "@/components/map/NearbySpotsMap";
 import { ApiError, getGreentea } from "@/lib/api";
 import { auth } from "@/lib/auth";
@@ -109,9 +111,8 @@ export default async function GreenteaDetailPage({
         <ShareButtons title={greentea.name} />
       </div>
 
-      {/* 画像未登録のスポットでは画像枠ごと表示しない。実 API の画像 URL が入れば表示される。 */}
-      {hasImage(greentea.img) && (
-        <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+      <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+        {hasImage(greentea.img) ? (
           <div className="aspect-[16/9] w-full">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -120,8 +121,14 @@ export default async function GreenteaDetailPage({
               className="h-full w-full object-cover"
             />
           </div>
-        </figure>
-      )}
+        ) : (
+          <SpotHeroPlaceholder
+            name={greentea.name}
+            tags={greentea.genres}
+            icon={<ChawanIcon size={28} color="#fbf6e5" />}
+          />
+        )}
+      </figure>
 
       <section className="mt-10">
         <p className="font-serif-jp text-base leading-[2.1] text-ink">

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -2,10 +2,12 @@ import type { Metadata, ResolvingMetadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { HiArrowLeft } from "react-icons/hi2";
+import { ToriiIcon } from "@/components/brand/icons";
 import Hairline from "@/components/brand/Hairline";
 import CommentSection from "@/components/common/CommentSection";
 import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
+import SpotHeroPlaceholder from "@/components/common/SpotHeroPlaceholder";
 import NearbySpotsMap from "@/components/map/NearbySpotsMap";
 import { ApiError, getTemple } from "@/lib/api";
 import { auth } from "@/lib/auth";
@@ -114,9 +116,8 @@ export default async function TempleDetailPage({
         <ShareButtons title={temple.name} />
       </div>
 
-      {/* 画像未登録のスポットでは画像枠ごと表示しない。実 API の画像 URL が入れば表示される。 */}
-      {hasImage(temple.img) && (
-        <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+      <figure className="mt-10 overflow-hidden border border-line-soft bg-paper">
+        {hasImage(temple.img) ? (
           <div className="aspect-[16/9] w-full">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -125,8 +126,14 @@ export default async function TempleDetailPage({
               className="h-full w-full object-cover"
             />
           </div>
-        </figure>
-      )}
+        ) : (
+          <SpotHeroPlaceholder
+            name={temple.name}
+            tags={temple.areas}
+            icon={<ToriiIcon size={28} color="#fbf6e5" />}
+          />
+        )}
+      </figure>
 
       <section className="mt-10">
         <p className="font-serif-jp text-base leading-[2.1] text-ink">

--- a/src/components/common/SpotHeroPlaceholder.tsx
+++ b/src/components/common/SpotHeroPlaceholder.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { latticeBackgroundStyle } from "./latticePattern";
+
+type Tag = { id: number; name: string };
+
+type SpotHeroPlaceholderProps = {
+  name: string;
+  tags: Tag[];
+  icon: ReactNode;
+};
+
+// 画像未登録時の詳細ページヒーロー。緑地格子柄の上に店名/社寺名・タグ・アイコンを重ねる。
+export default function SpotHeroPlaceholder({
+  name,
+  tags,
+  icon,
+}: SpotHeroPlaceholderProps) {
+  return (
+    <div
+      className="relative flex aspect-[16/9] w-full flex-col justify-between overflow-hidden bg-matcha-dark p-5 sm:p-8"
+      style={latticeBackgroundStyle}
+    >
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <span
+              key={tag.id}
+              className="border border-paper/30 bg-paper/10 px-2.5 py-1 font-sans-jp text-[11px] tracking-[0.1em] text-paper/90"
+            >
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex items-end justify-between gap-4">
+        <p className="font-mincho text-3xl font-semibold leading-tight text-paper/95 sm:text-4xl">
+          {name}
+        </p>
+        <span className="shrink-0 text-paper/60">{icon}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/SpotHeroPlaceholder.tsx
+++ b/src/components/common/SpotHeroPlaceholder.tsx
@@ -36,7 +36,7 @@ export default function SpotHeroPlaceholder({
         <p className="font-mincho text-3xl font-semibold leading-tight text-paper/95 sm:text-4xl">
           {name}
         </p>
-        <span className="shrink-0 text-paper/60">{icon}</span>
+        <span className="shrink-0 opacity-60">{icon}</span>
       </div>
     </div>
   );

--- a/src/components/common/SpotPlaceholder.tsx
+++ b/src/components/common/SpotPlaceholder.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { latticeBackgroundStyle } from "./latticePattern";
+
+type SpotPlaceholderProps = {
+  name: string;
+  icon: ReactNode;
+};
+
+// 画像未登録時のカードプレースホルダー。緑地に格子柄を敷き、店名/社寺名の頭文字を大きく見せる。
+export default function SpotPlaceholder({ name, icon }: SpotPlaceholderProps) {
+  const initial = [...name][0] ?? "";
+
+  return (
+    <div
+      className="relative flex h-full w-full items-center justify-center overflow-hidden bg-matcha-dark"
+      style={latticeBackgroundStyle}
+    >
+      <span
+        aria-hidden="true"
+        className="font-mincho text-6xl font-semibold text-paper/90 sm:text-7xl"
+      >
+        {initial}
+      </span>
+      <span className="absolute bottom-2 right-2 text-paper/60">{icon}</span>
+    </div>
+  );
+}

--- a/src/components/common/SpotPlaceholder.tsx
+++ b/src/components/common/SpotPlaceholder.tsx
@@ -21,7 +21,7 @@ export default function SpotPlaceholder({ name, icon }: SpotPlaceholderProps) {
       >
         {initial}
       </span>
-      <span className="absolute bottom-2 right-2 text-paper/60">{icon}</span>
+      <span className="absolute bottom-2 right-2 opacity-60">{icon}</span>
     </div>
   );
 }

--- a/src/components/common/latticePattern.ts
+++ b/src/components/common/latticePattern.ts
@@ -1,0 +1,7 @@
+import type { CSSProperties } from "react";
+
+// 緑地プレースホルダー共通の格子柄背景（カード/詳細ヒーローで共用）。
+export const latticeBackgroundStyle: CSSProperties = {
+  backgroundImage:
+    "repeating-linear-gradient(45deg, rgba(251,246,229,0.1) 0, rgba(251,246,229,0.1) 1px, transparent 1px, transparent 18px), repeating-linear-gradient(-45deg, rgba(251,246,229,0.1) 0, rgba(251,246,229,0.1) 1px, transparent 1px, transparent 18px)",
+};

--- a/src/components/greentea/GreenteaCard.tsx
+++ b/src/components/greentea/GreenteaCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
 import { hasImage } from "@/lib/utils/image";
 import { ChawanIcon } from "@/components/brand/icons";
+import SpotPlaceholder from "@/components/common/SpotPlaceholder";
 import type { Greentea } from "@/types";
 
 type GreenteaCardProps = {
@@ -26,9 +27,10 @@ export default function GreenteaCard({ greentea }: GreenteaCardProps) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center bg-washi-bg">
-            <ChawanIcon size={64} />
-          </div>
+          <SpotPlaceholder
+            name={greentea.name}
+            icon={<ChawanIcon size={20} color="#fbf6e5" />}
+          />
         )}
       </figure>
       <div className="flex flex-1 flex-col gap-2 p-4">

--- a/src/components/greentea/GreenteaCard.tsx
+++ b/src/components/greentea/GreenteaCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
 import { hasImage } from "@/lib/utils/image";
 import { ChawanIcon } from "@/components/brand/icons";
-import SpotPlaceholder from "@/components/common/SpotPlaceholder";
+import SpotPlaceholder from "../common/SpotPlaceholder";
 import type { Greentea } from "@/types";
 
 type GreenteaCardProps = {

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -34,7 +34,10 @@ export default function MobileNav() {
 
   return (
     <details ref={detailsRef} className="dropdown dropdown-end lg:hidden">
-      <summary className="btn btn-ghost btn-square" aria-label="メニューを開く">
+      <summary
+        className="btn btn-ghost btn-square -mr-2"
+        aria-label="メニューを開く"
+      >
         <HiBars3 className="h-5 w-5" />
       </summary>
       <div

--- a/src/components/temple/TempleCard.tsx
+++ b/src/components/temple/TempleCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
 import { hasImage } from "@/lib/utils/image";
 import { ToriiIcon } from "@/components/brand/icons";
+import SpotPlaceholder from "@/components/common/SpotPlaceholder";
 import type { Temple } from "@/types";
 
 type TempleCardProps = {
@@ -26,9 +27,10 @@ export default function TempleCard({ temple }: TempleCardProps) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center bg-washi-bg">
-            <ToriiIcon size={64} />
-          </div>
+          <SpotPlaceholder
+            name={temple.name}
+            icon={<ToriiIcon size={20} color="#fbf6e5" />}
+          />
         )}
       </figure>
       <div className="flex flex-1 flex-col gap-2 p-4">

--- a/src/components/temple/TempleCard.tsx
+++ b/src/components/temple/TempleCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { HiHeart } from "react-icons/hi2";
 import { hasImage } from "@/lib/utils/image";
 import { ToriiIcon } from "@/components/brand/icons";
-import SpotPlaceholder from "@/components/common/SpotPlaceholder";
+import SpotPlaceholder from "../common/SpotPlaceholder";
 import type { Temple } from "@/types";
 
 type TempleCardProps = {

--- a/src/lib/utils/__tests__/metadata.test.ts
+++ b/src/lib/utils/__tests__/metadata.test.ts
@@ -53,7 +53,7 @@ describe("buildSpotMetadata", () => {
       locale: "ja_JP",
       siteName: "抹茶と神社。",
     });
-    expect(meta.twitter?.card).toBe("summary_large_image");
+    expect(meta.twitter).toMatchObject({ card: "summary_large_image" });
   });
 
   it("親に画像が無くても空配列にフォールバックして壊れない", async () => {


### PR DESCRIPTION
## 概要

- モバイルヘッダーのハンバーガーメニューが右端から離れすぎていたので、右端に寄せた
- 画像未登録の抹茶店/神社仏閣の表示を、単なるアイコンのプレースホルダーから「緑地格子柄+頭文字」のデザインに刷新した
  - 一覧カード（`GreenteaCard` / `TempleCard`）: 店名の頭文字を大きく中央表示
  - 詳細ページのヒーロー画像（`greentea/temple` の `[id]/page.tsx`）: 店名全体+ジャンル/エリアタグ+ブランドアイコンを緑地格子柄に重ねて表示（従来は画像未登録時は非表示だった）
- ついでに `metadata.test.ts` の型エラー（`Metadata.twitter` がunion型で `card` プロパティに直接アクセスできない）を修正

## 変更内容

- `src/components/layout/MobileNav.tsx`: ハンバーガーボタンに負のマージンを追加し右端に寄せる
- `src/components/common/SpotPlaceholder.tsx`（新規）: 一覧カード用プレースホルダー
- `src/components/common/SpotHeroPlaceholder.tsx`（新規）: 詳細ページヒーロー用プレースホルダー
- `src/components/common/latticePattern.ts`（新規）: 格子柄背景スタイルの共通化
- `src/components/greentea/GreenteaCard.tsx` / `src/components/temple/TempleCard.tsx`: プレースホルダーを差し替え
- `src/app/greenteas/[id]/page.tsx` / `src/app/temples/[id]/page.tsx`: 画像未登録時もヒーロー枠を表示するよう変更
- `src/lib/utils/__tests__/metadata.test.ts`: `toMatchObject` を使ったアサーションに変更し型エラーを解消

## テスト

- `npx vitest run`（該当コンポーネント/ページ）: 全て通過
- `npx eslint`（変更ファイル）: エラーなし
- `npx tsc --noEmit`: エラーなし
- Playwright + モックAPIでモバイル幅のスクリーンショットを取得し、一覧カード・詳細ヒーローの見た目を目視確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_0148JhJ9wPYPQ6mPTbuAzzhr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branded placeholder visuals for greentea and temple cards and detail pages when images are unavailable.
  * Placeholders now include lattice backgrounds, spot names, relevant tags, and themed icons.
  * Standardized no-image displays across greentea and temple listings.

* **Style**
  * Adjusted mobile navigation alignment.

* **Tests**
  * Updated metadata validation for Twitter card information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->