### PR TITLE
神社仏閣の画像プレースホルダーを赤に変更 + 詳細ページに近隣一覧を追加

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -8,6 +8,7 @@ import CommentSection from "@/components/common/CommentSection";
 import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import SpotHeroPlaceholder from "@/components/common/SpotHeroPlaceholder";
+import NearbySpotsList from "@/components/map/NearbySpotsList";
 import NearbySpotsMap from "@/components/map/NearbySpotsMap";
 import { ApiError, getGreentea } from "@/lib/api";
 import { auth } from "@/lib/auth";
@@ -184,6 +185,7 @@ export default async function GreenteaDetailPage({
             kind="temple"
             emptyMessage="近隣 1.5km 以内に登録された神社仏閣はありません。"
           />
+          <NearbySpotsList spots={greentea.nearby_temples} kind="temple" />
         </div>
       </section>
 

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -131,6 +131,7 @@ export default async function TempleDetailPage({
             name={temple.name}
             tags={temple.areas}
             icon={<ToriiIcon size={28} color="#fbf6e5" />}
+            variant="shrine"
           />
         )}
       </figure>

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -8,6 +8,7 @@ import CommentSection from "@/components/common/CommentSection";
 import LikeButton from "@/components/common/LikeButton";
 import ShareButtons from "@/components/common/ShareButtons";
 import SpotHeroPlaceholder from "@/components/common/SpotHeroPlaceholder";
+import NearbySpotsList from "@/components/map/NearbySpotsList";
 import NearbySpotsMap from "@/components/map/NearbySpotsMap";
 import { ApiError, getTemple } from "@/lib/api";
 import { auth } from "@/lib/auth";
@@ -194,6 +195,7 @@ export default async function TempleDetailPage({
             kind="greentea"
             emptyMessage="近隣 1.5km 以内に登録された抹茶店はありません。"
           />
+          <NearbySpotsList spots={temple.nearby_greenteas} kind="greentea" />
         </div>
       </section>
 

--- a/src/components/common/SpotHeroPlaceholder.tsx
+++ b/src/components/common/SpotHeroPlaceholder.tsx
@@ -7,17 +7,28 @@ type SpotHeroPlaceholderProps = {
   name: string;
   tags: Tag[];
   icon: ReactNode;
+  variant?: "matcha" | "shrine";
 };
 
-// 画像未登録時の詳細ページヒーロー。緑地格子柄の上に店名/社寺名・タグ・アイコンを重ねる。
+const backgroundClassByVariant: Record<
+  NonNullable<SpotHeroPlaceholderProps["variant"]>,
+  string
+> = {
+  matcha: "bg-matcha-dark",
+  shrine: "bg-bengara-dark",
+};
+
+// 画像未登録時の詳細ページヒーロー。格子柄の上に店名/社寺名・タグ・アイコンを重ねる。
+// variant で背景色を切り替える（抹茶店=緑、神社仏閣=赤/弁柄）。
 export default function SpotHeroPlaceholder({
   name,
   tags,
   icon,
+  variant = "matcha",
 }: SpotHeroPlaceholderProps) {
   return (
     <div
-      className="relative flex aspect-[16/9] w-full flex-col justify-between overflow-hidden bg-matcha-dark p-5 sm:p-8"
+      className={`relative flex aspect-[16/9] w-full flex-col justify-between overflow-hidden ${backgroundClassByVariant[variant]} p-5 sm:p-8`}
       style={latticeBackgroundStyle}
     >
       {tags.length > 0 && (

--- a/src/components/common/SpotPlaceholder.tsx
+++ b/src/components/common/SpotPlaceholder.tsx
@@ -4,15 +4,29 @@ import { latticeBackgroundStyle } from "./latticePattern";
 type SpotPlaceholderProps = {
   name: string;
   icon: ReactNode;
+  variant?: "matcha" | "shrine";
 };
 
-// 画像未登録時のカードプレースホルダー。緑地に格子柄を敷き、店名/社寺名の頭文字を大きく見せる。
-export default function SpotPlaceholder({ name, icon }: SpotPlaceholderProps) {
+const backgroundClassByVariant: Record<
+  NonNullable<SpotPlaceholderProps["variant"]>,
+  string
+> = {
+  matcha: "bg-matcha-dark",
+  shrine: "bg-bengara-dark",
+};
+
+// 画像未登録時のカードプレースホルダー。格子柄を敷き、店名/社寺名の頭文字を大きく見せる。
+// variant で背景色を切り替える（抹茶店=緑、神社仏閣=赤/弁柄）。
+export default function SpotPlaceholder({
+  name,
+  icon,
+  variant = "matcha",
+}: SpotPlaceholderProps) {
   const initial = [...name][0] ?? "";
 
   return (
     <div
-      className="relative flex h-full w-full items-center justify-center overflow-hidden bg-matcha-dark"
+      className={`relative flex h-full w-full items-center justify-center overflow-hidden ${backgroundClassByVariant[variant]}`}
       style={latticeBackgroundStyle}
     >
       <span

--- a/src/components/map/NearbySpotsList.tsx
+++ b/src/components/map/NearbySpotsList.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import type { NearbySpot } from "@/types";
+
+type SpotKind = "greentea" | "temple";
+
+type NearbySpotsListProps = {
+  // 詳細ページ本体で既に取得済みの周辺スポット（再フェッチしない）。距離昇順は API 側の並びに従う。
+  spots: NearbySpot[];
+  // spots がどちらの種類か（アイコン・リンク先の切り替えに使う）。
+  kind: SpotKind;
+};
+
+const KIND_CONFIG = {
+  greentea: { href: "/greenteas", Icon: ChawanIcon, color: "#608060" },
+  temple: { href: "/temples", Icon: ToriiIcon, color: "#905050" },
+} as const;
+
+function formatDistance(meters: number): string {
+  if (meters < 1000) return `${meters}m`;
+  return `${(meters / 1000).toFixed(1)}km`;
+}
+
+// 地図の下に添える周辺スポット一覧。地図のマーカーは枠外だと気づきにくいため、
+// クリック不要で距離とリンクを確認できるようテキスト一覧としても表示する。
+export default function NearbySpotsList({ spots, kind }: NearbySpotsListProps) {
+  if (spots.length === 0) return null;
+
+  const { href, Icon, color } = KIND_CONFIG[kind];
+
+  return (
+    <ul className="mt-4 divide-y divide-line-soft border border-line-soft bg-paper">
+      {spots.map((spot) => (
+        <li key={spot.id}>
+          <Link
+            href={`${href}/${spot.id}`}
+            className="flex items-center gap-4 px-5 py-4 transition-colors hover:bg-washi-bg"
+          >
+            <Icon size={22} color={color} />
+            <span className="flex-1 font-mincho text-base text-ink">
+              {spot.name}
+            </span>
+            <span className="font-sans-jp text-xs tracking-[0.1em] text-muted">
+              {formatDistance(spot.distance_meters)}
+            </span>
+            <span aria-hidden="true" className="font-mincho text-base text-muted">
+              →
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/map/NearbySpotsList.tsx
+++ b/src/components/map/NearbySpotsList.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import { ChawanIcon, ToriiIcon } from "../brand/icons";
 import type { NearbySpot } from "@/types";
 
 type SpotKind = "greentea" | "temple";
@@ -7,7 +7,6 @@ type SpotKind = "greentea" | "temple";
 type NearbySpotsListProps = {
   // 詳細ページ本体で既に取得済みの周辺スポット（再フェッチしない）。距離昇順は API 側の並びに従う。
   spots: NearbySpot[];
-  // spots がどちらの種類か（アイコン・リンク先の切り替えに使う）。
   kind: SpotKind;
 };
 

--- a/src/components/map/NearbySpotsMap.tsx
+++ b/src/components/map/NearbySpotsMap.tsx
@@ -11,7 +11,7 @@ import {
   useMap,
   useMapsLibrary,
 } from "@vis.gl/react-google-maps";
-import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import { ChawanIcon, ToriiIcon } from "../brand/icons";
 import type { NearbySpot } from "@/types";
 
 type SpotKind = "greentea" | "temple";

--- a/src/components/map/__tests__/NearbySpotsList.test.tsx
+++ b/src/components/map/__tests__/NearbySpotsList.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import NearbySpotsList from "@/components/map/NearbySpotsList";
+import type { NearbySpot } from "@/types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const spots: NearbySpot[] = [
+  {
+    id: 2,
+    name: "八坂神社",
+    latitude: 35.0036,
+    longitude: 135.7786,
+    distance_meters: 320,
+  },
+  {
+    id: 3,
+    name: "清水寺",
+    latitude: 34.9948,
+    longitude: 135.785,
+    distance_meters: 1400,
+  },
+];
+
+describe("NearbySpotsList", () => {
+  it("spots が空なら何も表示しない", () => {
+    const { container } = render(<NearbySpotsList spots={[]} kind="temple" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("各スポットの名前・距離・詳細リンクを表示する", () => {
+    render(<NearbySpotsList spots={spots} kind="temple" />);
+
+    expect(screen.getByText("八坂神社")).toBeInTheDocument();
+    expect(screen.getByText("320m")).toBeInTheDocument();
+    expect(screen.getByText("清水寺")).toBeInTheDocument();
+    expect(screen.getByText("1.4km")).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /八坂神社/ })).toHaveAttribute(
+      "href",
+      "/temples/2",
+    );
+    expect(screen.getByRole("link", { name: /清水寺/ })).toHaveAttribute(
+      "href",
+      "/temples/3",
+    );
+  });
+
+  it("kind に応じてリンク先を切り替える", () => {
+    render(<NearbySpotsList spots={spots} kind="greentea" />);
+
+    expect(screen.getByRole("link", { name: /八坂神社/ })).toHaveAttribute(
+      "href",
+      "/greenteas/2",
+    );
+  });
+});

--- a/src/components/temple/TempleCard.tsx
+++ b/src/components/temple/TempleCard.tsx
@@ -30,6 +30,7 @@ export default function TempleCard({ temple }: TempleCardProps) {
           <SpotPlaceholder
             name={temple.name}
             icon={<ToriiIcon size={20} color="#fbf6e5" />}
+            variant="shrine"
           />
         )}
       </figure>


### PR DESCRIPTION
## 概要

- 神社仏閣（`Temple`）の画像未登録時プレースホルダーを、抹茶店と同じ緑ではなく赤(弁柄色)にしました。
- あわせて、抹茶店/神社仏閣の詳細ページで、地図の下に近隣スポットのテキスト一覧を追加しました（地図のマーカーだけだと枠外のスポットに気づきにくいため）。

## 変更内容

### 画像プレースホルダーの色分け
- `SpotPlaceholder`（一覧カード用）/ `SpotHeroPlaceholder`（詳細ページヒーロー用）に `variant`（`"matcha"` | `"shrine"`）プロパティを追加し、背景色を抹茶店=緑 / 神社仏閣=赤(`bg-bengara-dark`)で出し分け
- `TempleCard`（一覧カード）と神社詳細ページのヒーローに `variant="shrine"` を適用

### 詳細ページの近隣スポット一覧
- `NearbySpotsList` を新設: 地図(`NearbySpotsMap`)と同じ `nearby_temples`/`nearby_greenteas`（再フェッチなし）を、アイコン・名前・距離・詳細リンク付きの一覧としても表示
- 抹茶店/神社仏閣の詳細ページで `NearbySpotsMap` の直下に配置
- スポットが0件の場合は何も表示しない（地図側の空メッセージのみでOKなため重複を回避）

## 動作確認

- ローカルでモックAPI(`NEXT_PUBLIC_USE_MOCK=true`)を有効にして起動し、神社仏閣一覧（赤プレースホルダー）と神社詳細ページ（近隣一覧）を目視確認
- `npx vitest run` 全457件パス
- `npx eslint` / `npx tsc --noEmit` エラーなし（既存の未関連エラーを除く）

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbqMcRMfuaTdDMdWoSdbCQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nearby spot lists to green-tea shop and temple detail pages, including names, distances, directions, and links.
  * Added shrine-themed placeholders for temples without images.
  * Added support for distinct matcha and shrine visual styles.

* **Bug Fixes**
  * Improved nearby spot navigation and distance display for both green-tea shops and temples.

* **Tests**
  * Added coverage for empty results, distance formatting, and destination links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->