### PR TITLE
共通ローディングローダー Loader を追加

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,18 +3,13 @@
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import Hairline from "@/components/brand/Hairline";
+import Loader from "@/components/common/Loader";
 
 export default function MyPage() {
   const { data: session, status } = useSession();
 
   if (status === "loading") {
-    return (
-      <section className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
-        <p className="font-sans-jp text-[10px] tracking-[0.4em] text-muted">
-          読み込み中…
-        </p>
-      </section>
-    );
+    return <Loader fullScreen />;
   }
 
   if (!session?.user) {

--- a/src/components/common/LikedSpotsList.tsx
+++ b/src/components/common/LikedSpotsList.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect } from "react";
 import useSWR from "swr";
 import GreenteaCard from "@/components/greentea/GreenteaCard";
+import Loader from "./Loader";
 import TempleCard from "@/components/temple/TempleCard";
 import {
   ApiError,
@@ -67,11 +68,7 @@ export default function LikedSpotsList({ kind }: LikedSpotsListProps) {
   }
 
   if (isLoading) {
-    return (
-      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
-        読み込み中…
-      </p>
-    );
+    return <Loader />;
   }
 
   if (error) {

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,0 +1,37 @@
+// データ取得中に表示するローダー。文言のみの箇所が各所に重複していたため共通化。
+
+type LoaderProps = {
+  label?: string;
+  fullScreen?: boolean;
+  className?: string;
+};
+
+export default function Loader({
+  label = "読み込み中…",
+  fullScreen = false,
+  className,
+}: LoaderProps) {
+  const indicator = (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`inline-flex items-center gap-2.5 ${className ?? ""}`}
+    >
+      <span
+        aria-hidden="true"
+        className="h-3 w-3 animate-spin rounded-full border border-line-soft border-t-olive"
+      />
+      <span className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
+        {label}
+      </span>
+    </div>
+  );
+
+  if (!fullScreen) return indicator;
+
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+      {indicator}
+    </section>
+  );
+}

--- a/src/components/common/__tests__/Loader.test.tsx
+++ b/src/components/common/__tests__/Loader.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Loader from "@/components/common/Loader";
+
+describe("Loader", () => {
+  it("既定文言を role=status で表示する", () => {
+    render(<Loader />);
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("読み込み中…");
+  });
+
+  it("label を渡すとその文言を表示する", () => {
+    render(<Loader label="検索中…" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("検索中…");
+  });
+
+  it("fullScreen を指定すると中央寄せの section で囲む", () => {
+    const { container } = render(<Loader fullScreen />);
+
+    const section = container.querySelector("section");
+    expect(section).not.toBeNull();
+    expect(section).toContainElement(screen.getByRole("status"));
+  });
+
+  it("fullScreen 未指定では section を描画しない", () => {
+    const { container } = render(<Loader />);
+
+    expect(container.querySelector("section")).toBeNull();
+  });
+});

--- a/src/components/route/RouteBuilder.tsx
+++ b/src/components/route/RouteBuilder.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
-import Loader from "@/components/common/Loader";
+import Loader from "../common/Loader";
 import {
   ApiError,
   createRoute,

--- a/src/components/route/RouteBuilder.tsx
+++ b/src/components/route/RouteBuilder.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
+import Loader from "@/components/common/Loader";
 import {
   ApiError,
   createRoute,
@@ -474,9 +475,7 @@ function SpotPicker({
           候補の取得に失敗しました。時間を置いてお試しください。
         </p>
       ) : isLoading ? (
-        <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
-          読み込み中…
-        </p>
+        <Loader />
       ) : items.length === 0 ? (
         <p className="font-serif-jp text-sm text-muted">
           該当するスポットがありません。

--- a/src/components/route/RouteDetailView.tsx
+++ b/src/components/route/RouteDetailView.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
 import Hairline from "@/components/brand/Hairline";
-import Loader from "@/components/common/Loader";
+import Loader from "../common/Loader";
 import RouteMap from "./RouteMap";
 import {
   ApiError,

--- a/src/components/route/RouteDetailView.tsx
+++ b/src/components/route/RouteDetailView.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { ChawanIcon, ToriiIcon } from "@/components/brand/icons";
 import Hairline from "@/components/brand/Hairline";
+import Loader from "@/components/common/Loader";
 import RouteMap from "./RouteMap";
 import {
   ApiError,
@@ -88,11 +89,7 @@ export default function RouteDetailView({ id }: RouteDetailViewProps) {
   }
 
   if (isLoading) {
-    return (
-      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
-        読み込み中…
-      </p>
-    );
+    return <Loader />;
   }
 
   if (error) {

--- a/src/components/route/RouteEditForm.tsx
+++ b/src/components/route/RouteEditForm.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import useSWR from "swr";
+import Loader from "@/components/common/Loader";
 import RouteBuilder from "./RouteBuilder";
 import { ApiError, getErrorStatus, getRoute, isUnauthorized } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";
@@ -53,11 +54,7 @@ export default function RouteEditForm({ id }: RouteEditFormProps) {
   }
 
   if (isLoading) {
-    return (
-      <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
-        読み込み中…
-      </p>
-    );
+    return <Loader />;
   }
 
   if (error || !data) {

--- a/src/components/route/RouteEditForm.tsx
+++ b/src/components/route/RouteEditForm.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import useSWR from "swr";
-import Loader from "@/components/common/Loader";
+import Loader from "../common/Loader";
 import RouteBuilder from "./RouteBuilder";
 import { ApiError, getErrorStatus, getRoute, isUnauthorized } from "@/lib/api";
 import { useAuthToken } from "@/lib/api/useAuthToken";

--- a/src/components/route/RouteList.tsx
+++ b/src/components/route/RouteList.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
-import Loader from "@/components/common/Loader";
+import Loader from "../common/Loader";
 import Pagination from "@/components/common/Pagination";
 import {
   ApiError,

--- a/src/components/route/RouteList.tsx
+++ b/src/components/route/RouteList.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
+import Loader from "@/components/common/Loader";
 import Pagination from "@/components/common/Pagination";
 import {
   ApiError,
@@ -106,9 +107,7 @@ export default function RouteList({ page = 1 }: RouteListProps) {
       </div>
 
       {isLoading ? (
-        <p className="font-sans-jp text-[10px] tracking-[0.3em] text-muted">
-          読み込み中…
-        </p>
+        <Loader />
       ) : error ? (
         <p role="alert" className="font-sans-jp text-xs text-bengara">
           {isUnauthorized(error)


### PR DESCRIPTION
## Summary

- `src/components/common/Loader.tsx` を新規追加。各所に重複していた「読み込み中…」のテキスト表示を共通コンポーネント化した
- 細い円形スピナー + トラッキング広めのテキストで、既存の罫線・色面のみのデザイントーンに合わせた
- `fullScreen` prop でページ全体を中央寄せする表示（マイページのセッション読み込み待ちなど）にも対応
- 以下の読み込み中表示を `Loader` に置き換え
  - `RouteList`
  - `RouteDetailView`
  - `RouteEditForm`
  - `RouteBuilder`（`LikedSpotsList`）
  - マイページ（`src/app/mypage/page.tsx`、`fullScreen` 表示）

## Test plan

- [x] `npx eslint` （変更ファイル一式）
- [x] `npx vitest run`（`Loader` の新規テストおよび置き換え元コンポーネントのテスト、計51件）
- [x] `npx tsc --noEmit`（本変更に起因するエラーがないことを確認。既存の `src/lib/auth.ts` 関連のエラーは本変更と無関係）
- [x] 一時的に確認用ページを用意し、実際にビルドして表示を目視確認（コミットには含めていません）

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01M9Sh4YbZg7bQL29sZGSonS

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9Sh4YbZg7bQL29sZGSonS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable loading indicator with accessible status messaging and customizable display options.
  * Standardized loading experiences across My Page, liked spots, route browsing, route details, route editing, and spot selection.

* **Bug Fixes**
  * Improved loading-state visibility with consistent inline and full-screen presentations.

* **Tests**
  * Added coverage for default, customized, inline, and full-screen loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->