### PR TITLE
X共有にハッシュタグ「#抹茶と神社」を追加しシェア文言を改善

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function GreenteaDetailPage({
       </header>
 
       <div className="mt-6 flex justify-center">
-        <ShareButtons title={greentea.name} />
+        <ShareButtons title={greentea.name} hashtags={["抹茶スイーツ"]} />
       </div>
 
       <section className="mt-10">

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -135,7 +135,7 @@ export default async function TempleDetailPage({
       </header>
 
       <div className="mt-6 flex justify-center">
-        <ShareButtons title={temple.name} />
+        <ShareButtons title={temple.name} hashtags={["神社仏閣"]} />
       </div>
 
       <section className="mt-10">

--- a/src/components/common/ShareButtons.tsx
+++ b/src/components/common/ShareButtons.tsx
@@ -6,9 +6,10 @@ import { SiLine } from "react-icons/si";
 
 type ShareButtonsProps = {
   title: string;
+  hashtags?: string[];
 };
 
-export default function ShareButtons({ title }: ShareButtonsProps) {
+export default function ShareButtons({ title, hashtags = [] }: ShareButtonsProps) {
   const [url, setUrl] = useState("");
 
   useEffect(() => {
@@ -17,7 +18,9 @@ export default function ShareButtons({ title }: ShareButtonsProps) {
 
   if (!url) return null;
 
-  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`;
+  const text = `抹茶と神社。で見つけた素敵なスポット『${title}』をシェアします🍵`;
+  const allHashtags = ["抹茶と神社", ...hashtags];
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent(allHashtags.join(","))}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;
 
   return (

--- a/src/components/common/ShareButtons.tsx
+++ b/src/components/common/ShareButtons.tsx
@@ -18,7 +18,7 @@ export default function ShareButtons({ title, hashtags = [] }: ShareButtonsProps
 
   if (!url) return null;
 
-  const text = `抹茶と神社。で見つけた素敵なスポット『${title}』をシェアします🍵`;
+  const text = `抹茶と神社で見つけた素敵なスポット『${title}』をシェアします🍵`;
   const allHashtags = ["抹茶と神社", ...hashtags];
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent(allHashtags.join(","))}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;

--- a/src/components/common/__tests__/ShareButtons.test.tsx
+++ b/src/components/common/__tests__/ShareButtons.test.tsx
@@ -10,7 +10,7 @@ describe("ShareButtons", () => {
     const line = screen.getByLabelText("LINEでシェア");
 
     const url = window.location.href;
-    const text = "抹茶と神社。で見つけた素敵なスポット『中村藤吉本店』をシェアします🍵";
+    const text = "抹茶と神社で見つけた素敵なスポット『中村藤吉本店』をシェアします🍵";
     expect(twitter).toHaveAttribute(
       "href",
       `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent("抹茶と神社,抹茶スイーツ")}`,

--- a/src/components/common/__tests__/ShareButtons.test.tsx
+++ b/src/components/common/__tests__/ShareButtons.test.tsx
@@ -4,19 +4,29 @@ import ShareButtons from "@/components/common/ShareButtons";
 
 describe("ShareButtons", () => {
   it("マウント後に X / LINE のシェアリンクを表示する", async () => {
-    render(<ShareButtons title="中村藤吉本店" />);
+    render(<ShareButtons title="中村藤吉本店" hashtags={["抹茶スイーツ"]} />);
 
     const twitter = await screen.findByLabelText("X（Twitter）でシェア");
     const line = screen.getByLabelText("LINEでシェア");
 
     const url = window.location.href;
+    const text = "抹茶と神社。で見つけた素敵なスポット『中村藤吉本店』をシェアします🍵";
     expect(twitter).toHaveAttribute(
       "href",
-      `https://twitter.com/intent/tweet?text=${encodeURIComponent("中村藤吉本店")}&url=${encodeURIComponent(url)}`,
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent("抹茶と神社,抹茶スイーツ")}`,
     );
     expect(line).toHaveAttribute(
       "href",
       `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`,
+    );
+  });
+
+  it("hashtags を指定しない場合は「抹茶と神社」のみが付与される", async () => {
+    render(<ShareButtons title="伏見稲荷大社" />);
+
+    const twitter = await screen.findByLabelText("X（Twitter）でシェア");
+    expect(twitter.getAttribute("href")).toContain(
+      `hashtags=${encodeURIComponent("抹茶と神社")}`,
     );
   });
 


### PR DESCRIPTION
## 概要

X（Twitter）でのシェア時に、ハッシュタグ `#抹茶と神社` を必ず付与し、あわせてシェア文言もスポット名だけの素っ気ないものから改善しました。

## 変更内容

- `ShareButtons` に `hashtags` props を追加し、常に `抹茶と神社` を付与
  - 神社詳細ページ (`src/app/temples/[id]/page.tsx`) は追加で `神社仏閣`
  - 抹茶店詳細ページ (`src/app/greenteas/[id]/page.tsx`) は追加で `抹茶スイーツ`
- シェア文言を `スポット名のみ` から `抹茶と神社。で見つけた素敵なスポット『◯◯』をシェアします🍵` に変更
- テスト (`ShareButtons.test.tsx`) を新しい文言・ハッシュタグに合わせて更新

## テスト計画

- [x] `npx vitest run src/components/common/__tests__/ShareButtons.test.tsx`（3件 pass）
- [x] `npx eslint` 変更ファイル（エラーなし）
- [x] `npx tsc --noEmit`（今回の変更ファイルに起因するエラーなし。既存の `src/lib/auth.ts` 関連エラーは本PRと無関係）


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4f2bzQdD9HCNpqzoYh5zx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved X/Twitter sharing with localized share text and relevant hashtags for greentea and temple pages.
  * Added support for custom hashtags when sharing content.
  * Preserved LINE sharing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->