### PR TITLE
fix: 神社仏閣シェア文言を神社絵文字に変更しハッシュタグを削除

### DIFF
--- a/src/app/greenteas/[id]/page.tsx
+++ b/src/app/greenteas/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function GreenteaDetailPage({
       </header>
 
       <div className="mt-6 flex justify-center">
-        <ShareButtons title={greentea.name} hashtags={["抹茶スイーツ"]} />
+        <ShareButtons title={greentea.name} />
       </div>
 
       <section className="mt-10">

--- a/src/app/temples/[id]/page.tsx
+++ b/src/app/temples/[id]/page.tsx
@@ -135,7 +135,7 @@ export default async function TempleDetailPage({
       </header>
 
       <div className="mt-6 flex justify-center">
-        <ShareButtons title={temple.name} hashtags={["神社仏閣"]} />
+        <ShareButtons title={temple.name} emoji="⛩️" />
       </div>
 
       <section className="mt-10">

--- a/src/components/common/ShareButtons.tsx
+++ b/src/components/common/ShareButtons.tsx
@@ -6,10 +6,11 @@ import { SiLine } from "react-icons/si";
 
 type ShareButtonsProps = {
   title: string;
+  emoji?: string;
   hashtags?: string[];
 };
 
-export default function ShareButtons({ title, hashtags = [] }: ShareButtonsProps) {
+export default function ShareButtons({ title, emoji = "🍵", hashtags = [] }: ShareButtonsProps) {
   const [url, setUrl] = useState("");
 
   useEffect(() => {
@@ -18,7 +19,7 @@ export default function ShareButtons({ title, hashtags = [] }: ShareButtonsProps
 
   if (!url) return null;
 
-  const text = `抹茶と神社で見つけた素敵なスポット『${title}』をシェアします🍵`;
+  const text = `抹茶と神社で見つけた素敵なスポット『${title}』をシェアします${emoji}`;
   const allHashtags = ["抹茶と神社", ...hashtags];
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent(allHashtags.join(","))}`;
   const lineUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;

--- a/src/components/common/__tests__/ShareButtons.test.tsx
+++ b/src/components/common/__tests__/ShareButtons.test.tsx
@@ -4,7 +4,7 @@ import ShareButtons from "@/components/common/ShareButtons";
 
 describe("ShareButtons", () => {
   it("マウント後に X / LINE のシェアリンクを表示する", async () => {
-    render(<ShareButtons title="中村藤吉本店" hashtags={["抹茶スイーツ"]} />);
+    render(<ShareButtons title="中村藤吉本店" />);
 
     const twitter = await screen.findByLabelText("X（Twitter）でシェア");
     const line = screen.getByLabelText("LINEでシェア");
@@ -13,11 +13,23 @@ describe("ShareButtons", () => {
     const text = "抹茶と神社で見つけた素敵なスポット『中村藤吉本店』をシェアします🍵";
     expect(twitter).toHaveAttribute(
       "href",
-      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent("抹茶と神社,抹茶スイーツ")}`,
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent("抹茶と神社")}`,
     );
     expect(line).toHaveAttribute(
       "href",
       `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`,
+    );
+  });
+
+  it("emoji を指定すると文言内の絵文字が置き換わる（神社仏閣など）", async () => {
+    render(<ShareButtons title="伏見稲荷大社" emoji="⛩️" />);
+
+    const twitter = await screen.findByLabelText("X（Twitter）でシェア");
+    const url = window.location.href;
+    const text = "抹茶と神社で見つけた素敵なスポット『伏見稲荷大社』をシェアします⛩️";
+    expect(twitter).toHaveAttribute(
+      "href",
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent("抹茶と神社")}`,
     );
   });
 


### PR DESCRIPTION
## 概要

- Xでシェアする際の文言について、神社仏閣ページでは抹茶の絵文字（🍵）ではなく神社の絵文字（⛩️）を使うように変更
- 神社仏閣ページの `神社仏閣` ハッシュタグ、抹茶スイーツページの `抹茶スイーツ` ハッシュタグを削除（共通の `抹茶と神社` タグのみ付与）

## 変更内容

- `src/components/common/ShareButtons.tsx`: `emoji` prop を追加し、シェア文言内の絵文字を差し替え可能に（デフォルトは従来通り🍵）
- `src/app/temples/[id]/page.tsx`: `ShareButtons` に `emoji="⛩️"` を指定し、`hashtags={["神社仏閣"]}` を削除
- `src/app/greenteas/[id]/page.tsx`: `hashtags={["抹茶スイーツ"]}` を削除
- `src/components/common/__tests__/ShareButtons.test.tsx`: emoji 差し替えのテストケースを追加、ハッシュタグ関連のアサーションを更新

## テスト

- `npx vitest run` — 全464件パス
- `npx eslint` — 変更ファイルにエラーなし



---
_Generated by [Claude Code](https://claude.ai/code/session_01UH4KGdL83tFpfj4Xrt1GqG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share messages now support page-specific emojis, with a tea emoji used by default.
  * Temple and greentea pages provide more relevant sharing content.

* **Bug Fixes**
  * Updated default share text to use the intended hashtag and avoid inappropriate category tags.

* **Tests**
  * Added coverage for custom emojis and updated expectations for default share content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->